### PR TITLE
better banner grab defaults

### DIFF
--- a/cmd/host.go
+++ b/cmd/host.go
@@ -99,7 +99,7 @@ func (a *NetworkScan) InitHostCommand() {
 
 	hostBannerGrabCmd.Flags().String("target", "", "Target address (e.g., 192.168.1.1)")
 	hostBannerGrabCmd.Flags().Uint16("port", 0, "Address Port (e.g., 443)")
-	hostBannerGrabCmd.Flags().Int("timeout", 30, "Timeout limit in seconds")
+	hostBannerGrabCmd.Flags().Int("timeout", 5, "Timeout limit in seconds")
 	_ = hostBannerGrabCmd.MarkFlagRequired("target")
 	_ = hostBannerGrabCmd.MarkFlagRequired("port")
 

--- a/internal/host/bannergrab.go
+++ b/internal/host/bannergrab.go
@@ -32,7 +32,7 @@ func RunHostBannerGrab(ctx context.Context, timeout int, target string, port uin
 			FastMode:       false,
 			DefaultTimeout: time.Duration(timeout) * time.Second,
 			UDP:            false,
-			Verbose:        false,
+			Verbose:        true,
 		}
 		ipAddr, err := netip.ParseAddr(ip.String())
 		if err != nil {


### PR DESCRIPTION
Something about the default of 30 seconds was too long, and causing fingerprintx to take upwards of 10 minutes sometimes