### PR TITLE
Bannergrab CLI: bug fix + add panic handler

### DIFF
--- a/cmd/address.go
+++ b/cmd/address.go
@@ -24,6 +24,8 @@ func (a *NetworkScan) InitAddressCommand() {
 		Short: "Grab banner from a network address",
 		Long:  `Grab banner from a network address`,
 		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+
 			target, err := cmd.Flags().GetString("target")
 			if err != nil {
 				a.OutputSignal.AddError(err)


### PR DESCRIPTION
**Error**
`2024-10-17 09:16:16 panic: reflect: call of reflect.Value.NumField on map Value`

**Fix**

- Check the type of metadata properly before treating it as a struct
- Add Panic handler to prevent future panics