### PR TITLE
Update TLS Signal 'Optional' Fields

### DIFF
--- a/fern/definition/discover/tls.yml
+++ b/fern/definition/discover/tls.yml
@@ -48,21 +48,21 @@ types:
   # Report structs
   Certificate:
     properties:
-      subjectCommonName: optional<string>
-      issuerCommonName: optional<string>
-      validFrom: optional<datetime>
-      validTo: optional<datetime>
-      version: optional<integer>
-      serialNumber: optional<string>
-      certificate: optional<string>
-      signature: optional<string>
-      signatureAlgorithm: optional<SignatureAlgorithm>
-      publicKeyAlgorithm: optional<PublicKeyAlgorithm>
+      certificate: string
+      serialNumber: string
+      signature: string
+      publicKeyAlgorithm: PublicKeyAlgorithm
+      signatureAlgorithm: SignatureAlgorithm
+      validFrom: datetime
+      validTo: datetime
+      version: integer
+      issuerCommonName: optional<string> # Can be empty
+      subjectCommonName: optional<string> # Can be empty
   TlsDetails:
     properties:
       version: optional<TlsVersion>
       cipherSuite: optional<string>
-      certificates: optional<list<Certificate>>
+      certificates: list<Certificate>
   TlsSummary:
     properties:
       socket: string

--- a/internal/discover/tls.go
+++ b/internal/discover/tls.go
@@ -153,25 +153,25 @@ func convertToTLSInfo(state *tls.ConnectionState) *discoverfern.TlsDetails {
 		certString := string(certPEM)
 		signatureHex := hex.EncodeToString(cert.Signature)
 		certificate := &discoverfern.Certificate{
+			Certificate:       certString,
+			SerialNumber:      serialNumber,
+			Signature:         signatureHex,
 			SubjectCommonName: &cert.Subject.CommonName,
 			IssuerCommonName:  &cert.Issuer.CommonName,
-			ValidFrom:         &cert.NotBefore,
-			ValidTo:           &cert.NotAfter,
-			Version:           &cert.Version,
-			SerialNumber:      &serialNumber,
-			Certificate:       &certString,
-			Signature:         &signatureHex,
+			ValidFrom:         cert.NotBefore,
+			ValidTo:           cert.NotAfter,
+			Version:           cert.Version,
 		}
 
 		// Signature names defined in `signatureAlgorithmDetails` in the `x509` package have a hyphen
 		// Which is removed for proper enum conversion
 		signatureAlgorithm, err := discoverfern.NewSignatureAlgorithmFromString(strings.Replace(cert.SignatureAlgorithm.String(), "-", "_", 1))
 		if err == nil {
-			certificate.SignatureAlgorithm = &signatureAlgorithm
+			certificate.SignatureAlgorithm = signatureAlgorithm
 		}
 		publicKeyAlgorithm, err := discoverfern.NewPublicKeyAlgorithmFromString(cert.PublicKeyAlgorithm.String())
 		if err == nil {
-			certificate.PublicKeyAlgorithm = &publicKeyAlgorithm
+			certificate.PublicKeyAlgorithm = publicKeyAlgorithm
 		}
 
 		tlsInfo.Certificates = append(tlsInfo.Certificates, certificate)


### PR DESCRIPTION
### TL;DR

Updated the TLS Certificate data model to make required fields non-optional and reordered properties for better readability.
