### PR TITLE
Address Bannergrab Bug Fix

### DIFF
--- a/internal/address/bannergrab.go
+++ b/internal/address/bannergrab.go
@@ -51,6 +51,11 @@ func RunBannerGrab(ctx context.Context, timeout int, target string, port uint16)
 			continue
 		}
 
+		if result == nil {
+			errors = append(errors, "scan result is empty")
+			continue
+		}
+
 		metadata := metadataMap(result.Metadata())
 		bannerResult := networkscan.BannerGrab{
 			Host:        result.Host,


### PR DESCRIPTION
## Error
The `result` value is nil but no err is thrown despite it not being able to connect to the host

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x100606060]
```

## Fix
Check for empty `result` before parsing `result.Metadata()`

## Fixed output

```
{"content":{"target":"lms.schwarzmanscholars.org","errors":["unable to connect, err = dial tcp 45.251.107.99:49176: connect: connection refused","unable to connect, err = dial tcp 203.93.1.248:49176: i/o timeout"]},"started_at":"2024-09-30T13:47:51.123961-04:00","completed_at":"2024-09-30T13:49:27.059158-04:00","status":0}
```

