### PR TITLE
add GRPC ProtocolType

### DIFF
--- a/fern/definition/common/common.yml
+++ b/fern/definition/common/common.yml
@@ -5,6 +5,7 @@ types:
       - DHCP
       - ECHO
       - FTP
+      - GRPC
       - HTTP
       - HTTPS
       - HTTP2


### PR DESCRIPTION
### TL;DR

Added GRPC to the list of supported protocols in the common definitions.

### What changed?

Added the `GRPC` protocol to the enumeration of supported protocols in `fern/definition/common/common.yml`. The protocol was inserted alphabetically between FTP and HTTP.

### How to test?

1. Verify that the GRPC protocol is now available in the generated API definitions
2. Ensure that any code that consumes this enumeration can properly handle the new GRPC protocol value
3. Confirm that existing functionality using other protocol values continues to work as expected

### Why make this change?

This addition enables support for gRPC protocol in the system, allowing clients to specify gRPC as a protocol type in their configurations. This expands the platform's capabilities to handle modern API communication methods.