### PR TITLE
Match Config optional/required to CLI flags

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -272,7 +272,7 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 		Target:   target,
 		Ports:    &ports,
 		TopPorts: &topPorts,
-		Threads:  threads,
+		Threads:  &threads,
 		ScanType: scanType,
 	}
 }
@@ -283,7 +283,7 @@ func getDiscoverServiceConfig(target string, port int, timeout int) discoverfern
 	return discoverfern.DiscoverServiceConfig{
 		Target:  target,
 		Port:    port,
-		Timeout: timeout,
+		Timeout: &timeout,
 	}
 }
 
@@ -292,8 +292,8 @@ func getDiscoverServiceConfig(target string, port int, timeout int) discoverfern
 func getDiscoverTLSConfig(targets []string, timeout int, verifyTLS bool) discoverfern.DiscoverTlsConfig {
 	config := discoverfern.DiscoverTlsConfig{
 		Targets:   targets,
-		Timeout:   timeout,
-		VerifyTls: verifyTLS,
+		Timeout:   &timeout,
+		VerifyTls: &verifyTLS,
 	}
 	return config
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -273,7 +273,7 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 		Ports:    &ports,
 		TopPorts: &topPorts,
 		Threads:  &threads,
-		ScanType: scanType,
+		ScanType: &scanType,
 	}
 }
 

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -53,7 +53,7 @@ func (a *NetworkScan) InitEnumerateCommand() {
 			config := enumeratefern.EnumerateServiceConfig{
 				Targets: targets,
 				Service: serviceEnum,
-				Timeout: timeout,
+				Timeout: &timeout,
 			}
 
 			// Generate the report

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -166,11 +166,11 @@ func getPentestServiceBruteForceConfig(service bruteforcefern.SupportedServiceTy
 		Targets:          targets,
 		Usernames:        usernames,
 		Passwords:        passwords,
-		Timeout:          max(timeout, 0),
-		Sleep:            max(sleep, 0),
-		Retries:          max(retries, 0),
-		SuccessfulOnly:   successfulOnly,
-		StopFirstSuccess: stopFirstSuccess,
+		Timeout:          &timeout,
+		Sleep:            &sleep,
+		Retries:          &retries,
+		SuccessfulOnly:   &successfulOnly,
+		StopFirstSuccess: &stopFirstSuccess,
 	}
 	return config, nil
 }

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -1,7 +1,7 @@
 imports:
   common: ../common/common.yml
 types:
-# ENUMs
+  # ENUMs
   PortScanType:
     enum:
       - SYN
@@ -25,7 +25,7 @@ types:
       target: string
       ports: optional<string>
       topPorts: optional<string>
-      threads: integer
+      threads: optional<integer>
       scanType: PortScanType
   # Final report
   DiscoverPortReport:

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -26,7 +26,7 @@ types:
       ports: optional<string>
       topPorts: optional<string>
       threads: optional<integer>
-      scanType: PortScanType
+      scanType: optional<PortScanType>
   # Final report
   DiscoverPortReport:
     properties:

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -20,7 +20,7 @@ types:
     properties:
       target: string
       port: integer
-      timeout: integer
+      timeout: optional<integer>
   # Final report
   DiscoverServiceReport:
     properties:

--- a/fern/definition/discover/tls.yml
+++ b/fern/definition/discover/tls.yml
@@ -75,8 +75,8 @@ types:
   DiscoverTlsConfig:
     properties:
       targets: list<string>
-      timeout: integer
-      verifyTls: boolean
+      timeout: optional<integer>
+      verifyTls: optional<boolean>
   # Final report
   DiscoverTlsReport:
     properties:

--- a/fern/definition/enumerate/enumerate.yml
+++ b/fern/definition/enumerate/enumerate.yml
@@ -26,7 +26,7 @@ types:
     properties:
       targets: list<string>
       service: SupportedServiceType
-      timeout: integer
+      timeout: optional<integer>
   # Final report
   EnumerateServiceReport:
     properties:

--- a/fern/definition/pentest/bruteforce/bruteforce.yml
+++ b/fern/definition/pentest/bruteforce/bruteforce.yml
@@ -57,11 +57,11 @@ types:
       usernameLists: optional<list<string>>
       passwords: optional<list<string>>
       passwordLists: optional<list<string>>
-      timeout: integer
-      sleep: integer
-      retries: integer
-      successfulOnly: boolean
-      stopFirstSuccess: boolean
+      timeout: optional<integer>
+      sleep: optional<integer>
+      retries: optional<integer>
+      successfulOnly: optional<boolean>
+      stopFirstSuccess: optional<boolean>
   # Final report
   PentestServiceBruteForceReport:
     properties:

--- a/internal/discover/port.go
+++ b/internal/discover/port.go
@@ -57,7 +57,7 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 		},
 	}
 
