### PR TITLE
Fern Generator: PyPi Publish Package name change

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -21,10 +21,10 @@ groups:
       - name: fernapi/fern-pydantic-model
         version:  1.4.3
         config:
-          package_name: networkscan
+          package_name: methodnetworkscan
         output:
           location: pypi
-          package-name: networkscan
+          package-name: methodnetworkscan
           token: ${TEST_PYPI_TOKEN}
           url: https://test.pypi.org/legacy/
   pypi:
@@ -32,8 +32,8 @@ groups:
       - name: fernapi/fern-pydantic-model
         version: 1.4.3
         config:
-          package_name: networkscan
+          package_name: methodnetworkscan
         output:
           location: pypi
-          package-name: networkscan
+          package-name: methodnetworkscan
           token: ${PYPI_TOKEN}


### PR DESCRIPTION
- 'networkscan' is already taken, switching to 'methodnetworkscan'