### PR TITLE
Naabu Host Discovery Improvements

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -36,7 +36,12 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			report, err := discover.RunHostDiscovery(cmd.Context(), target, scanType)
+			scanTypeEnum, err := discoverFern.NewScanTypeFromString(scanType)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			report, err := discover.RunHostDiscovery(cmd.Context(), target, scanTypeEnum)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -45,7 +50,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 		},
 	}
 	discoverHostCmd.Flags().String("target", "", "Target IP address, hostname, or CIDR range to scan for live hosts")
-	discoverHostCmd.Flags().String("scan-type", "", "Discovery scan type: tcpsyn, tcpack, icmpecho, icmptimestamp, arp, or icmpaddressmask")
+	discoverHostCmd.Flags().String("scan-type", "ICMP_ECHO", "Discovery scan type: TCP_SYN, TCP_ACK, ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK")
 	_ = discoverHostCmd.MarkFlagRequired("target")
 	discoverCmd.AddCommand(discoverHostCmd)
 

--- a/internal/discover/host.go
+++ b/internal/discover/host.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RunHostDiscovery takes a target host (which can be a CIDR) and a scantype and returns a report of all hosts that were discovered
-func RunHostDiscovery(ctx context.Context, target string, scantype string) (discoverFern.DiscoverHostReport, error) {
+func RunHostDiscovery(ctx context.Context, target string, scantype discoverFern.ScanType) (discoverFern.DiscoverHostReport, error) {
 	errors := []string{}
 
 	hostDiscoverResult, err := getHostDiscover(ctx, target, scantype)
@@ -25,7 +25,7 @@ func RunHostDiscovery(ctx context.Context, target string, scantype string) (disc
 	}, nil
 }
 
-func getHostDiscover(ctx context.Context, target string, scantype string) ([]*discoverFern.HostDetails, error) {
+func getHostDiscover(ctx context.Context, target string, scantype discoverFern.ScanType) ([]*discoverFern.HostDetails, error) {
 	hostDetails := []*discoverFern.HostDetails{}
 	hostDiscoverOpts := &runner.Options{
 		Silent:            true,
@@ -49,20 +49,20 @@ func getHostDiscover(ctx context.Context, target string, scantype string) ([]*di
 	}
 
 	switch scantype {
-	case "tcpsyn":
+	case discoverFern.ScanTypeTcpSyn:
 		hostDiscoverOpts.TcpSynPingProbes = goflags.StringSlice{"80"}
-	case "tcpack":
+	case discoverFern.ScanTypeTcpAck:
 		hostDiscoverOpts.TcpAckPingProbes = goflags.StringSlice{"80"}
-	case "icmpecho":
+	case discoverFern.ScanTypeIcmpEcho:
 		hostDiscoverOpts.IcmpEchoRequestProbe = true
-	case "icmptimestamp":
+	case discoverFern.ScanTypeIcmpTimestamp:
 		hostDiscoverOpts.IcmpTimestampRequestProbe = true
-	case "arp":
+	case discoverFern.ScanTypeArp:
 		hostDiscoverOpts.ArpPing = true
-	case "icmpaddressmask":
+	case discoverFern.ScanTypeIcmpAddressMask:
 		hostDiscoverOpts.IcmpAddressMaskRequestProbe = true
 	default:
-		fmt.Print("No valid scantype provided")
+		return hostDetails, fmt.Errorf("no valid scantype provided")
 	}
 
 	hostdiscover, err := runner.NewRunner(hostDiscoverOpts)
@@ -76,8 +76,18 @@ func getHostDiscover(ctx context.Context, target string, scantype string) ([]*di
 		return hostDetails, err
 	}
 
-	return hostDetails, nil
+	// Deduplicate hostDetails by Host and Ip
+	unique := make(map[string]*discoverFern.HostDetails)
+	for _, hd := range hostDetails {
+		key := hd.Host + "|" + hd.Ip
+		unique[key] = hd
+	}
+	result := make([]*discoverFern.HostDetails, 0, len(unique))
+	for _, hd := range unique {
+		result = append(result, hd)
+	}
 
+	return result, nil
 }
 
 func parseHostDiscoverResult(result result.HostResult) *discoverFern.HostDetails {


### PR DESCRIPTION
### TL;DR

Improved host discovery functionality with enum-based scan types and deduplication of results.

### What changed?

- Replaced string-based scan type with a proper enum type (`discoverFern.ScanType`)
- Updated function signatures in `RunHostDiscovery` and `getHostDiscover` to use the enum type
- Added proper error handling for invalid scan types
- Set a default scan type of "ICMP_ECHO" in the CLI flags
- Implemented deduplication of host discovery results to prevent duplicate entries
- Updated the switch statement to use enum constants instead of string literals

### How to test?

1. Run a host discovery scan with the default scan type:
   ```
   ./networkscan discover host --target 192.168.1.0/24
   ```

2. Try different scan types:
   ```
   ./networkscan discover host --target 192.168.1.0/24 --scan-type TCP_SYN
   ./networkscan discover host --target 192.168.1.0/24 --scan-type ARP
   ```

3. Verify that results don't contain duplicate hosts

### Why make this change?

This change improves type safety by using enums instead of strings for scan types, which prevents runtime errors from invalid scan type inputs. It also enhances the quality of results by eliminating duplicate entries in the host discovery output, making the results cleaner and more accurate for users.