### PR TITLE
Make successfulCredentials optional in SprayResult

### DIFF
--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -16,12 +16,12 @@ types:
 
   WordlistType:
     enum:
-      - SYSTEM_PASSWORDS      # Simple passwords for SSH/Linux servers
-      - SYSTEM_USERNAMES      # System users (root, admin, ec2-user, etc.)
-      - DOMAIN_PASSWORDS      # Policy-compliant passwords for Windows domains (includes seasonal)
-      - DOMAIN_USERNAMES      # Windows domain users (real people)
-      - SERVICE_PASSWORDS     # Passwords for service accounts
-      - SERVICE_USERNAMES     # Service account usernames
+      - SYSTEM_PASSWORDS # Simple passwords for SSH/Linux servers
+      - SYSTEM_USERNAMES # System users (root, admin, ec2-user, etc.)
+      - DOMAIN_PASSWORDS # Policy-compliant passwords for Windows domains (includes seasonal)
+      - DOMAIN_USERNAMES # Windows domain users (real people)
+      - SERVICE_PASSWORDS # Passwords for service accounts
+      - SERVICE_USERNAMES # Service account usernames
       - CUSTOM
 
   # Core Types
@@ -73,7 +73,7 @@ types:
       operationType: SprayMode # PASSWORD or USERNAME to distinguish operation type
       attempts: list<SprayAttempt>
       statistics: SprayStatistics
-      successfulCredentials: list<Credential>
+      successfulCredentials: optional<list<Credential>>
       errors: optional<list<string>>
 
   # Configuration Types


### PR DESCRIPTION
### TL;DR

Made `successfulCredentials` field optional in the `SprayResult` type.

### What changed?

Modified the `SprayResult` type in the pentest spray definition by changing the `successfulCredentials` field from a required list to an optional list. Also cleaned up comment formatting in the `WordlistType` enum.

### How to test?

1. Verify that API clients can properly handle the case when `successfulCredentials` is not present in a `SprayResult` response
2. Ensure that existing code that expects this field handles the optional nature correctly
3. Confirm that the API documentation reflects this change

### Why make this change?

Making the `successfulCredentials` field optional allows for more flexibility in API responses, particularly in cases where a spray operation completes but doesn't yield any successful credentials. This change improves the API's robustness by not requiring an empty list to be returned when there are no successful credentials.