### PR TITLE
Remove Standard Ports from Bruteforce Lib

### DIFF
--- a/internal/pentest/bruteforce/engine.go
+++ b/internal/pentest/bruteforce/engine.go
@@ -167,12 +167,12 @@ func getHostAndPorts(target string) (string, []int, error) {
 	host, port, err := net.SplitHostPort(target)
 	if err != nil {
 		return "", nil, err
-	} else {
-		intPort, err := strconv.Atoi(port)
-		if err != nil {
-			return "", nil, err
-		}
-		ports = []int{intPort}
 	}
+	intPort, err := strconv.Atoi(port)
+	if err != nil {
+		return "", nil, err
+	}
+	ports = []int{intPort}
+
 	return host, ports, nil
 }

--- a/internal/pentest/bruteforce/engine.go
+++ b/internal/pentest/bruteforce/engine.go
@@ -14,7 +14,6 @@ import (
 type Library interface {
 	BruteForce(host string, port int, credPair *bruteforceFern.CredentialPair, config *bruteforceFern.PentestBruteForceConfig) (*bruteforceFern.AttemptInfo, []string)
 	AnalyzeResponse(response *bruteforceFern.ResponseUnion) *bruteforceFern.ResultInfo
-	StandardPorts() []int
 }
 
 type Engine struct {
@@ -28,7 +27,7 @@ func (e *Engine) Run(ctx context.Context, target string, credPair *bruteforceFer
 		errors     []string
 	)
 
-	host, ports, err := getHostAndPorts(target, e.Library.StandardPorts())
+	host, ports, err := getHostAndPorts(target)
 	if err != nil {
 		return attempts, successful, append(errors, err.Error())
 	}
@@ -163,12 +162,11 @@ func getCredentialPairs(usernames []string, passwords []string) []bruteforceFern
 	return pairs
 }
 
-func getHostAndPorts(target string, standardPorts []int) (string, []int, error) {
+func getHostAndPorts(target string) (string, []int, error) {
 	var ports []int
 	host, port, err := net.SplitHostPort(target)
 	if err != nil {
-		host = target
-		ports = standardPorts
+		return "", nil, err
 	} else {
 		intPort, err := strconv.Atoi(port)
 		if err != nil {

--- a/internal/pentest/bruteforce/modules/ssh.go
+++ b/internal/pentest/bruteforce/modules/ssh.go
@@ -11,10 +11,6 @@ import (
 
 type SSHLibrary struct{}
 
-func (SSHLib *SSHLibrary) StandardPorts() []int {
-	return []int{22, 2222}
-}
-
 func (SSHLib *SSHLibrary) BruteForce(host string, port int, credPair *bruteforceFern.CredentialPair, config *bruteforceFern.PentestBruteForceConfig) (*bruteforceFern.AttemptInfo, []string) {
 	attempt := bruteforceFern.AttemptInfo{Timestamp: time.Now()}
 	errors := []string{}

--- a/internal/pentest/bruteforce/modules/telnet.go
+++ b/internal/pentest/bruteforce/modules/telnet.go
@@ -13,10 +13,6 @@ import (
 
 type TelnetLibrary struct{}
 
-func (TelnetLib *TelnetLibrary) StandardPorts() []int {
-	return []int{23, 2323}
-}
-
 func (TelnetLib *TelnetLibrary) BruteForce(host string, port int, credPair *bruteforceFern.CredentialPair, config *bruteforceFern.PentestBruteForceConfig) (*bruteforceFern.AttemptInfo, []string) {
 	attempt := bruteforceFern.AttemptInfo{Timestamp: time.Now()}
 	errors := []string{}


### PR DESCRIPTION
### TL;DR

Removed the `StandardPorts()` method from the bruteforce library interface and updated port handling logic.

### What changed?

- Removed the `StandardPorts()` method from the `Library` interface in `engine.go`
- Modified the `getHostAndPorts()` function to return an error when a target doesn't include a port, rather than falling back to standard ports
- Removed the `StandardPorts()` implementation from both the SSH and Telnet library modules
- Updated the `Run()` method to pass only the target to `getHostAndPorts()` without standard ports

### How to test?

1. Ensure all bruteforce operations now require explicit port specification in the target string
2. Verify that attempts to run bruteforce operations without specifying a port now return an appropriate error
3. Test SSH and Telnet bruteforce operations with properly formatted targets (host:port)

### Why make this change?

This change enforces explicit port specification for bruteforce operations, removing the implicit fallback to standard ports. This improves security by requiring deliberate port targeting rather than automatically attempting common ports, and simplifies the interface by removing the need for each module to define its standard ports.