-	switch config.ScanType {
+	switch *config.ScanType {
 	case discoverfern.PortScanTypeSyn:
 		portscanOpts.ScanType = runner.SynScan
 	case discoverfern.PortScanTypeConnect:

--- a/internal/discover/port.go
+++ b/internal/discover/port.go
@@ -45,7 +45,7 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 		NoColor:           true,
 		Rate:              runner.DefaultRateConnectScan,
 		Retries:           runner.DefaultRetriesConnectScan,
-		Threads:           config.Threads,
+		Threads:           *config.Threads,
 		Timeout:           runner.DefaultPortTimeoutConnectScan,
 		Host:              goflags.StringSlice{config.Target},
 		SkipHostDiscovery: true,

--- a/internal/discover/service.go
+++ b/internal/discover/service.go
@@ -31,7 +31,7 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 
 	fxConfig := scan.Config{
 		FastMode:       false,
-		DefaultTimeout: time.Duration(config.Timeout) * time.Second,
+		DefaultTimeout: time.Duration(*config.Timeout) * time.Second,
 		UDP:            false,
 		Verbose:        true,
 	}

--- a/internal/discover/tls.go
+++ b/internal/discover/tls.go
@@ -47,7 +47,7 @@ func GetTLSInfo(ctx context.Context, addresses []string, config discoverfern.Dis
 	for _, targetAddress := range addresses {
 		// Define timeout for the TLS connection
 		dialer := &net.Dialer{
-			Timeout: time.Duration(config.Timeout) * time.Second,
+			Timeout: time.Duration(*config.Timeout) * time.Second,
 		}
 
 		// Check if the address includes a port
@@ -74,7 +74,7 @@ func GetTLSInfo(ctx context.Context, addresses []string, config discoverfern.Dis
 
 		// Establish TLS connection
 		conn, err := tls.DialWithDialer(dialer, "tcp", targetAddress, &tls.Config{
-			InsecureSkipVerify: !config.VerifyTls,
+			InsecureSkipVerify: !*config.VerifyTls,
 		})
 		if err != nil {
 			errors = append(errors, err.Error())

--- a/internal/enumerate/engine.go
+++ b/internal/enumerate/engine.go
@@ -54,7 +54,7 @@ func RunServiceEnumerate(ctx context.Context, config enumeratefern.EnumerateServ
 			defer wg.Done()
 
 			// Create a context with timeout for each target
-			targetCtx, targetCancel := context.WithTimeout(ctx, time.Duration(config.Timeout)*time.Second)
+			targetCtx, targetCancel := context.WithTimeout(ctx, time.Duration(*config.Timeout)*time.Second)
 			defer targetCancel()
 
 			// Start enumeration

--- a/internal/pentest/bruteforce/engine.go
+++ b/internal/pentest/bruteforce/engine.go
@@ -46,7 +46,7 @@ func (e *Engine) Run(ctx context.Context, target string, credPair *bruteforcefer
 	}
 
 	for _, port := range ports {
-		for i := 0; i < config.Retries; i++ {
+		for i := 0; i < *config.Retries; i++ {
 			var attempt *bruteforcefern.AttemptInfo
 			var errs []string
 
@@ -59,8 +59,8 @@ func (e *Engine) Run(ctx context.Context, target string, credPair *bruteforcefer
 				successful = true
 				break
 			}
-			if config.Sleep > 0 {
-				time.Sleep(time.Duration(config.Sleep) * time.Millisecond)
+			if *config.Sleep > 0 {
+				time.Sleep(time.Duration(*config.Sleep) * time.Millisecond)
 			}
 		}
 	}
@@ -123,7 +123,7 @@ func Attack(ctx context.Context, config *bruteforcefern.PentestServiceBruteForce
 				errors = append(errors, errs...)
 				attempts = append(attempts, attempt...)
 
-				if successful && config.StopFirstSuccess {
+				if successful && *config.StopFirstSuccess {
 					break
 				}
 
@@ -135,7 +135,7 @@ func Attack(ctx context.Context, config *bruteforcefern.PentestServiceBruteForce
 
 		stats := engine.gatherAttemptStatistics(attempts, config)
 
-		if config.SuccessfulOnly {
+		if *config.SuccessfulOnly {
 			successfulAttempts := []*bruteforcefern.AttemptInfo{}
 			for _, attempt := range attempts {
 				if attempt.Result.Login {

--- a/internal/pentest/bruteforce/services/ssh.go
+++ b/internal/pentest/bruteforce/services/ssh.go
@@ -33,7 +33,7 @@ func (SSHLib *SSHLibrary) BruteForce(host string, port int, credPair *bruteforce
 		User:            username,
 		Auth:            []ssh.AuthMethod{ssh.Password(password)},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         time.Duration(config.Timeout) * time.Millisecond,
+		Timeout:         time.Duration(*config.Timeout) * time.Millisecond,
 	}
 
 	targetAddr := fmt.Sprintf("%s:%d", host, port)

--- a/internal/pentest/bruteforce/services/telnet.go
+++ b/internal/pentest/bruteforce/services/telnet.go
@@ -29,7 +29,7 @@ func (TelnetLib *TelnetLibrary) BruteForce(host string, port int, credPair *brut
 	var message string
 
 	targetAddr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-	timeout := time.Duration(config.Timeout) * time.Second
+	timeout := time.Duration(*config.Timeout) * time.Second
 
 	username, password := "", ""
 	if credPair != nil {


### PR DESCRIPTION
# Make configuration parameters optional in Fern definitions

This PR updates the Fern API definitions to make configuration parameters optional by:

1. Updating the type definitions in YAML files to mark parameters as `optional<type>` instead of required
2. Updating the corresponding Go code to handle these optional parameters with pointers

This ensures consistent handling of configuration parameters across the codebase and improves API flexibility.