### PR TITLE
Add FTP authentication support for password spraying

### DIFF
--- a/internal/pentest/ftp/auth.go
+++ b/internal/pentest/ftp/auth.go
@@ -1,0 +1,116 @@
+package ftp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/Method-Security/networkscan/utils"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+var bufferSize = 2048
+
+// AuthenticateUser attempts to authenticate with the FTP server using the provided credentials
+func AuthenticateUser(ctx context.Context, target, username, password string, timeoutMs int) (bool, string, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Parse target to handle default port (21) if not specified
+	host, port := utils.ParseHostPort(target, 21)
+	ftpTarget := fmt.Sprintf("%s:%d", host, port)
+
+	log.Info("Attempting FTP authentication",
+		svc1log.SafeParam("target", ftpTarget),
+		svc1log.SafeParam("username", username))
+
+	// Create connection with timeout
+	dialer := net.Dialer{
+		Timeout: time.Duration(timeoutMs) * time.Millisecond,
+	}
+
+	conn, err := dialer.DialContext(ctx, "tcp", ftpTarget)
+	if err != nil {
+		return false, fmt.Sprintf("Connection failed: %v", err), err
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Warn("Failed to close FTP connection", svc1log.SafeParam("error", closeErr.Error()))
+		}
+	}()
+
+	// Set connection timeout for read/write operations
+	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+	if err := conn.SetDeadline(deadline); err != nil {
+		return false, fmt.Sprintf("Failed to set deadline: %v", err), err
+	}
+
+	// Read initial banner
+	response := make([]byte, bufferSize)
+	n, err := conn.Read(response)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to read banner: %v", err), err
+	}
+
+	banner := string(response[:n])
+	log.Info("Received FTP banner", svc1log.SafeParam("banner", strings.TrimSpace(banner)))
+
+	// Check if banner indicates successful connection (220 response code)
+	if !strings.Contains(banner, "220") {
+		return false, fmt.Sprintf("Invalid FTP banner: %s", strings.TrimSpace(banner)), nil
+	}
+
+	// Send USER command
+	userCmd := fmt.Sprintf("USER %s\r\n", username)
+	_, err = conn.Write([]byte(userCmd))
+	if err != nil {
+		return false, fmt.Sprintf("Failed to send USER command: %v", err), err
+	}
+
+	// Read USER response
+	n, err = conn.Read(response)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to read USER response: %v", err), err
+	}
+
+	userResponse := string(response[:n])
+	log.Info("USER response", svc1log.SafeParam("response", strings.TrimSpace(userResponse)))
+
+	// Check if server requests password (331 response code)
+	if !strings.HasPrefix(userResponse, "331") {
+		if strings.HasPrefix(userResponse, "530") {
+			return false, "User not allowed", nil
+		}
+		return false, fmt.Sprintf("Unexpected USER response: %s", strings.TrimSpace(userResponse)), nil
+	}
+
+	// Send PASS command
+	passCmd := fmt.Sprintf("PASS %s\r\n", password)
+	_, err = conn.Write([]byte(passCmd))
+	if err != nil {
+		return false, fmt.Sprintf("Failed to send PASS command: %v", err), err
+	}
+
+	// Read PASS response
+	n, err = conn.Read(response)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to read PASS response: %v", err), err
+	}
+
+	passResponse := string(response[:n])
+	log.Info("PASS response", svc1log.SafeParam("response", strings.TrimSpace(passResponse)))
+
+	// Check authentication result
+	if strings.HasPrefix(passResponse, "230") {
+		// Send QUIT command to cleanly close connection
+		if _, err := conn.Write([]byte("QUIT\r\n")); err != nil {
+			log.Warn("Failed to send QUIT command", svc1log.SafeParam("error", err.Error()))
+		}
+		return true, "Authentication successful", nil
+	} else if strings.HasPrefix(passResponse, "530") {
+		return false, "Authentication failed - invalid credentials", nil
+	} else {
+		return false, fmt.Sprintf("Unexpected PASS response: %s", strings.TrimSpace(passResponse)), nil
+	}
+}

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -10,6 +10,7 @@ import (
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
 	telnetfern "github.com/Method-Security/networkscan/generated/go/pentest/telnet"
+	ftppentest "github.com/Method-Security/networkscan/internal/pentest/ftp"
 	kerberospentest "github.com/Method-Security/networkscan/internal/pentest/kerberos"
 	ldappentest "github.com/Method-Security/networkscan/internal/pentest/ldap"
 	smbpentest "github.com/Method-Security/networkscan/internal/pentest/smb"
@@ -337,6 +338,8 @@ func (e *Engine) performSprayAttempt(ctx context.Context, target string, service
 		success, message = e.performSMBSpray(ctx, target, cred, config)
 	case pentest.SprayTargetServiceTelnet:
 		success, message = e.performTelnetSpray(ctx, target, cred, config)
+	case pentest.SprayTargetServiceFtp:
+		success, message = e.performFTPSpray(ctx, target, cred, config)
 	case pentest.SprayTargetServiceKerberos:
 		success, message = e.performKerberosSpray(ctx, target, cred, config)
 	case pentest.SprayTargetServiceLdap:
@@ -411,6 +414,17 @@ func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pente
 	}
 
 	return false, "Authentication failed"
+}
+
+// performFTPSpray uses FTP auth functionality
+func (e *Engine) performFTPSpray(ctx context.Context, target string, cred *pentest.Credential, config *pentest.SprayPasswordConfig) (bool, string) {
+	// Use the FTP authentication function
+	success, message, err := ftppentest.AuthenticateUser(ctx, target, cred.Username, cred.Password, config.Timeout)
+	if err != nil {
+		return false, fmt.Sprintf("FTP error: %v", err)
+	}
+
+	return success, message
 }
 
 // performSMBSpray uses existing SMB auth functionality


### PR DESCRIPTION
### TL;DR

Added FTP authentication support to the password spraying functionality.

### What changed?

- Created a new `auth.go` file in the `internal/pentest/ftp` package that implements FTP authentication
- Added the `AuthenticateUser` function that attempts to authenticate with an FTP server using provided credentials
- Integrated FTP authentication into the password spraying engine by adding a `performFTPSpray` method
- Updated the `performSprayAttempt` function to handle the FTP service type

### How to test?

1. Run a password spray against an FTP target using:
   ```
   networkscan spray --target ftp.example.com:21 --service ftp --username test --password test
   ```
2. Verify successful authentication with valid credentials
3. Verify failed authentication with invalid credentials
4. Check that connection timeouts and error handling work as expected

### Why make this change?

FTP servers are common in many environments and can be vulnerable to password attacks. Adding FTP support to the password spraying functionality provides a more comprehensive security testing capability, allowing security teams to identify weak FTP credentials that could be exploited by attackers.