### PR TITLE
Update bruteforce wordlist paths to absolute

### DIFF
--- a/internal/pentest/bruteforce/helpers.go
+++ b/internal/pentest/bruteforce/helpers.go
@@ -54,14 +54,14 @@ type WordlistFiles struct {
 var builtInWordlistMap = map[string]map[string]WordlistFiles{
 	"SSH": {
 		"TINY": {
-			UsernameFile: "conf/pentest/bruteforce/ssh/username_tiny.txt",
-			PasswordFile: "conf/pentest/bruteforce/ssh/password_tiny.txt",
+			UsernameFile: "/opt/method/networkscan/var/conf/pentest/bruteforce/ssh/username_tiny.txt",
+			PasswordFile: "/opt/method/networkscan/var/conf/pentest/bruteforce/ssh/password_tiny.txt",
 		},
 	},
 	"TELNET": {
 		"TINY": {
-			UsernameFile: "conf/pentest/bruteforce/telnet/username_tiny.txt",
-			PasswordFile: "conf/pentest/bruteforce/telnet/password_tiny.txt",
+			UsernameFile: "/opt/method/networkscan/var/conf/pentest/bruteforce/telnet/username_tiny.txt",
+			PasswordFile: "/opt/method/networkscan/var/conf/pentest/bruteforce/telnet/password_tiny.txt",
 		},
 	},
 }


### PR DESCRIPTION
### TL;DR

Updated file paths for bruteforce configuration files to use absolute paths.

### What changed?

Modified the file paths in `internal/pentest/bruteforce/helpers.go` to use absolute paths instead of relative paths for SSH and Telnet bruteforce configuration files. The paths now point to `/opt/method/networkscan/var/conf/` directory instead of the relative `conf/` directory.

### How to test?

1. Verify that the bruteforce functionality can correctly locate and load the username and password files
2. Run SSH bruteforce tests to confirm the new paths are working
3. Run Telnet bruteforce tests to confirm the new paths are working

### Why make this change?

Using absolute paths ensures that the application can reliably find the configuration files regardless of the working directory from which the application is launched. This improves reliability and prevents path-related errors when the application is run from different contexts or deployment environments.