### PR TITLE
Adopted naabu default settings for retries and timeouts to achieve fu…

### DIFF
--- a/cmd/port.go
+++ b/cmd/port.go
@@ -40,7 +40,16 @@ func (a *NetworkScan) InitPortCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			report, err := port.RunPortScan(cmd.Context(), target, ports, topport)
+			scantype, err := cmd.Flags().GetString("scantype")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if scantype != "syn" && scantype != "connect" {
+				a.OutputSignal.AddError(errors.New("scantype must be either syn or connect"))
+				return
+			}
+			report, err := port.RunPortScan(cmd.Context(), target, ports, topport, scantype)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -52,6 +61,7 @@ func (a *NetworkScan) InitPortCommand() {
 	portScanCmd.Flags().String("target", "", "Target IP or FQDN to scan for ports")
 	portScanCmd.Flags().String("ports", "", "Port/Port Range to scan")
 	portScanCmd.Flags().String("topports", "", "Top Ports to scan (full | 100 |1000)")
+	portScanCmd.Flags().String("scantype", "syn", "Type of scan to perform (syn | connect)")
 	_ = portScanCmd.MarkFlagRequired("target")
 
 	portCmd.AddCommand(portScanCmd)

--- a/cmd/port.go
+++ b/cmd/port.go
@@ -40,6 +40,11 @@ func (a *NetworkScan) InitPortCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			threads, err := cmd.Flags().GetInt("threads")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			scantype, err := cmd.Flags().GetString("scantype")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -49,7 +54,7 @@ func (a *NetworkScan) InitPortCommand() {
 				a.OutputSignal.AddError(errors.New("scantype must be either syn or connect"))
 				return
 			}
-			report, err := port.RunPortScan(cmd.Context(), target, ports, topport, scantype)
+			report, err := port.RunPortScan(cmd.Context(), target, ports, topport, threads, scantype)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -61,6 +66,7 @@ func (a *NetworkScan) InitPortCommand() {
 	portScanCmd.Flags().String("target", "", "Target IP or FQDN to scan for ports")
 	portScanCmd.Flags().String("ports", "", "Port/Port Range to scan")
 	portScanCmd.Flags().String("topports", "", "Top Ports to scan (full | 100 |1000)")
+	portScanCmd.Flags().Int("threads", 25, "Number of threads to use for scanning")
 	portScanCmd.Flags().String("scantype", "syn", "Type of scan to perform (syn | connect)")
 	_ = portScanCmd.MarkFlagRequired("target")
 

--- a/godel/config/godel.properties
+++ b/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://github.com/palantir/godel/releases/download/v2.118.0/godel-2.118.0.tgz
+distributionURL=https://github.com/palantir/godel/releases/download/v2.119.0/godel-2.119.0.tgz
 distributionSHA256=

--- a/godel/config/godel.properties
+++ b/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://github.com/palantir/godel/releases/download/v2.109.0/godel-2.109.0.tgz
+distributionURL=https://github.com/palantir/godel/releases/download/v2.118.0/godel-2.118.0.tgz
 distributionSHA256=

--- a/godelw
+++ b/godelw
@@ -3,11 +3,11 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.109.0
-DARWIN_AMD64_CHECKSUM=4acc8002b8a4ed666ce75d9e2a23d58e78ae3ef960c22c7588414ab09d71ad85
-DARWIN_ARM64_CHECKSUM=d4bd42f50fc5f1c8f1fb751f19790683236e71dac3098fe8eb3e01c37b0606b0
-LINUX_AMD64_CHECKSUM=89ea803a20ed7996f1a6ff7f21f60270b6d34d4b98e316aa6280c51e72550177
-LINUX_ARM64_CHECKSUM=f4a4386a157eda73b3d8d9e8eb39a7b9760906176c8b26a701dd9f7608140e73
+VERSION=2.119.0
+DARWIN_AMD64_CHECKSUM=43c1bcd06f2db28c62b14294bef89986a0dad48fe706893425ffb4b418155d47
+DARWIN_ARM64_CHECKSUM=73aa3b2ab838b2ea6af34954b611e181d8b11d2a940ad00abba22c9c86cefd32
+LINUX_AMD64_CHECKSUM=77178fcc7b0c1bdeba106d85d93665a15236306f011357f82f0c6d27b33bba8d
+LINUX_ARM64_CHECKSUM=1365599b5accb930c6e0bfcf8f1addb1deaeb01b0df935a2bf6743dbd9f20b79
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/internal/port/scan.go
+++ b/internal/port/scan.go
@@ -29,7 +29,7 @@ type Report struct {
 	Errors []string `json:"errors" yaml:"errors"`
 }
 
-func getPortScan(ctx context.Context, target string, ports string, topports string, scantype string) ([]Host, error) {
+func getPortScan(ctx context.Context, target string, ports string, topports string, threads int, scantype string) ([]Host, error) {
 	output := result.HostResult{}
 	hosts := []Host{}
 	// These settings mimic naabu's default settings
@@ -39,7 +39,7 @@ func getPortScan(ctx context.Context, target string, ports string, topports stri
 		NoColor:           true,
 		Rate:              runner.DefaultRateConnectScan,
 		Retries:           runner.DefaultRetriesConnectScan,
-		Threads:           25,
+		Threads:           threads,
 		Timeout:           runner.DefaultPortTimeoutConnectScan,
 		Host:              goflags.StringSlice{target},
 		SkipHostDiscovery: true,
@@ -99,10 +99,10 @@ func parseResult(result result.HostResult) Host {
 
 // RunPortScan takes a target host and a list of ports to scan and returns a report of all hosts that were scanned and
 // their open ports.
-func RunPortScan(ctx context.Context, target string, ports string, topport string, scantype string) (Report, error) {
+func RunPortScan(ctx context.Context, target string, ports string, topport string, threads int, scantype string) (Report, error) {
 	errors := []string{}
 
-	portscanResult, err := getPortScan(ctx, target, ports, topport, scantype)
+	portscanResult, err := getPortScan(ctx, target, ports, topport, threads, scantype)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}

--- a/internal/port/scan.go
+++ b/internal/port/scan.go
@@ -29,22 +29,37 @@ type Report struct {
 	Errors []string `json:"errors" yaml:"errors"`
 }
 
-func getPortScan(ctx context.Context, target string, ports string, topports string) ([]Host, error) {
+func getPortScan(ctx context.Context, target string, ports string, topports string, scantype string) ([]Host, error) {
 	output := result.HostResult{}
 	hosts := []Host{}
+	// These settings mimic naabu's default settings
 	portscanOpts := &runner.Options{
-		Silent:            true,
+		Silent:            false,
 		JSON:              true,
 		NoColor:           true,
-		Threads:           10,
-		Timeout:           runner.DefaultPortTimeoutSynScan,
+		Rate:              runner.DefaultRateConnectScan,
+		Retries:           runner.DefaultRetriesConnectScan,
+		Threads:           25,
+		Timeout:           runner.DefaultPortTimeoutConnectScan,
 		Host:              goflags.StringSlice{target},
 		SkipHostDiscovery: true,
+		WarmUpTime:        2,
+		InputReadTimeout:  180000000000, // This is their default
 		OnResult: func(hr *result.HostResult) {
 			output = *hr
 			hosts = append(hosts, parseResult(output))
 		},
 	}
+
+	switch scantype {
+	case "syn":
+		portscanOpts.ScanType = runner.SynScan
+	case "connect":
+		portscanOpts.ScanType = runner.ConnectScan
+	default:
+		portscanOpts.ScanType = ""
+	}
+
 	if ports != "" {
 		portscanOpts.Ports = ports
 	}
@@ -84,10 +99,10 @@ func parseResult(result result.HostResult) Host {
 
 // RunPortScan takes a target host and a list of ports to scan and returns a report of all hosts that were scanned and
 // their open ports.
-func RunPortScan(ctx context.Context, target string, ports string, topport string) (Report, error) {
+func RunPortScan(ctx context.Context, target string, ports string, topport string, scantype string) (Report, error) {
 	errors := []string{}
 
-	portscanResult, err := getPortScan(ctx, target, ports, topport)
+	portscanResult, err := getPortScan(ctx, target, ports, topport, scantype)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}


### PR DESCRIPTION
Full scans were failing because of default runner options, it was causing resource contention across threads - likely has to do with not setting rate and retries and timeout. All settings are now adopted from naabu defaults, and full scanning works.

Compared running our CLI vs. direct in naabu CLI and got identical results:

Naabu in go - 10 ports

go run main.go port scan --target scanme.sh --topports full
[INF] Running CONNECT scan with non root privileges
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:15:16.711918Z","port":444,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:15:20.666875Z","port":15000,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:15:23.695917Z","port":448,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:15:35.640125Z","port":443,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:15:38.639911Z","port":446,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:15:57.673871Z","port":447,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:15:59.630401Z","port":22,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:16:06.743853Z","port":80,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:16:22.702836Z","port":445,"protocol":"tcp","tls":false}
{"host":"scanme.sh","ip":"128.199.158.128","timestamp":"2024-09-26T19:16:27.469011Z","port":1723,"protocol":"tcp","tls":false}
[INF] Found 10 ports on host scanme.sh (128.199.158.128)

Naabu standalone - 10 ports

❯ naabu -host scanme.sh --top-ports full

                  __
  ___  ___  ___ _/ /  __ __
 / _ \/ _ \/ _ \/ _ \/ // /
/_//_/\_,_/\_,_/_.__/\_,_/

                projectdiscovery.io

[INF] Current naabu version 2.3.1 (latest)
[INF] Running CONNECT scan with non root privileges
scanme.sh:1723
scanme.sh:22
scanme.sh:446
scanme.sh:15000
scanme.sh:80
scanme.sh:443
scanme.sh:444
scanme.sh:447
scanme.sh:448
scanme.sh:445
[INF] Found 10 ports on host scanme.sh (128.199.158.128)