### PR TITLE
Service Command > Pentest Module

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -26,6 +26,14 @@ func (a *NetworkScan) InitPentestCommand() {
 		Long:  `Run penetration testing modules against network services.`,
 	}
 
+	serviceCmd := &cobra.Command{
+		Use:   "service",
+		Short: "Run penetration testing modules against network services.",
+		Long:  `Run penetration testing modules against network services.`,
+	}
+
+	pentestCmd.AddCommand(serviceCmd)
+
 	bruteForceCmd := &cobra.Command{
 		Use:   "bruteforce",
 		Short: "Perform a brute-force attack against a specified service module (e.g., SSH, TELNET) using provided credentials.",
@@ -144,7 +152,7 @@ func (a *NetworkScan) InitPentestCommand() {
 	_ = bruteForceCmd.MarkFlagRequired("service")
 
 	// Add Command to 'Pentest' Command
-	pentestCmd.AddCommand(bruteForceCmd)
+	serviceCmd.AddCommand(bruteForceCmd)
 
 	// Add Command to 'Root' Command
 	a.RootCmd.AddCommand(pentestCmd)
@@ -152,8 +160,8 @@ func (a *NetworkScan) InitPentestCommand() {
 
 // getPentestBruteForceConfig creates a configuration for brute force attacks with the provided parameters.
 // It validates and sets up the attack parameters including module type, targets, credentials, and timing settings.
-func getPentestBruteForceConfig(service bruteforcefern.SupportedServiceType, targets []string, usernames []string, passwords []string, timeout int, sleep int, retries int, successfulOnly bool, stopFirstSuccess bool) (*bruteforcefern.PentestBruteForceConfig, error) {
-	config := &bruteforcefern.PentestBruteForceConfig{
+func getPentestBruteForceConfig(service bruteforcefern.SupportedServiceType, targets []string, usernames []string, passwords []string, timeout int, sleep int, retries int, successfulOnly bool, stopFirstSuccess bool) (*bruteforcefern.PentestServiceBruteForceConfig, error) {
+	config := &bruteforcefern.PentestServiceBruteForceConfig{
 		Service:          service,
 		Targets:          targets,
 		Usernames:        usernames,

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -120,7 +120,7 @@ func (a *NetworkScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			bruteForceConfig, err := getPentestBruteForceConfig(serviceEnum, targets, allUsernames, allPasswords, timeout, sleep, retries, successfulOnly, stopFirstSuccess)
+			bruteForceConfig, err := getPentestServiceBruteForceConfig(serviceEnum, targets, allUsernames, allPasswords, timeout, sleep, retries, successfulOnly, stopFirstSuccess)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -158,9 +158,9 @@ func (a *NetworkScan) InitPentestCommand() {
 	a.RootCmd.AddCommand(pentestCmd)
 }
 
-// getPentestBruteForceConfig creates a configuration for brute force attacks with the provided parameters.
+// getPentestServiceBruteForceConfig creates a configuration for brute force attacks with the provided parameters.
 // It validates and sets up the attack parameters including module type, targets, credentials, and timing settings.
-func getPentestBruteForceConfig(service bruteforcefern.SupportedServiceType, targets []string, usernames []string, passwords []string, timeout int, sleep int, retries int, successfulOnly bool, stopFirstSuccess bool) (*bruteforcefern.PentestServiceBruteForceConfig, error) {
+func getPentestServiceBruteForceConfig(service bruteforcefern.SupportedServiceType, targets []string, usernames []string, passwords []string, timeout int, sleep int, retries int, successfulOnly bool, stopFirstSuccess bool) (*bruteforcefern.PentestServiceBruteForceConfig, error) {
 	config := &bruteforcefern.PentestServiceBruteForceConfig{
 		Service:          service,
 		Targets:          targets,

--- a/fern/definition/pentest/bruteforce/bruteforce.yml
+++ b/fern/definition/pentest/bruteforce/bruteforce.yml
@@ -45,11 +45,11 @@ types:
       target: string
       statistics: StatisticsInfo
       attempts: optional<list<AttemptInfo>>
-  PentestBruteForceResult:
+  PentestServiceBruteForceResult:
     properties:
       attempts: optional<list<BruteForceAttempt>>
-# Config
-  PentestBruteForceConfig:
+  # Config
+  PentestServiceBruteForceConfig:
     properties:
       targets: list<string>
       service: SupportedServiceType
@@ -63,8 +63,8 @@ types:
       successfulOnly: boolean
       stopFirstSuccess: boolean
   # Final report
-  PentestBruteForceReport:
+  PentestServiceBruteForceReport:
     properties:
-      config: PentestBruteForceConfig
-      result: PentestBruteForceResult
+      config: PentestServiceBruteForceConfig
+      result: PentestServiceBruteForceResult
       errors: optional<list<string>>

--- a/fern/definition/pentest/bruteforce/bruteforce.yml
+++ b/fern/definition/pentest/bruteforce/bruteforce.yml
@@ -40,14 +40,14 @@ types:
       response: ResponseUnion
       result: ResultInfo
       timestamp: datetime
-  BruteForceAttempt:
+  ServiceBruteForceAttempt:
     properties:
       target: string
       statistics: StatisticsInfo
       attempts: optional<list<AttemptInfo>>
   PentestServiceBruteForceResult:
     properties:
-      attempts: optional<list<BruteForceAttempt>>
+      attempts: optional<list<ServiceBruteForceAttempt>>
   # Config
   PentestServiceBruteForceConfig:
     properties:

--- a/internal/pentest/bruteforce/engine.go
+++ b/internal/pentest/bruteforce/engine.go
@@ -103,7 +103,7 @@ func Attack(ctx context.Context, config *bruteforcefern.PentestServiceBruteForce
 		return nil, fmt.Errorf("unsupported service: %s", config.Service)
 	}
 
-	var bruteForceResults []*bruteforcefern.BruteForceAttempt
+	var bruteForceResults []*bruteforcefern.ServiceBruteForceAttempt
 	for _, target := range config.Targets {
 		var attempts []*bruteforcefern.AttemptInfo
 
@@ -145,7 +145,7 @@ func Attack(ctx context.Context, config *bruteforcefern.PentestServiceBruteForce
 			attempts = successfulAttempts
 		}
 
-		bruteForceResult := bruteforcefern.BruteForceAttempt{
+		bruteForceResult := bruteforcefern.ServiceBruteForceAttempt{
 			Target:     target,
 			Attempts:   attempts,
 			Statistics: stats,

--- a/internal/pentest/bruteforce/engine.go
+++ b/internal/pentest/bruteforce/engine.go
@@ -20,7 +20,7 @@ import (
 // Each service type (SSH, Telnet) must implement this interface to provide
 // authentication attempt functionality and response analysis.
 type Library interface {
-	BruteForce(host string, port int, credPair *bruteforcefern.CredentialPair, config *bruteforcefern.PentestBruteForceConfig) (*bruteforcefern.AttemptInfo, []string)
+	BruteForce(host string, port int, credPair *bruteforcefern.CredentialPair, config *bruteforcefern.PentestServiceBruteForceConfig) (*bruteforcefern.AttemptInfo, []string)
 	AnalyzeResponse(response *bruteforcefern.ResponseUnion) *bruteforcefern.ResultInfo
 }
 
@@ -33,7 +33,7 @@ type Engine struct {
 // Run executes brute force attempts against a target using the configured library.
 // It handles retries, sleep intervals, and success detection.
 // Returns a list of attempt results, success status, and any errors encountered.
-func (e *Engine) Run(ctx context.Context, target string, credPair *bruteforcefern.CredentialPair, config *bruteforcefern.PentestBruteForceConfig) ([]*bruteforcefern.AttemptInfo, bool, []string) {
+func (e *Engine) Run(ctx context.Context, target string, credPair *bruteforcefern.CredentialPair, config *bruteforcefern.PentestServiceBruteForceConfig) ([]*bruteforcefern.AttemptInfo, bool, []string) {
 	var (
 		attempts   []*bruteforcefern.AttemptInfo
 		successful bool
@@ -70,7 +70,7 @@ func (e *Engine) Run(ctx context.Context, target string, credPair *bruteforcefer
 
 // gatherAttemptStatistics collects and calculates statistics about brute force attempts.
 // It tracks the number of successful and failed attempts, along with credential set sizes.
-func (e *Engine) gatherAttemptStatistics(attempts []*bruteforcefern.AttemptInfo, config *bruteforcefern.PentestBruteForceConfig) *bruteforcefern.StatisticsInfo {
+func (e *Engine) gatherAttemptStatistics(attempts []*bruteforcefern.AttemptInfo, config *bruteforcefern.PentestServiceBruteForceConfig) *bruteforcefern.StatisticsInfo {
 	stats := &bruteforcefern.StatisticsInfo{
 		NumUsernames: len(config.Usernames),
 		NumPasswords: len(config.Passwords),
@@ -86,7 +86,7 @@ func (e *Engine) gatherAttemptStatistics(attempts []*bruteforcefern.AttemptInfo,
 	return stats
 }
 
-func Attack(ctx context.Context, config *bruteforcefern.PentestBruteForceConfig) (*bruteforcefern.PentestBruteForceReport, error) {
+func Attack(ctx context.Context, config *bruteforcefern.PentestServiceBruteForceConfig) (*bruteforcefern.PentestServiceBruteForceReport, error) {
 	errors := []string{}
 
 	var engine *Engine
@@ -153,9 +153,9 @@ func Attack(ctx context.Context, config *bruteforcefern.PentestBruteForceConfig)
 		bruteForceResults = append(bruteForceResults, &bruteForceResult)
 	}
 
-	return &bruteforcefern.PentestBruteForceReport{
+	return &bruteforcefern.PentestServiceBruteForceReport{
 		Config: config,
-		Result: &bruteforcefern.PentestBruteForceResult{Attempts: bruteForceResults},
+		Result: &bruteforcefern.PentestServiceBruteForceResult{Attempts: bruteForceResults},
 		Errors: errors,
 	}, nil
 }

--- a/internal/pentest/bruteforce/services/ssh.go
+++ b/internal/pentest/bruteforce/services/ssh.go
@@ -20,7 +20,7 @@ type SSHLibrary struct{}
 // BruteForce attempts to authenticate to an SSH server using the provided credentials.
 // It handles both unauthenticated attempts (when credPair is nil) and authenticated attempts.
 // Returns attempt information including timestamp, request/response details, and any errors.
-func (SSHLib *SSHLibrary) BruteForce(host string, port int, credPair *bruteforcefern.CredentialPair, config *bruteforcefern.PentestBruteForceConfig) (*bruteforcefern.AttemptInfo, []string) {
+func (SSHLib *SSHLibrary) BruteForce(host string, port int, credPair *bruteforcefern.CredentialPair, config *bruteforcefern.PentestServiceBruteForceConfig) (*bruteforcefern.AttemptInfo, []string) {
 	attempt := bruteforcefern.AttemptInfo{Timestamp: time.Now()}
 	errors := []string{}
 

--- a/internal/pentest/bruteforce/services/telnet.go
+++ b/internal/pentest/bruteforce/services/telnet.go
@@ -22,7 +22,7 @@ type TelnetLibrary struct{}
 // It handles both unauthenticated attempts (when credPair is nil) and authenticated attempts.
 // The function manages the Telnet protocol interaction, including reading prompts and sending credentials.
 // Returns attempt information including timestamp, request/response details, and any errors.
-func (TelnetLib *TelnetLibrary) BruteForce(host string, port int, credPair *bruteforcefern.CredentialPair, config *bruteforcefern.PentestBruteForceConfig) (*bruteforcefern.AttemptInfo, []string) {
+func (TelnetLib *TelnetLibrary) BruteForce(host string, port int, credPair *bruteforcefern.CredentialPair, config *bruteforcefern.PentestServiceBruteForceConfig) (*bruteforcefern.AttemptInfo, []string) {
 	attempt := bruteforcefern.AttemptInfo{Timestamp: time.Now()}
 	errors := []string{}
 


### PR DESCRIPTION
# Add Service Command to Pentest Module

This PR restructures the pentest command hierarchy by adding a new `service` subcommand. The brute force functionality is now organized under this new service command, providing a clearer command structure for network service penetration testing.

The PR also renames related types and functions to better reflect their purpose, changing from generic `PentestBruteForceConfig` to more specific `PentestServiceBruteForceConfig` and similar naming updates throughout the codebase.