### PR TITLE
fixes

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -99,14 +99,16 @@ func (a *NetworkScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			wordlistSizeEnum, err := bruteforcefern.NewWordlistSizeFromString(strings.ToUpper(wordlistSize))
-			if err != nil {
-				a.OutputSignal.AddError(errors.New("invalid wordlist size"))
-				return
-			}
-			// Add built-in wordlists if wordlist-size is specified
+			var wordlistSizeEnum bruteforcefern.WordlistSize
+			// Only parse wordlist size enum if it's actually provided
 			if wordlistSize != "" {
-				builtInUsernames, builtInPasswords, err := utils.GetBuiltInWordlists(string(serviceEnum), wordlistSize)
+				wordlistSizeEnum, err = bruteforcefern.NewWordlistSizeFromString(strings.ToUpper(wordlistSize))
+				if err != nil {
+					a.OutputSignal.AddError(errors.New("invalid wordlist size"))
+					return
+				}
+				// Add built-in wordlists if wordlist-size is specified
+				builtInUsernames, builtInPasswords, err := bruteforce.GetBuiltInWordlists(string(serviceEnum), wordlistSize)
 				if err != nil {
 					a.OutputSignal.AddError(err)
 					return
@@ -142,7 +144,11 @@ func (a *NetworkScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			bruteForceConfig, err := getPentestServiceBruteForceConfig(serviceEnum, targets, allUsernames, allPasswords, usernameFiles, passwordFiles, wordlistSizeEnum, timeout, sleep, retries, successfulOnly, stopFirstSuccess)
+			var wordlistSizePtr *bruteforcefern.WordlistSize
+			if wordlistSize != "" {
+				wordlistSizePtr = &wordlistSizeEnum
+			}
+			bruteForceConfig, err := getPentestServiceBruteForceConfig(serviceEnum, targets, allUsernames, allPasswords, usernameFiles, passwordFiles, wordlistSizePtr, timeout, sleep, retries, successfulOnly, stopFirstSuccess)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -183,7 +189,7 @@ func (a *NetworkScan) InitPentestCommand() {
 
 // getPentestServiceBruteForceConfig creates a configuration for brute force attacks with the provided parameters.
 // It validates and sets up the attack parameters including module type, targets, credentials, and timing settings.
-func getPentestServiceBruteForceConfig(service bruteforcefern.SupportedServiceType, targets []string, usernames []string, passwords []string, usernameLists []string, passwordLists []string, wordlistSize bruteforcefern.WordlistSize, timeout int, sleep int, retries int, successfulOnly bool, stopFirstSuccess bool) (*bruteforcefern.PentestServiceBruteForceConfig, error) {
+func getPentestServiceBruteForceConfig(service bruteforcefern.SupportedServiceType, targets []string, usernames []string, passwords []string, usernameLists []string, passwordLists []string, wordlistSize *bruteforcefern.WordlistSize, timeout int, sleep int, retries int, successfulOnly bool, stopFirstSuccess bool) (*bruteforcefern.PentestServiceBruteForceConfig, error) {
 	config := &bruteforcefern.PentestServiceBruteForceConfig{
 		Service:          service,
 		Targets:          targets,
@@ -191,7 +197,7 @@ func getPentestServiceBruteForceConfig(service bruteforcefern.SupportedServiceTy
 		Passwords:        passwords,
 		UsernameLists:    usernameLists,
 		PasswordLists:    passwordLists,
-		WordlistSize:     &wordlistSize,
+		WordlistSize:     wordlistSize,
 		Timeout:          max(timeout, 0),
 		Sleep:            max(sleep, 0),
 		Retries:          max(retries, 0),

--- a/internal/pentest/bruteforce/engine.go
+++ b/internal/pentest/bruteforce/engine.go
@@ -4,16 +4,20 @@ package bruteforce
 import (
 	// Standard
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	// Generated
 	bruteforcefern "github.com/Method-Security/networkscan/generated/go/pentest/bruteforce"
+
 	// Internal
 	services "github.com/Method-Security/networkscan/internal/pentest/bruteforce/services"
+	utils "github.com/Method-Security/networkscan/utils"
 )
 
 // Library defines the interface for service-specific brute force implementations.
@@ -189,4 +193,60 @@ func getHostAndPorts(target string) (string, []int, error) {
 	ports = []int{intPort}
 
 	return host, ports, nil
+}
+
+// WordlistFiles maps service types and sizes to their corresponding username and password file paths
+type WordlistFiles struct {
+	UsernameFile string
+	PasswordFile string
+}
+
+// builtInWordlistMap maps service types and wordlist sizes to their corresponding files
+var builtInWordlistMap = map[string]map[string]WordlistFiles{
+	"SSH": {
+		"TINY": {
+			UsernameFile: "configs/pentest/bruteforce/ssh/username_tiny.txt",
+			PasswordFile: "configs/pentest/bruteforce/ssh/password_tiny.txt",
+		},
+	},
+	"TELNET": {
+		"TINY": {
+			UsernameFile: "configs/pentest/bruteforce/telnet/username_tiny.txt",
+			PasswordFile: "configs/pentest/bruteforce/telnet/password_tiny.txt",
+		},
+	},
+}
+
+// GetBuiltInWordlists loads built-in username and password wordlists based on service type and size.
+// It returns slices of usernames and passwords from the appropriate wordlist files.
+func GetBuiltInWordlists(service, size string) ([]string, []string, error) {
+	// Convert service to uppercase for map lookup
+	serviceStr := strings.ToUpper(service)
+	sizeStr := strings.ToUpper(size)
+
+	// Check if service exists in the map
+	serviceMap, exists := builtInWordlistMap[serviceStr]
+	if !exists {
+		return nil, nil, errors.New("unsupported service type: " + service)
+	}
+
+	// Check if size exists for the service
+	wordlistFiles, exists := serviceMap[sizeStr]
+	if !exists {
+		return nil, nil, errors.New("unsupported wordlist size '" + size + "' for service '" + service + "'")
+	}
+
+	// Load usernames from built-in wordlist
+	usernames, err := utils.GetEntriesFromTXTFiles([]string{wordlistFiles.UsernameFile})
+	if err != nil {
+		return nil, nil, errors.New("failed to load built-in username wordlist: " + err.Error())
+	}
+
+	// Load passwords from built-in wordlist
+	passwords, err := utils.GetEntriesFromTXTFiles([]string{wordlistFiles.PasswordFile})
+	if err != nil {
+		return nil, nil, errors.New("failed to load built-in password wordlist: " + err.Error())
+	}
+
+	return usernames, passwords, nil
 }

--- a/utils/files.go
+++ b/utils/files.go
@@ -3,10 +3,8 @@ package utils
 
 import (
 	"bufio"
-	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // GetEntriesFromTXTFiles reads and combines entries from multiple text files.
@@ -36,60 +34,4 @@ func GetEntriesFromTXTFiles(paths []string) ([]string, error) {
 		entries = append(entries, lines...)
 	}
 	return entries, nil
-}
-
-// WordlistFiles maps service types and sizes to their corresponding username and password file paths
-type WordlistFiles struct {
-	UsernameFile string
-	PasswordFile string
-}
-
-// builtInWordlistMap maps service types and wordlist sizes to their corresponding files
-var builtInWordlistMap = map[string]map[string]WordlistFiles{
-	"SSH": {
-		"TINY": {
-			UsernameFile: "configs/pentest/bruteforce/ssh/username_tiny.txt",
-			PasswordFile: "configs/pentest/bruteforce/ssh/password_tiny.txt",
-		},
-	},
-	"TELNET": {
-		"TINY": {
-			UsernameFile: "configs/pentest/bruteforce/telnet/username_tiny.txt",
-			PasswordFile: "configs/pentest/bruteforce/telnet/password_tiny.txt",
-		},
-	},
-}
-
-// GetBuiltInWordlists loads built-in username and password wordlists based on service type and size.
-// It returns slices of usernames and passwords from the appropriate wordlist files.
-func GetBuiltInWordlists(service, size string) ([]string, []string, error) {
-	// Convert service to uppercase for map lookup
-	serviceStr := strings.ToUpper(service)
-	sizeStr := strings.ToUpper(size)
-
-	// Check if service exists in the map
-	serviceMap, exists := builtInWordlistMap[serviceStr]
-	if !exists {
-		return nil, nil, errors.New("unsupported service type: " + service)
-	}
-
-	// Check if size exists for the service
-	wordlistFiles, exists := serviceMap[sizeStr]
-	if !exists {
-		return nil, nil, errors.New("unsupported wordlist size '" + size + "' for service '" + service + "'")
-	}
-
-	// Load usernames from built-in wordlist
-	usernames, err := GetEntriesFromTXTFiles([]string{wordlistFiles.UsernameFile})
-	if err != nil {
-		return nil, nil, errors.New("failed to load built-in username wordlist: " + err.Error())
-	}
-
-	// Load passwords from built-in wordlist
-	passwords, err := GetEntriesFromTXTFiles([]string{wordlistFiles.PasswordFile})
-	if err != nil {
-		return nil, nil, errors.New("failed to load built-in password wordlist: " + err.Error())
-	}
-
-	return usernames, passwords, nil
 }


### PR DESCRIPTION
### TL;DR

Fixed a bug in the pentest command where wordlist size was being processed even when not provided.

### What changed?

- Made `wordlistSize` parameter optional in the pentest command by only parsing it when actually provided
- Moved the `GetBuiltInWordlists` function from `utils` package to the `bruteforce` package for better code organization
- Modified `getPentestServiceBruteForceConfig` to accept a pointer to `WordlistSize` instead of the value directly, allowing it to be nil when not specified
- Added proper conditional checks to only process wordlist size when it's explicitly provided by the user

### How to test?

1. Run the pentest command without specifying a wordlist size:
   ```
   ./networkscan pentest --service ssh --target 192.168.1.1
   ```

2. Run the pentest command with a wordlist size:
   ```
   ./networkscan pentest --service ssh --target 192.168.1.1 --wordlist-size tiny
   ```

3. Verify both commands execute without errors related to wordlist size parsing

### Why make this change?

Previously, the code was attempting to process the wordlist size parameter even when it wasn't provided by the user, which could lead to errors. This change makes the parameter truly optional, improving the user experience by allowing the command to run without requiring a wordlist size specification.