### PR TITLE
gRPC Fern Fix

### DIFF
--- a/fern/definition/enumerate/grpc/grpc.yml
+++ b/fern/definition/enumerate/grpc/grpc.yml
@@ -18,4 +18,4 @@ types:
       services: list<GrpcService>
       rawDescriptorSet: string # base64-encoded FileDescriptorSet
       reflectionSupported: boolean
-      errors: list<string>
+      errors: optional<list<string>>


### PR DESCRIPTION
### TL;DR

Made `errors` field optional in the GrpcServiceList type.

### What changed?

Updated the `errors` field in the `GrpcServiceList` type to be optional by changing it from `list<string>` to `optional<list<string>>` in the gRPC definition file.

### How to test?

1. Verify that the API still accepts requests with the `errors` field
2. Confirm that requests without the `errors` field are now properly processed
3. Check that generated client code correctly handles the optional field

### Why make this change?

This change provides more flexibility in the API by making the `errors` field optional, allowing clients to omit this field when not needed. This is particularly useful in cases where no errors occurred during service enumeration, eliminating the need to send an empty list.