### PR TITLE
TLS Update + Remove Redundant Config 

### DIFF
--- a/fern/definition/discover/host.yml
+++ b/fern/definition/discover/host.yml
@@ -7,10 +7,12 @@ types:
       - ICMP_TIMESTAMP
       - ARP
       - ICMP_ADDRESS_MASK
+  # Report structs
   HostDetails:
     properties:
       ip: string
       host: string
+  # Final report
   DiscoverHostReport:
     properties:
       hosts: list<HostDetails>

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -1,10 +1,12 @@
 imports:
   common: ../common/common.yml
 types:
+# ENUMs
   PortScanType:
     enum:
       - SYN
       - CONNECT
+  # Report structs
   PortDetails:
     properties:
       port: integer
@@ -14,6 +16,10 @@ types:
       host: string
       ip: string
       ports: optional<list<PortDetails>>
+  DiscoverPortResult:
+    properties:
+      sockets: optional<list<SocketDetails>>
+  # Config
   DiscoverPortConfig:
     properties:
       target: string
@@ -21,9 +27,7 @@ types:
       topPorts: optional<string>
       threads: integer
       scanType: PortScanType
-  DiscoverPortResult:
-    properties:
-      sockets: optional<list<SocketDetails>>
+  # Final report
   DiscoverPortReport:
     properties:
       config: DiscoverPortConfig

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -1,6 +1,7 @@
 imports:
   common: ../common/common.yml
 types:
+  # Report structs
   ServiceDetails:
     properties:
       host: string
@@ -11,14 +12,16 @@ types:
       transport: common.TransportType
       protocol: common.ProtocolType
       metadata: optional<map<string, string>>
+  DiscoverServiceResult:
+    properties:
+      services: optional<list<ServiceDetails>>
+  # Config
   DiscoverServiceConfig:
     properties:
       target: string
       port: integer
       timeout: integer
-  DiscoverServiceResult:
-    properties:
-      services: optional<list<ServiceDetails>>
+  # Final report
   DiscoverServiceReport:
     properties:
       config: DiscoverServiceConfig

--- a/fern/definition/discover/tls.yml
+++ b/fern/definition/discover/tls.yml
@@ -45,6 +45,7 @@ types:
       - RSA
       - RSA_1024
       - UNKNOWN
+  # Report structs
   Certificate:
     properties:
       subjectCommonName: optional<string>
@@ -64,16 +65,19 @@ types:
       certificates: optional<list<Certificate>>
   TlsSummary:
     properties:
-      address: string
+      socket: string
+      ipAddress: string
       tlsDetails: optional<TlsDetails>
+  DiscoverTlsResult:
+    properties:
+      details: optional<list<TlsSummary>>
+  # Config
   DiscoverTlsConfig:
     properties:
       targets: list<string>
       timeout: integer
       verifyTls: boolean
-  DiscoverTlsResult:
-    properties:
-      details: optional<list<TlsSummary>>
+  # Final report
   DiscoverTlsReport:
     properties:
       config: DiscoverTlsConfig

--- a/fern/definition/enumerate/enumerate.yml
+++ b/fern/definition/enumerate/enumerate.yml
@@ -4,26 +4,30 @@ imports:
   smtp: ./smtp/smtp.yml
   grpc: ./grpc/grpc.yml
 types:
+  # ENUMs
   SupportedServiceType:
     enum:
       - SSH
       - FTP
       - SMTP
       - GRPC
+  # Report structs
   EnumerateServiceDetails:
     union:
       EnumerateSshDetails: ssh.EnumerateSshDetails
       EnumerateFtpDetails: ftp.EnumerateFtpDetails
       EnumerateSmtpDetails: smtp.EnumerateSmtpDetails
       EnumerateGrpcDetails: grpc.EnumerateGrpcDetails
+  EnumerateServiceResult:
+    properties:
+      details: optional<list<EnumerateServiceDetails>>
+  # Config
   EnumerateServiceConfig:
     properties:
       targets: list<string>
       service: SupportedServiceType
       timeout: integer
-  EnumerateServiceResult:
-    properties:
-      details: optional<list<EnumerateServiceDetails>>
+  # Final report
   EnumerateServiceReport:
     properties:
       config: EnumerateServiceConfig

--- a/fern/definition/enumerate/ftp/ftp.yml
+++ b/fern/definition/enumerate/ftp/ftp.yml
@@ -1,4 +1,5 @@
 types:
+  # Report structs
   EnumerateFtpDetails:
     properties:
       target: string

--- a/fern/definition/enumerate/grpc/grpc.yml
+++ b/fern/definition/enumerate/grpc/grpc.yml
@@ -12,6 +12,7 @@ types:
     properties:
       name: string # pkg.Svc
       methods: list<RpcMethod>
+  # Report structs
   EnumerateGrpcDetails:
     properties:
       target: string

--- a/fern/definition/enumerate/smtp/smtp.yml
+++ b/fern/definition/enumerate/smtp/smtp.yml
@@ -1,4 +1,5 @@
 types:
+  # ENUMs
   AuthCommand:
     enum:
       - XOAUTH2
@@ -7,6 +8,7 @@ types:
       - CRAMMD5
       - NTLM
       - GSSAPI
+  # Report structs
   EnumerateSmtpDetails:
     properties:
       target: string

