### PR TITLE
Networkscan Refactor v2

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -13,14 +13,14 @@ import (
 func (a *NetworkScan) InitDiscoverCommand() {
 	discoverCmd := &cobra.Command{
 		Use:   "discover",
-		Short: "Discover hosts, ports, services, and TLS info",
-		Long:  `Discover hosts, ports, services, and TLS info`,
+		Short: "Discover live hosts, open ports, running services, and TLS configurations on a network.",
+		Long:  `Discover live hosts, open ports, running services, and TLS configurations on a network.`,
 	}
 
 	discoverHostCmd := &cobra.Command{
 		Use:   "host",
-		Short: "Discover hosts on a network",
-		Long:  `Discover hosts on a network`,
+		Short: "Identify live hosts within a given IP, hostname, or CIDR range using various discovery techniques.",
+		Long:  `Identify live hosts within a given IP, hostname, or CIDR range using various discovery techniques.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if !privileges.IsPrivileged {
 				a.OutputSignal.AddError(errors.New("discover host can only be run as a privileged user"))
@@ -44,15 +44,15 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	discoverHostCmd.Flags().String("target", "", "Target IP, host, or CIDR to scan for hosts")
-	discoverHostCmd.Flags().String("scan-type", "", "Scan type for host discovery (tcpsyn | tcpack | icmpecho | icmptimestamp | arp | icmpaddressmask)")
+	discoverHostCmd.Flags().String("target", "", "Target IP address, hostname, or CIDR range to scan for live hosts")
+	discoverHostCmd.Flags().String("scan-type", "", "Discovery scan type: tcpsyn, tcpack, icmpecho, icmptimestamp, arp, or icmpaddressmask")
 	_ = discoverHostCmd.MarkFlagRequired("target")
 	discoverCmd.AddCommand(discoverHostCmd)
 
 	discoverOSCmd := &cobra.Command{
 		Use:   "os",
-		Short: "Fingerprint the operating system on a target host",
-		Long:  `Fingerprint the operating system on a target host`,
+		Short: "Detect and fingerprint the operating system running on a specified host (requires nmap and root privileges).",
+		Long:  `Detect and fingerprint the operating system running on a specified host (requires nmap and root privileges).`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if !privileges.IsPrivileged {
 				a.OutputSignal.AddError(errors.New("discover os can only be run as a privileged user"))
@@ -76,14 +76,14 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	discoverOSCmd.Flags().String("target", "", "Target IP or FQDN to detect")
+	discoverOSCmd.Flags().String("target", "", "Target IP address or fully qualified domain name (FQDN) for OS fingerprinting")
 	_ = discoverOSCmd.MarkFlagRequired("target")
 	discoverCmd.AddCommand(discoverOSCmd)
 
 	discoverPortCmd := &cobra.Command{
 		Use:   "port",
-		Short: "Scan open ports on a target host",
-		Long:  `Scan open ports on a target host`,
+		Short: "Scan a target host for open TCP and UDP ports using customizable scan types and port ranges.",
+		Long:  `Scan a target host for open TCP and UDP ports using customizable scan types and port ranges.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			target, err := cmd.Flags().GetString("target")
 			if err != nil {
@@ -131,19 +131,19 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	discoverPortCmd.Flags().String("target", "", "Target IP or FQDN to scan for ports")
-	discoverPortCmd.Flags().String("tcp-ports", "", "TCP Port/Port Range to scan")
-	discoverPortCmd.Flags().String("udp-ports", "", "UDP Port/Port Range to scan")
-	discoverPortCmd.Flags().String("top-ports", "", "Top TCP Ports to scan (full | 100 | 1000)")
-	discoverPortCmd.Flags().Int("threads", 25, "Number of threads to use for scanning")
-	discoverPortCmd.Flags().String("scan-type", "syn", "Type of scan to perform (syn | connect)")
+	discoverPortCmd.Flags().String("target", "", "Target IP address or FQDN to scan for open ports")
+	discoverPortCmd.Flags().String("tcp-ports", "", "Comma-separated list or range of TCP ports to scan (e.g., 22,80,443 or 1-1024)")
+	discoverPortCmd.Flags().String("udp-ports", "", "Comma-separated list or range of UDP ports to scan (e.g., 53,161 or 1-1024)")
+	discoverPortCmd.Flags().String("top-ports", "", "Scan the top N most common TCP ports (options: full, 100, 1000)")
+	discoverPortCmd.Flags().Int("threads", 25, "Number of concurrent threads to use during port scanning")
+	discoverPortCmd.Flags().String("scan-type", "syn", "Port scan type: syn (default, requires root) or connect (TCP connect scan)")
 	_ = discoverPortCmd.MarkFlagRequired("target")
 	discoverCmd.AddCommand(discoverPortCmd)
 
 	discoverServiceCmd := &cobra.Command{
 		Use:   "service",
-		Short: "Fingerprint a network service behind an open port",
-		Long:  `Fingerprint a network service behind an open port`,
+		Short: "Identify and fingerprint the network service running on a specific open port of a target host.",
+		Long:  `Identify and fingerprint the network service running on a specific open port of a target host.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			target, err := cmd.Flags().GetString("target")
 			if err != nil {
@@ -173,17 +173,17 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	discoverServiceCmd.Flags().String("target", "", "Target address (e.g., 192.168.1.1 or example.com)")
-	discoverServiceCmd.Flags().Int("port", 0, "Address Port (e.g., 443)")
-	discoverServiceCmd.Flags().Int("timeout", 5, "Timeout limit for each handshake in seconds")
+	discoverServiceCmd.Flags().String("target", "", "Target IP address or hostname where the service is running")
+	discoverServiceCmd.Flags().Int("port", 0, "Port number of the service to fingerprint (e.g., 443)")
+	discoverServiceCmd.Flags().Int("timeout", 5, "Timeout in seconds for each service fingerprinting attempt")
 	_ = discoverServiceCmd.MarkFlagRequired("target")
 	_ = discoverServiceCmd.MarkFlagRequired("port")
 	discoverCmd.AddCommand(discoverServiceCmd)
 
 	discoverTLSCmd := &cobra.Command{
 		Use:   "tls",
-		Short: "Discover TLS Config and Certificate of a network address socket",
-		Long:  `Discover TLS Config and Certificate of a network address socket`,
+		Short: "Retrieve and analyze the TLS configuration and certificate details for one or more target addresses.",
+		Long:  `Retrieve and analyze the TLS configuration and certificate details for one or more target addresses.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			targets, err := cmd.Flags().GetStringSlice("targets")
 			if err != nil {
@@ -208,9 +208,9 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	discoverTLSCmd.Flags().StringSlice("targets", []string{}, "Address of target")
-	discoverTLSCmd.Flags().Int("timeout", 30, "Timeout limit for each handshake in seconds")
-	discoverTLSCmd.Flags().Bool("insecure", false, "Skip TLS verification")
+	discoverTLSCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to analyze TLS configuration")
+	discoverTLSCmd.Flags().Int("timeout", 30, "Timeout in seconds for each TLS handshake attempt")
+	discoverTLSCmd.Flags().Bool("insecure", false, "Skip certificate verification (allow insecure TLS connections)")
 	discoverCmd.AddCommand(discoverTLSCmd)
 
 	a.RootCmd.AddCommand(discoverCmd)

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -9,15 +9,15 @@ import (
 func (a *NetworkScan) InitEnumerateCommand() {
 	enumerateCmd := &cobra.Command{
 		Use:   "enumerate",
-		Short: "Enumerate information about network services",
-		Long:  `Enumerate information about network services`,
+		Short: "Enumerate detailed information about supported network services on target hosts.",
+		Long:  `Enumerate detailed information about supported network services on target hosts.`,
 	}
 
 	// FTP enumerate
 	enumerateFtpCmd := &cobra.Command{
 		Use:   "ftp",
-		Short: "Enumerate information about FTP on a target host",
-		Long:  `Enumerate information about FTP on a target host`,
+		Short: "Gather detailed information about FTP services running on specified targets.",
+		Long:  `Gather detailed information about FTP services running on specified targets.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			targets, err := cmd.Flags().GetStringSlice("targets")
 			if err != nil {
@@ -31,7 +31,7 @@ func (a *NetworkScan) InitEnumerateCommand() {
 				return
 			}
 
-			report, err := enumerate.RunNetworkApplicationEnumerate(cmd.Context(), targets, enumerateFern.NetworkApplicationTypeFtp, timeout)
+			report, err := enumerate.RunServiceEnumerate(cmd.Context(), targets, enumerateFern.ServiceTypeFtp, timeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -39,16 +39,16 @@ func (a *NetworkScan) InitEnumerateCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	enumerateFtpCmd.Flags().StringSlice("targets", []string{}, "Target IP Socket or FQDN Socket to enumerate")
-	enumerateFtpCmd.Flags().Int("timeout", 30, "Total time allowed for enumeration of each target in seconds")
+	enumerateFtpCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to enumerate")
+	enumerateFtpCmd.Flags().Int("timeout", 30, "Timeout in seconds for enumerating each target")
 	_ = enumerateFtpCmd.MarkFlagRequired("targets")
 	enumerateCmd.AddCommand(enumerateFtpCmd)
 
 	// GRPC enumerate
 	enumerateGrpcCmd := &cobra.Command{
 		Use:   "grpc",
-		Short: "Enumerate data about GRPC on a target host",
-		Long:  `Enumerate data about GRPC on a target host`,
+		Short: "Enumerate available gRPC services and methods on specified targets.",
+		Long:  `Enumerate available gRPC services and methods on specified targets.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			targets, err := cmd.Flags().GetStringSlice("targets")
 			if err != nil {
@@ -62,7 +62,7 @@ func (a *NetworkScan) InitEnumerateCommand() {
 				return
 			}
 
-			report, err := enumerate.RunNetworkApplicationEnumerate(cmd.Context(), targets, enumerateFern.NetworkApplicationTypeGrpc, timeout)
+			report, err := enumerate.RunServiceEnumerate(cmd.Context(), targets, enumerateFern.ServiceTypeGrpc, timeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -70,16 +70,16 @@ func (a *NetworkScan) InitEnumerateCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	enumerateGrpcCmd.Flags().StringSlice("targets", []string{}, "Target IP Socket or FQDN Socket to enumerate")
-	enumerateGrpcCmd.Flags().Int("timeout", 30, "Total time allowed for enumeration of each target in seconds")
+	enumerateGrpcCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to enumerate")
+	enumerateGrpcCmd.Flags().Int("timeout", 30, "Timeout in seconds for enumerating each target")
 	_ = enumerateGrpcCmd.MarkFlagRequired("targets")
 	enumerateCmd.AddCommand(enumerateGrpcCmd)
 
 	// SMTP enumerate
 	enumerateSMTPCmd := &cobra.Command{
 		Use:   "smtp",
-		Short: "Enumerate data about SMTP on a target host",
-		Long:  `Enumerate data about SMTP on a target host`,
+		Short: "Gather information about SMTP servers and their supported features on specified targets.",
+		Long:  `Gather information about SMTP servers and their supported features on specified targets.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			targets, err := cmd.Flags().GetStringSlice("targets")
 			if err != nil {
@@ -93,7 +93,7 @@ func (a *NetworkScan) InitEnumerateCommand() {
 				return
 			}
 
-			report, err := enumerate.RunNetworkApplicationEnumerate(cmd.Context(), targets, enumerateFern.NetworkApplicationTypeSmtp, timeout)
+			report, err := enumerate.RunServiceEnumerate(cmd.Context(), targets, enumerateFern.ServiceTypeSmtp, timeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -101,16 +101,16 @@ func (a *NetworkScan) InitEnumerateCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	enumerateSMTPCmd.Flags().StringSlice("targets", []string{}, "Target IP Socket or FQDN Socket to enumerate")
-	enumerateSMTPCmd.Flags().Int("timeout", 30, "Total time allowed for enumeration of each target in seconds")
+	enumerateSMTPCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to enumerate")
+	enumerateSMTPCmd.Flags().Int("timeout", 30, "Timeout in seconds for enumerating each target")
 	_ = enumerateSMTPCmd.MarkFlagRequired("targets")
 	enumerateCmd.AddCommand(enumerateSMTPCmd)
 
 	// SSH enumerate
 	enumerateSSHCmd := &cobra.Command{
 		Use:   "ssh",
-		Short: "Enumerate data about SSH on a target host",
-		Long:  `Enumerate data about SSH on a target host`,
+		Short: "Enumerate SSH server details, supported authentication methods, and features on specified targets.",
+		Long:  `Enumerate SSH server details, supported authentication methods, and features on specified targets.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			targets, err := cmd.Flags().GetStringSlice("targets")
 			if err != nil {
@@ -124,7 +124,7 @@ func (a *NetworkScan) InitEnumerateCommand() {
 				return
 			}
 
-			report, err := enumerate.RunNetworkApplicationEnumerate(cmd.Context(), targets, enumerateFern.NetworkApplicationTypeSsh, timeout)
+			report, err := enumerate.RunServiceEnumerate(cmd.Context(), targets, enumerateFern.ServiceTypeSsh, timeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -132,8 +132,8 @@ func (a *NetworkScan) InitEnumerateCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	enumerateSSHCmd.Flags().StringSlice("targets", []string{}, "Target IP Socket or FQDN Socket to enumerate")
-	enumerateSSHCmd.Flags().Int("timeout", 30, "Total time allowed for enumeration of each target in seconds")
+	enumerateSSHCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to enumerate")
+	enumerateSSHCmd.Flags().Int("timeout", 30, "Timeout in seconds for enumerating each target")
 	_ = enumerateSSHCmd.MarkFlagRequired("targets")
 	enumerateCmd.AddCommand(enumerateSSHCmd)
 

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -12,14 +12,14 @@ import (
 func (a *NetworkScan) InitPentestCommand() {
 	pentestCmd := &cobra.Command{
 		Use:   "pentest",
-		Short: "Run pentest modules",
-		Long:  `Run pentest modules`,
+		Short: "Run penetration testing modules against network services.",
+		Long:  `Run penetration testing modules against network services.`,
 	}
 
 	bruteForceCmd := &cobra.Command{
 		Use:   "bruteforce",
-		Short: "Execute a Bruteforce attack against an application",
-		Long:  `Execute a Bruteforce attack against an application`,
+		Short: "Perform a brute-force attack against a specified service module (e.g., SSH, FTP) using provided credentials.",
+		Long:  `Perform a brute-force attack against a specified service module (e.g., SSH, FTP) using provided credentials.`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			// Targets
@@ -119,17 +119,17 @@ func (a *NetworkScan) InitPentestCommand() {
 		},
 	}
 
-	bruteForceCmd.Flags().StringSlice("targets", []string{}, "Address of target")
-	bruteForceCmd.Flags().String("module", "", "Module type (ie.SSH)")
-	bruteForceCmd.Flags().StringSlice("usernames", []string{}, "Username to use in attack")
-	bruteForceCmd.Flags().StringSlice("passwords", []string{}, "Password to use in attack")
-	bruteForceCmd.Flags().StringSlice("username-lists", []string{}, "File paths containing usernames to use in attack")
-	bruteForceCmd.Flags().StringSlice("password-lists", []string{}, "File paths containing passwords to use in attack")
-	bruteForceCmd.Flags().Int("timeout", 3000, "Timeout per request (MilliSeconds)")
-	bruteForceCmd.Flags().Int("sleep", 3000, "Sleep time between requests (MilliSeconds)")
-	bruteForceCmd.Flags().Int("retries", 2, "Number of Attempts per credential pair")
-	bruteForceCmd.Flags().Bool("successful-only", false, "Only show successful attempts")
-	bruteForceCmd.Flags().Bool("stop-first-success", false, "Stop on the first successful login")
+	bruteForceCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to attack")
+	bruteForceCmd.Flags().String("module", "", "Type of service module to attack (e.g., SSH, FTP, etc.)")
+	bruteForceCmd.Flags().StringSlice("usernames", []string{}, "List of usernames to use in the brute-force attack")
+	bruteForceCmd.Flags().StringSlice("passwords", []string{}, "List of passwords to use in the brute-force attack")
+	bruteForceCmd.Flags().StringSlice("username-lists", []string{}, "File paths containing lists of usernames (one per line) to use in the attack")
+	bruteForceCmd.Flags().StringSlice("password-lists", []string{}, "File paths containing lists of passwords (one per line) to use in the attack")
+	bruteForceCmd.Flags().Int("timeout", 3000, "Timeout per authentication attempt in milliseconds")
+	bruteForceCmd.Flags().Int("sleep", 3000, "Sleep duration in milliseconds between authentication attempts")
+	bruteForceCmd.Flags().Int("retries", 2, "Number of retry attempts per username/password pair")
+	bruteForceCmd.Flags().Bool("successful-only", false, "Display only successful authentication attempts in the output")
+	bruteForceCmd.Flags().Bool("stop-first-success", false, "Stop the brute-force attack after the first successful login")
 
 	_ = bruteForceCmd.MarkFlagRequired("targets")
 	_ = bruteForceCmd.MarkFlagRequired("module")

--- a/fern/definition/common/common.yml
+++ b/fern/definition/common/common.yml
@@ -42,6 +42,7 @@ types:
       - TELNET
       - VNC
       - UNKNOWN
+
   TransportType:
     enum:
       - TCP

--- a/fern/definition/discover/host.yml
+++ b/fern/definition/discover/host.yml
@@ -8,12 +8,12 @@ types:
       - ARP
       - ICMP_ADDRESS_MASK
 
-  DiscoverHostDetails:
+  HostDetails:
     properties:
       ip: string
       host: string
 
   DiscoverHostReport:
     properties:
-      hosts: list<DiscoverHostDetails>
+      hosts: list<HostDetails>
       errors: list<string>

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -7,17 +7,20 @@ types:
       topPorts: optional<string>
       threads: integer
       scanType: string
-  DiscoverPortDetails:
+
+  PortDetails:
     properties:
       port: integer
       protocol: string
-  DiscoverSocketDetails:
+
+  SocketDetails:
     properties:
       host: string
       ip: string
-      ports: optional<list<DiscoverPortDetails>>
+      ports: optional<list<PortDetails>>
+
   DiscoverPortReport:
     properties:
       config: DiscoverPortConfig
-      hosts: optional<list<DiscoverSocketDetails>>
+      hosts: optional<list<SocketDetails>>
       errors: optional<list<string>>

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -7,7 +7,7 @@ types:
       port: integer
       timeout: integer
 
-  DiscoverServiceDetails:
+  ServiceDetails:
     properties:
       host: string
       ip: string
@@ -17,8 +17,9 @@ types:
       transport: common.TransportType
       protocol: common.ProtocolType
       metadata: optional<map<string, string>>
+
   DiscoverServiceReport:
     properties:
       config: DiscoverServiceConfig
-      services: optional<list<DiscoverServiceDetails>>
+      services: optional<list<ServiceDetails>>
       errors: optional<list<string>>

--- a/fern/definition/discover/tls.yml
+++ b/fern/definition/discover/tls.yml
@@ -10,6 +10,7 @@ types:
       - TLS_1_2
       - TLS_1_3
       - UNKNOWN
+
   SignatureAlgorithm:
     enum:
       - MD2_RSA
@@ -29,6 +30,7 @@ types:
       - SHA384_RSA_PSS
       - SHA512_RSA_PSS
       - ED25519
+
   PublicKeyAlgorithm:
     enum:
       - DES
@@ -45,6 +47,7 @@ types:
       - RSA
       - RSA_1024
       - UNKNOWN
+
   Certificate:
     properties:
       subjectCommonName: optional<string>
@@ -57,23 +60,24 @@ types:
       signature: optional<string>
       signatureAlgorithm: optional<SignatureAlgorithm>
       publicKeyAlgorithm: optional<PublicKeyAlgorithm>
+
   # Config
   DiscoverTlsConfig:
     properties:
       timeout: integer
       insecureSkipVerify: boolean
   # Data
-  DiscoverTlsDetails:
+  TlsDetails:
     properties:
       version: optional<TlsVersion>
       cipherSuite: optional<string>
       certificates: optional<list<Certificate>>
-  DiscoverTlsSummary:
+  TlsSummary:
     properties:
       address: string
-      tlsDetails: optional<DiscoverTlsDetails>
+      tlsDetails: optional<TlsDetails>
   DiscoverTlsReport:
     properties:
-      details: optional<list<DiscoverTlsSummary>>
+      details: optional<list<TlsSummary>>
       errors: optional<list<string>>
       config: DiscoverTlsConfig

--- a/fern/definition/enumerate/enumerate.yml
+++ b/fern/definition/enumerate/enumerate.yml
@@ -4,20 +4,20 @@ imports:
   smtp: ./smtp/smtp.yml
   grpc: ./grpc/grpc.yml
 types:
-  NetworkApplicationType:
+  ServiceType:
     enum:
       - SSH
       - FTP
       - SMTP
       - GRPC
-  NetworkApplicationEnumerateDetails:
+  EnumerateServiceDetails:
     union:
       EnumerateSshDetails: ssh.EnumerateSshDetails
       EnumerateFtpDetails: ftp.EnumerateFtpDetails
       EnumerateSmtpDetails: smtp.EnumerateSmtpDetails
       EnumerateGrpcDetails: grpc.EnumerateGrpcDetails
-  NetworkApplicationEnumerateReport:
+  EnumerateServiceReport:
     properties:
       targets: list<string>
-      details: optional<list<NetworkApplicationEnumerateDetails>>
+      details: optional<list<EnumerateServiceDetails>>
       errors: optional<list<string>>

--- a/fern/definition/pentest/bruteforce/bruteforce.yml
+++ b/fern/definition/pentest/bruteforce/bruteforce.yml
@@ -43,7 +43,7 @@ types:
       retries: integer
       successfulOnly: boolean
       stopFirstSuccess: boolean
-  PentestBruteForceAttempt:
+  BruteForceAttempt:
     properties:
       target: string
       statistics: StatisticsInfo
@@ -51,5 +51,5 @@ types:
   PentestBruteForceReport:
     properties:
       module: ModuleType
-      attempts: optional<list<PentestBruteForceAttempt>>
+      attempts: optional<list<BruteForceAttempt>>
       errors: optional<list<string>>

--- a/internal/discover/host.go
+++ b/internal/discover/host.go
@@ -25,8 +25,8 @@ func RunHostDiscovery(ctx context.Context, target string, scantype string) (disc
 	}, nil
 }
 
-func getHostDiscover(ctx context.Context, target string, scantype string) ([]*discoverFern.DiscoverHostDetails, error) {
-	hostDetails := []*discoverFern.DiscoverHostDetails{}
+func getHostDiscover(ctx context.Context, target string, scantype string) ([]*discoverFern.HostDetails, error) {
+	hostDetails := []*discoverFern.HostDetails{}
 	hostDiscoverOpts := &runner.Options{
 		Silent:            true,
 		JSON:              true,
@@ -80,8 +80,8 @@ func getHostDiscover(ctx context.Context, target string, scantype string) ([]*di
 
 }
 
-func parseHostDiscoverResult(result result.HostResult) *discoverFern.DiscoverHostDetails {
-	return &discoverFern.DiscoverHostDetails{
+func parseHostDiscoverResult(result result.HostResult) *discoverFern.HostDetails {
+	return &discoverFern.HostDetails{
 		Host: result.Host,
 		Ip:   result.IP,
 	}

--- a/internal/discover/port.go
+++ b/internal/discover/port.go
@@ -26,9 +26,9 @@ func RunPortScan(ctx context.Context, config discoverFern.DiscoverPortConfig) (*
 	return &resources, nil
 }
 
-func getPortScan(ctx context.Context, config discoverFern.DiscoverPortConfig) ([]*discoverFern.DiscoverSocketDetails, error) {
+func getPortScan(ctx context.Context, config discoverFern.DiscoverPortConfig) ([]*discoverFern.SocketDetails, error) {
 	output := result.HostResult{}
-	hosts := []*discoverFern.DiscoverSocketDetails{}
+	hosts := []*discoverFern.SocketDetails{}
 	// These settings mimic naabu's default settings
 	portscanOpts := &runner.Options{
 		Silent:            false,
@@ -92,15 +92,15 @@ func getPortScan(ctx context.Context, config discoverFern.DiscoverPortConfig) ([
 
 }
 
-func parsePortScanResult(result *result.HostResult) *discoverFern.DiscoverSocketDetails {
-	ports := []*discoverFern.DiscoverPortDetails{}
+func parsePortScanResult(result *result.HostResult) *discoverFern.SocketDetails {
+	ports := []*discoverFern.PortDetails{}
 	for _, p := range result.Ports {
-		ports = append(ports, &discoverFern.DiscoverPortDetails{
+		ports = append(ports, &discoverFern.PortDetails{
 			Port:     p.Port,
 			Protocol: p.Protocol.String(),
 		})
 	}
-	host := discoverFern.DiscoverSocketDetails{
+	host := discoverFern.SocketDetails{
 		Host:  result.Host,
 		Ip:    result.IP,
 		Ports: ports,

--- a/internal/discover/service.go
+++ b/internal/discover/service.go
@@ -36,7 +36,7 @@ func RunServiceFingerprint(ctx context.Context, config discoverFern.DiscoverServ
 		return &resources, err
 	}
 
-	var fingerprintResults []*discoverFern.DiscoverServiceDetails
+	var fingerprintResults []*discoverFern.ServiceDetails
 	for _, ip := range ips {
 		ipAddr, err := netip.ParseAddr(ip.String())
 		if err != nil {
@@ -60,7 +60,7 @@ func RunServiceFingerprint(ctx context.Context, config discoverFern.DiscoverServ
 		}
 
 		metadata := metadataMap(result.Metadata())
-		fingerprintResult := discoverFern.DiscoverServiceDetails{
+		fingerprintResult := discoverFern.ServiceDetails{
 			Host:      result.Host,
 			Ip:        result.IP,
 			Port:      result.Port,

--- a/internal/discover/tls.go
+++ b/internal/discover/tls.go
@@ -17,7 +17,7 @@ func GetTLSInfo(ctx context.Context, addresses []string, config discoverFern.Dis
 	resources := discoverFern.DiscoverTlsReport{Config: &config}
 	errors := []string{}
 
-	serviceDetails := []*discoverFern.DiscoverTlsSummary{}
+	serviceDetails := []*discoverFern.TlsSummary{}
 	for _, targetAddress := range addresses {
 		// Define timeout for the TLS connection
 		dialer := &net.Dialer{
@@ -54,7 +54,7 @@ func GetTLSInfo(ctx context.Context, addresses []string, config discoverFern.Dis
 		}
 
 		// Construct AddressTlsReport
-		serviceDetail := discoverFern.DiscoverTlsSummary{
+		serviceDetail := discoverFern.TlsSummary{
 			Address:    targetAddress,
 			TlsDetails: tlsInfo,
 		}
@@ -84,8 +84,8 @@ func tlsVersionToString(version uint16) discoverFern.TlsVersion {
 }
 
 // Convert TLS connection state to TLSInfo
-func convertToTLSInfo(state *tls.ConnectionState) *discoverFern.DiscoverTlsDetails {
-	tlsInfo := &discoverFern.DiscoverTlsDetails{
+func convertToTLSInfo(state *tls.ConnectionState) *discoverFern.TlsDetails {
+	tlsInfo := &discoverFern.TlsDetails{
 		Certificates: []*discoverFern.Certificate{},
 	}
 

--- a/internal/enumerate/engine.go
+++ b/internal/enumerate/engine.go
@@ -15,24 +15,24 @@ import (
 )
 
 type NetworkApplicationLibrary interface {
-	EnumerateTarget(ctx context.Context, target string) (*enumerateFern.NetworkApplicationEnumerateDetails, []string)
+	EnumerateTarget(ctx context.Context, target string) (*enumerateFern.EnumerateServiceDetails, []string)
 }
 
 type NetworkApplicationEngine struct {
 	Library NetworkApplicationLibrary
 }
 
-func RunNetworkApplicationEnumerate(ctx context.Context, targets []string, networkApplication enumerateFern.NetworkApplicationType, timeout int) (enumerateFern.NetworkApplicationEnumerateReport, error) {
+func RunServiceEnumerate(ctx context.Context, targets []string, serviceType enumerateFern.ServiceType, timeout int) (enumerateFern.EnumerateServiceReport, error) {
 	log.Printf("[INFO] Starting enumeration for %d targets with a timeout of %ds", len(targets), timeout)
-	resource := enumerateFern.NetworkApplicationEnumerateReport{Targets: targets}
+	resource := enumerateFern.EnumerateServiceReport{Targets: targets}
 
-	engine, err := getEngine(networkApplication)
+	engine, err := getEngine(serviceType)
 	if err != nil {
-		return enumerateFern.NetworkApplicationEnumerateReport{}, err
+		return enumerateFern.EnumerateServiceReport{}, err
 	}
 
 	// Create channels for collecting results and errors
-	detailsChan := make(chan *enumerateFern.NetworkApplicationEnumerateDetails, len(targets))
+	detailsChan := make(chan *enumerateFern.EnumerateServiceDetails, len(targets))
 	errorsChan := make(chan string, len(targets))
 	var wg sync.WaitGroup
 
@@ -48,14 +48,14 @@ func RunNetworkApplicationEnumerate(ctx context.Context, targets []string, netwo
 
 			// Start enumeration
 			resultChan := make(chan struct {
-				detail *enumerateFern.NetworkApplicationEnumerateDetails
+				detail *enumerateFern.EnumerateServiceDetails
 				errs   []string
 			}, 1)
 
 			go func() {
 				detail, errs := engine.Library.EnumerateTarget(targetCtx, target)
 				resultChan <- struct {
-					detail *enumerateFern.NetworkApplicationEnumerateDetails
+					detail *enumerateFern.EnumerateServiceDetails
 					errs   []string
 				}{detail, errs}
 			}()
@@ -89,7 +89,7 @@ func RunNetworkApplicationEnumerate(ctx context.Context, targets []string, netwo
 	}()
 
 	// Collect results
-	var details []*enumerateFern.NetworkApplicationEnumerateDetails
+	var details []*enumerateFern.EnumerateServiceDetails
 	var errors []string
 
 	for detail := range detailsChan {
@@ -106,17 +106,17 @@ func RunNetworkApplicationEnumerate(ctx context.Context, targets []string, netwo
 }
 
 // Factory function to create the appropriate engine
-func getEngine(application enumerateFern.NetworkApplicationType) (NetworkApplicationEngine, error) {
-	switch application {
-	case enumerateFern.NetworkApplicationTypeSsh:
+func getEngine(serviceType enumerateFern.ServiceType) (NetworkApplicationEngine, error) {
+	switch serviceType {
+	case enumerateFern.ServiceTypeSsh:
 		return NetworkApplicationEngine{Library: &ssh.LibraryEnumerateSSH{}}, nil
-	case enumerateFern.NetworkApplicationTypeFtp:
+	case enumerateFern.ServiceTypeFtp:
 		return NetworkApplicationEngine{Library: &ftp.LibraryEnumerateFTP{}}, nil
-	case enumerateFern.NetworkApplicationTypeSmtp:
+	case enumerateFern.ServiceTypeSmtp:
 		return NetworkApplicationEngine{Library: &smtp.LibraryEnumerateSMTP{}}, nil
-	case enumerateFern.NetworkApplicationTypeGrpc:
+	case enumerateFern.ServiceTypeGrpc:
 		return NetworkApplicationEngine{Library: &grpc.LibraryEnumerateGRPC{}}, nil
 	default:
-		return NetworkApplicationEngine{}, fmt.Errorf("unsupported network application: %v", application)
+		return NetworkApplicationEngine{}, fmt.Errorf("unsupported network application: %v", serviceType)
 	}
 }

--- a/internal/enumerate/ftp/ftp.go
+++ b/internal/enumerate/ftp/ftp.go
@@ -41,7 +41,7 @@ var bufferSize = 2048
 type LibraryEnumerateFTP struct{}
 
 // EnumerateTarget connects to the target and extracts FTP details.
-func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string) (*enumerateFern.NetworkApplicationEnumerateDetails, []string) {
+func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string) (*enumerateFern.EnumerateServiceDetails, []string) {
 	var details ftp.EnumerateFtpDetails
 	details.Target = target
 	errors := []string{}
@@ -52,14 +52,14 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 	if err != nil {
 		log.Printf("[ERROR] Failed to connect to %s: %v", target, err)
 		errors = append(errors, fmt.Sprintf("Failed to connect to %s: %v", target, err))
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateFtpDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
 	}
 
 	// Grab the FTP banner
 	bannerStr, err := grabBanner(conn)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("error reading banner from %s: %v", target, err))
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateFtpDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
 	}
 	details.Banner = &bannerStr
 	successFulConnection := true
@@ -93,5 +93,5 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 		errors = append(errors, fmt.Sprintf("failed to close connection: %v", err))
 	}
 
-	return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateFtpDetails(&details), errors
+	return enumerateFern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
 }

--- a/internal/enumerate/grpc/grpc.go
+++ b/internal/enumerate/grpc/grpc.go
@@ -24,7 +24,7 @@ import (
 type LibraryEnumerateGRPC struct{}
 
 // EnumerateTarget performs a gRPC scan against a target URL and returns the report.
-func (lib *LibraryEnumerateGRPC) EnumerateTarget(ctx context.Context, target string) (*enumerateFern.NetworkApplicationEnumerateDetails, []string) {
+func (lib *LibraryEnumerateGRPC) EnumerateTarget(ctx context.Context, target string) (*enumerateFern.EnumerateServiceDetails, []string) {
 	var details grpc.EnumerateGrpcDetails
 	details.Target = target
 	errors := []string{}
@@ -33,34 +33,34 @@ func (lib *LibraryEnumerateGRPC) EnumerateTarget(ctx context.Context, target str
 	conn, err := connectToGRPCServer(ctx, target)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateGrpcDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
 	}
 	defer closeConnection(conn)
 
 	stream, err := createReflectionClient(ctx, conn)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateGrpcDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
 	}
 
 	services, err := requestAndReceiveServices(stream)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateGrpcDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
 	}
 
 	rawDescriptors, err := processServices(stream, services, &details)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateGrpcDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
 	}
 
 	if err := encodeRawDescriptors(rawDescriptors, &details); err != nil {
 		errors = append(errors, err.Error())
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateGrpcDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
 	}
 
-	return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateGrpcDetails(&details), errors
+	return enumerateFern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
 }
 
 // connectToGRPCServer dials the target with a timeout.

--- a/internal/enumerate/smtp/smtp.go
+++ b/internal/enumerate/smtp/smtp.go
@@ -26,7 +26,7 @@ type LibraryEnumerateSMTP struct{}
 //     a. Parse data returned from 'AUTH' command
 //  4. Test unauthenticated email
 //     a. If unauthenticated email is not allowed, set AllowsUnauthenticatedEmail to false
-func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target string) (*enumerateFern.NetworkApplicationEnumerateDetails, []string) {
+func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target string) (*enumerateFern.EnumerateServiceDetails, []string) {
 	log.Printf("[INFO] Starting enumeration for target: %s", target)
 	detail := smtp.EnumerateSmtpDetails{
 		Target: target,
@@ -37,7 +37,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	hostname, _, err := net.SplitHostPort(target)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("invalid target format: %v", err))
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateSmtpDetails(&detail), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
 	}
 	config := &tls.Config{
 		ServerName:         hostname,
@@ -60,7 +60,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 			canConnect := false
 			detail.CanConnect = &canConnect
 			errors = append(errors, fmt.Sprintf("both TCP and TLS connections failed: %v", err))
-			return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateSmtpDetails(&detail), errors
+			return enumerateFern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
 		}
 		log.Printf("[DEBUG] TLS connection successful")
 		TLSSupported := true
@@ -77,7 +77,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	client, err := netsmtp.NewClient(conn, hostname)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("SMTP client creation failed: %v", err))
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateSmtpDetails(&detail), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
 	}
 
 	// Try STARTTLS if TLS connection established above
@@ -118,5 +118,5 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 		errors = append(errors, fmt.Sprintf("failed to close connection: %v", err))
 	}
 
-	return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateSmtpDetails(&detail), errors
+	return enumerateFern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
 }

--- a/internal/enumerate/ssh/ssh.go
+++ b/internal/enumerate/ssh/ssh.go
@@ -32,7 +32,7 @@ type LibraryEnumerateSSH struct{}
 //   e. MACs
 //   f. Auth Methods (Public Key, Password)
 
-func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string) (*enumerateFern.NetworkApplicationEnumerateDetails, []string) {
+func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string) (*enumerateFern.EnumerateServiceDetails, []string) {
 	var details ssh.EnumerateSshDetails
 	details.Target = target
 	errors := []string{}
@@ -42,14 +42,14 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 	conn, err := dialer.DialContext(ctx, "tcp", target)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateSshDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
 	}
 
 	// Get SSH Banner
 	version, versionASCII, err := getSSHVersion(conn)
 	if err != nil || version == nil {
 		errors = append(errors, err.Error())
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateSshDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
 	}
 	details.Version = version
 
@@ -57,7 +57,7 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 	rawASCII, err := getSSHAlgorithms(conn)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateSshDetails(&details), errors
+		return enumerateFern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
 	}
 
 	fullASCII := rawASCII
@@ -87,5 +87,5 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 		errors = append(errors, err.Error())
 	}
 
-	return enumerateFern.NewNetworkApplicationEnumerateDetailsFromEnumerateSshDetails(&details), errors
+	return enumerateFern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
 }

--- a/internal/pentest/bruteforce/engine.go
+++ b/internal/pentest/bruteforce/engine.go
@@ -90,7 +90,7 @@ func Attack(ctx context.Context, config *bruteforceFern.PentestBruteForceConfig)
 		return &resources, fmt.Errorf("unsupported module: %s", config.Module)
 	}
 
-	var bruteForceResults []*bruteforceFern.PentestBruteForceAttempt
+	var bruteForceResults []*bruteforceFern.BruteForceAttempt
 	for _, target := range config.Targets {
 		var attempts []*bruteforceFern.AttemptInfo
 
@@ -133,7 +133,7 @@ func Attack(ctx context.Context, config *bruteforceFern.PentestBruteForceConfig)
 			attempts = successfulAttempts
 		}
 
-		bruteForceResult := bruteforceFern.PentestBruteForceAttempt{
+		bruteForceResult := bruteforceFern.BruteForceAttempt{
 			Target:     target,
 			Attempts:   attempts,
 			Statistics: stats,


### PR DESCRIPTION
### TL;DR

Improved command descriptions and parameter documentation throughout the CLI tool, while refactoring type names for better consistency.

### What changed?

- Enhanced command descriptions for all `discover`, `enumerate`, and `pentest` commands to be more descriptive and user-friendly
- Improved flag descriptions to provide clearer guidance on expected values and formats
- Renamed several data types to follow consistent naming conventions:
  - Removed redundant prefixes from type names (e.g., `DiscoverHostDetails` → `HostDetails`)
  - Renamed `NetworkApplicationType` to `ServiceType` and related types for clarity
  - Updated function names to match the new type names
- Standardized parameter descriptions across all commands to provide more detailed information about their purpose and expected values

### How to test?

1. Run the CLI tool with the `--help` flag to verify the improved command descriptions
2. Test each command with the updated parameter names to ensure they work as expected:
   ```
   ./tool discover host --target 192.168.1.0/24 --scan-type tcpsyn
   ./tool enumerate ssh --targets 192.168.1.10:22 --timeout 30
   ./tool pentest bruteforce --targets 192.168.1.10:22 --module SSH --usernames admin --passwords password
   ```
3. Verify that all functionality continues to work as expected with the renamed types

### Why make this change?

This change improves the user experience by providing more detailed and consistent documentation directly in the CLI. The clearer command and parameter descriptions make it easier for users to understand the tool's capabilities and how to use them correctly. The type name refactoring creates a more consistent naming convention throughout the codebase, making it more maintainable and easier to understand for developers.