### PR TITLE
Naabu CLI flag parsing fix

### DIFF
--- a/internal/discover/port.go
+++ b/internal/discover/port.go
@@ -2,6 +2,8 @@ package discover
 
 import (
 	"context"
+	"flag"
+	"os"
 	"strings"
 
 	discoverFern "github.com/Method-Security/networkscan/generated/go/discover"
@@ -27,6 +29,8 @@ func RunPortScan(ctx context.Context, config discoverFern.DiscoverPortConfig) (*
 }
 
 func getPortScan(ctx context.Context, config discoverFern.DiscoverPortConfig) ([]*discoverFern.SocketDetails, error) {
+	// Hide OS args from Naabu
+	hideOsArgsFromNaabu()
 	output := result.HostResult{}
 	hosts := []*discoverFern.SocketDetails{}
 	// These settings mimic naabu's default settings
@@ -106,4 +110,11 @@ func parsePortScanResult(result *result.HostResult) *discoverFern.SocketDetails 
 		Ports: ports,
 	}
 	return &host
+}
+
+func hideOsArgsFromNaabu() {
+	orig := make([]string, len(os.Args))
+	copy(orig, os.Args)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	os.Args = os.Args[:1]
 }


### PR DESCRIPTION
### TL;DR

Added functionality to hide OS arguments from Naabu during port scanning.

### What changed?

- Created a new `hideOsArgsFromNaabu()` function that saves the original command line arguments, resets the flag command line, and truncates `os.Args` to only include the program name
- Added a call to this function at the beginning of the `getPortScan` method
- Imported the required `flag` and `os` packages

### How to test?

Run a port scan with command line arguments and verify that Naabu doesn't attempt to parse those arguments, which would previously cause conflicts or errors.

### Why make this change?

Naabu was attempting to parse command line arguments intended for our application, causing conflicts between the two flag parsers. This change prevents Naabu from seeing our application's command line arguments, allowing both systems to work independently without interference.