--- a/fern/definition/enumerate/ssh/ssh.yml
+++ b/fern/definition/enumerate/ssh/ssh.yml
@@ -1,4 +1,5 @@
 types:
+  # ENUMs
   AuthMethod:
     enum:
       - PASSWORD
@@ -69,6 +70,7 @@ types:
       - HMACRIPEMD160
       - HMACSHA3256
       - HMACSHA3512
+  # Report structs
   EnumerateSshDetails:
     properties:
       target: string

--- a/fern/definition/pentest/bruteforce/bruteforce.yml
+++ b/fern/definition/pentest/bruteforce/bruteforce.yml
@@ -28,7 +28,6 @@ types:
       numPasswords: integer
       numSuccessful: integer
       numFailed: integer
-      runConfig: PentestBruteForceConfig
   ResultInfo:
     properties:
       login: boolean

--- a/fern/definition/pentest/bruteforce/bruteforce.yml
+++ b/fern/definition/pentest/bruteforce/bruteforce.yml
@@ -1,4 +1,10 @@
 types:
+  # ENUMs
+  SupportedServiceType:
+    enum:
+      - SSH
+      - TELNET
+  # Report structs
   GeneralRequestInfo:
     properties:
       username: string
@@ -8,10 +14,6 @@ types:
   GeneralResponseInfo:
     properties:
       message: string
-  SupportedServiceType:
-    enum:
-      - SSH
-      - TELNET
   CredentialPair:
     properties:
       username: string
@@ -43,6 +45,10 @@ types:
       target: string
       statistics: StatisticsInfo
       attempts: optional<list<AttemptInfo>>
+  PentestBruteForceResult:
+    properties:
+      attempts: optional<list<BruteForceAttempt>>
+# Config
   PentestBruteForceConfig:
     properties:
       targets: list<string>
@@ -56,9 +62,7 @@ types:
       retries: integer
       successfulOnly: boolean
       stopFirstSuccess: boolean
-  PentestBruteForceResult:
-    properties:
-      attempts: optional<list<BruteForceAttempt>>
+  # Final report
   PentestBruteForceReport:
     properties:
       config: PentestBruteForceConfig

--- a/internal/discover/tls.go
+++ b/internal/discover/tls.go
@@ -15,6 +15,28 @@ import (
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 )
 
+// isIPAddress checks if a given host string is an IP address (IPv4 or IPv6)
+func isIPAddress(host string) bool {
+	return net.ParseIP(host) != nil
+}
+
+// lookupIPAddress performs DNS lookup for a hostname and returns the first IP address found
+func lookupIPAddress(ctx context.Context, hostname string) (string, error) {
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, hostname)
+	if err != nil {
+		return "", err
+	}
+	if len(ips) == 0 {
+		return "", &net.DNSError{
+			Err:        "no such host",
+			Name:       hostname,
+			Server:     "",
+			IsNotFound: true,
+		}
+	}
+	return ips[0].IP.String(), nil
+}
+
 // GetTLSInfo retrieves TLS configuration and certificate details for a list of target addresses.
 // It establishes TLS connections to each target and extracts information about the TLS version,
 // cipher suite, and certificates. Returns a report containing the TLS details and any errors encountered.
@@ -29,10 +51,25 @@ func GetTLSInfo(ctx context.Context, addresses []string, config discoverfern.Dis
 		}
 
 		// Check if the address includes a port
-		_, port, err := net.SplitHostPort(targetAddress)
+		host, port, err := net.SplitHostPort(targetAddress)
 		if err != nil || port == "" {
 			errors = append(errors, "Address does not have a valid port")
 			continue
+		}
+
+		// Determine IP address for the target
+		var ipAddress string
+		if isIPAddress(host) {
+			// Host is already an IP address
+			ipAddress = host
+		} else {
+			// Host is an FQDN, perform DNS lookup
+			resolvedIP, err := lookupIPAddress(ctx, host)
+			if err != nil {
+				errors = append(errors, "Failed to resolve hostname "+host+": "+err.Error())
+				continue
+			}
+			ipAddress = resolvedIP
 		}
 
 		// Establish TLS connection
@@ -59,7 +96,8 @@ func GetTLSInfo(ctx context.Context, addresses []string, config discoverfern.Dis
 
 		// Construct AddressTlsReport
 		serviceDetail := discoverfern.TlsSummary{
-			Address:    targetAddress,
+			Socket:     targetAddress,
+			IpAddress:  ipAddress,
 			TlsDetails: tlsInfo,
 		}
 		serviceDetails = append(serviceDetails, &serviceDetail)

--- a/internal/pentest/bruteforce/engine.go
+++ b/internal/pentest/bruteforce/engine.go
@@ -134,7 +134,6 @@ func Attack(ctx context.Context, config *bruteforcefern.PentestBruteForceConfig)
 		}
 
 		stats := engine.gatherAttemptStatistics(attempts, config)
-		stats.RunConfig = config
 
 		if config.SuccessfulOnly {
 			successfulAttempts := []*bruteforcefern.AttemptInfo{}


### PR DESCRIPTION
### TL;DR
* Update TLS CLI to return IP Address

* Removed the `runConfig` field from the `PentestBruteForceStats` type in the bruteforce API definition and its corresponding implementation.
