### PR TITLE
Add built-in wordlist support for bruteforce attacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,11 @@ RUN \
   mkdir -p /opt/method/${CLI_NAME}/var/data && \
   mkdir -p /opt/method/${CLI_NAME}/var/data/tmp && \
   mkdir -p /opt/method/${CLI_NAME}/var/conf && \
-  mkdir -p /opt/method/${CLI_NAME}/var/conf/pentest && \
-  mkdir -p /opt/method/${CLI_NAME}/var/conf/pentest/bruteforce && \
-  mkdir -p /opt/method/${CLI_NAME}/var/conf/pentest/ssh && \
-  mkdir -p /opt/method/${CLI_NAME}/var/conf/pentest/telnet && \
   mkdir -p /opt/method/${CLI_NAME}/var/log && \
   mkdir -p /opt/method/${CLI_NAME}/service/bin && \
   mkdir -p /mnt/output
 
-COPY configs/*                              /opt/method/${CLI_NAME}/var/conf/
-COPY configs/pentest/                       /opt/method/${CLI_NAME}/var/conf/pentest/
-COPY configs/pentest/bruteforce/            /opt/method/${CLI_NAME}/var/conf/pentest/bruteforce/
-COPY configs/pentest/bruteforce/ssh/        /opt/method/${CLI_NAME}/var/conf/pentest/bruteforce/ssh/
-COPY configs/pentest/bruteforce/telnet/     /opt/method/${CLI_NAME}/var/conf/pentest/bruteforce/telnet/
+COPY configs/                              /opt/method/${CLI_NAME}/var/conf/
 
 COPY ${CLI_NAME} /opt/method/${CLI_NAME}/service/bin/${CLI_NAME}
 

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -92,6 +92,28 @@ func (a *NetworkScan) InitPentestCommand() {
 				return
 			}
 			allPasswords := append(passwords, passwordsFromFiles...)
+
+			// Wordlist size for built-in wordlists
+			wordlistSize, err := cmd.Flags().GetString("wordlist-size")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			wordlistSizeEnum, err := bruteforcefern.NewWordlistSizeFromString(strings.ToUpper(wordlistSize))
+			if err != nil {
+				a.OutputSignal.AddError(errors.New("invalid wordlist size"))
+				return
+			}
+			// Add built-in wordlists if wordlist-size is specified
+			if wordlistSize != "" {
+				builtInUsernames, builtInPasswords, err := utils.GetBuiltInWordlists(string(serviceEnum), wordlistSize)
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
+				}
+				allUsernames = append(allUsernames, builtInUsernames...)
+				allPasswords = append(allPasswords, builtInPasswords...)
+			}
 			// Attack Configurations
 			timeout, err := cmd.Flags().GetInt("timeout")
 			if err != nil {
@@ -120,7 +142,7 @@ func (a *NetworkScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			bruteForceConfig, err := getPentestServiceBruteForceConfig(serviceEnum, targets, allUsernames, allPasswords, timeout, sleep, retries, successfulOnly, stopFirstSuccess)
+			bruteForceConfig, err := getPentestServiceBruteForceConfig(serviceEnum, targets, allUsernames, allPasswords, usernameFiles, passwordFiles, wordlistSizeEnum, timeout, sleep, retries, successfulOnly, stopFirstSuccess)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -141,6 +163,7 @@ func (a *NetworkScan) InitPentestCommand() {
 	bruteForceCmd.Flags().StringSlice("passwords", []string{}, "List of passwords to use in the brute-force attack")
 	bruteForceCmd.Flags().StringSlice("username-lists", []string{}, "File paths containing lists of usernames (one per line) to use in the attack")
 	bruteForceCmd.Flags().StringSlice("password-lists", []string{}, "File paths containing lists of passwords (one per line) to use in the attack")
+	bruteForceCmd.Flags().String("wordlist-size", "", "The size of the in-built wordlist to use in the attack")
 	bruteForceCmd.Flags().Int("timeout", 3000, "Timeout per authentication attempt in milliseconds")
 	bruteForceCmd.Flags().Int("sleep", 3000, "Sleep duration in milliseconds between authentication attempts")
 	bruteForceCmd.Flags().Int("retries", 2, "Number of retry attempts per username/password pair")
@@ -160,12 +183,15 @@ func (a *NetworkScan) InitPentestCommand() {
 
 // getPentestServiceBruteForceConfig creates a configuration for brute force attacks with the provided parameters.
 // It validates and sets up the attack parameters including module type, targets, credentials, and timing settings.
-func getPentestServiceBruteForceConfig(service bruteforcefern.SupportedServiceType, targets []string, usernames []string, passwords []string, timeout int, sleep int, retries int, successfulOnly bool, stopFirstSuccess bool) (*bruteforcefern.PentestServiceBruteForceConfig, error) {
+func getPentestServiceBruteForceConfig(service bruteforcefern.SupportedServiceType, targets []string, usernames []string, passwords []string, usernameLists []string, passwordLists []string, wordlistSize bruteforcefern.WordlistSize, timeout int, sleep int, retries int, successfulOnly bool, stopFirstSuccess bool) (*bruteforcefern.PentestServiceBruteForceConfig, error) {
 	config := &bruteforcefern.PentestServiceBruteForceConfig{
 		Service:          service,
 		Targets:          targets,
 		Usernames:        usernames,
 		Passwords:        passwords,
+		UsernameLists:    usernameLists,
+		PasswordLists:    passwordLists,
+		WordlistSize:     &wordlistSize,
 		Timeout:          max(timeout, 0),
 		Sleep:            max(sleep, 0),
 		Retries:          max(retries, 0),

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -1,7 +1,7 @@
 imports:
   common: ../common/common.yml
 types:
-# ENUMs
+  # ENUMs
   PortScanType:
     enum:
       - SYN

--- a/fern/definition/pentest/bruteforce/bruteforce.yml
+++ b/fern/definition/pentest/bruteforce/bruteforce.yml
@@ -4,6 +4,9 @@ types:
     enum:
       - SSH
       - TELNET
+  WordlistSize:
+    enum:
+      - TINY
   # Report structs
   GeneralRequestInfo:
     properties:
@@ -57,6 +60,7 @@ types:
       usernameLists: optional<list<string>>
       passwords: optional<list<string>>
       passwordLists: optional<list<string>>
+      wordlistSize: optional<WordlistSize>
       timeout: integer
       sleep: integer
       retries: integer

--- a/utils/files.go
+++ b/utils/files.go
@@ -3,8 +3,10 @@ package utils
 
 import (
 	"bufio"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // GetEntriesFromTXTFiles reads and combines entries from multiple text files.
@@ -34,4 +36,60 @@ func GetEntriesFromTXTFiles(paths []string) ([]string, error) {
 		entries = append(entries, lines...)
 	}
 	return entries, nil
+}
+
+// WordlistFiles maps service types and sizes to their corresponding username and password file paths
+type WordlistFiles struct {
+	UsernameFile string
+	PasswordFile string
+}
+
+// builtInWordlistMap maps service types and wordlist sizes to their corresponding files
+var builtInWordlistMap = map[string]map[string]WordlistFiles{
+	"SSH": {
+		"TINY": {
+			UsernameFile: "configs/pentest/bruteforce/ssh/username_tiny.txt",
+			PasswordFile: "configs/pentest/bruteforce/ssh/password_tiny.txt",
+		},
+	},
+	"TELNET": {
+		"TINY": {
+			UsernameFile: "configs/pentest/bruteforce/telnet/username_tiny.txt",
+			PasswordFile: "configs/pentest/bruteforce/telnet/password_tiny.txt",
+		},
+	},
+}
+
+// GetBuiltInWordlists loads built-in username and password wordlists based on service type and size.
+// It returns slices of usernames and passwords from the appropriate wordlist files.
+func GetBuiltInWordlists(service, size string) ([]string, []string, error) {
+	// Convert service to uppercase for map lookup
+	serviceStr := strings.ToUpper(service)
+	sizeStr := strings.ToUpper(size)
+
+	// Check if service exists in the map
+	serviceMap, exists := builtInWordlistMap[serviceStr]
+	if !exists {
+		return nil, nil, errors.New("unsupported service type: " + service)
+	}
+
+	// Check if size exists for the service
+	wordlistFiles, exists := serviceMap[sizeStr]
+	if !exists {
+		return nil, nil, errors.New("unsupported wordlist size '" + size + "' for service '" + service + "'")
+	}
+
+	// Load usernames from built-in wordlist
+	usernames, err := GetEntriesFromTXTFiles([]string{wordlistFiles.UsernameFile})
+	if err != nil {
+		return nil, nil, errors.New("failed to load built-in username wordlist: " + err.Error())
+	}
+
+	// Load passwords from built-in wordlist
+	passwords, err := GetEntriesFromTXTFiles([]string{wordlistFiles.PasswordFile})
+	if err != nil {
+		return nil, nil, errors.New("failed to load built-in password wordlist: " + err.Error())
+	}
+
+	return usernames, passwords, nil
 }


### PR DESCRIPTION
# Add built-in wordlist support for brute force attacks

### TL;DR

Added support for built-in wordlists in brute force attacks with a new `--wordlist-size` flag.

### What changed?

- Added a new `WordlistSize` enum with a `TINY` option in the Fern definition
- Implemented a new `--wordlist-size` flag in the brute force command
- Created a `GetBuiltInWordlists` utility function to load predefined username and password lists
- Updated the `PentestServiceBruteForceConfig` struct to include wordlist size information
- Simplified the Docker configuration for wordlist files by using a single COPY command
- Removed explicit directory creation for wordlist paths in the Dockerfile

### How to test?

Run a brute force attack with the new wordlist size parameter:

```bash
./cli pentest bruteforce ssh --targets 192.168.1.1 --wordlist-size tiny
```

This will automatically load the built-in tiny wordlists for SSH without needing to specify username or password files.

### Why make this change?

This enhancement makes it easier for users to run brute force tests without having to provide their own wordlists. By offering built-in wordlists of different sizes, users can quickly perform security assessments with common credentials while still having the flexibility to use custom wordlists when needed.