### PR TITLE
Refactor pentest command with service-specific operations for SMB, SSH, and Telnet

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -2,8 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
 	// Generated
 	pentest "github.com/Method-Security/networkscan/generated/go/pentest"
+	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
+	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
+	telnetfern "github.com/Method-Security/networkscan/generated/go/pentest/telnet"
+
 	// Internal
 	pentest_internal "github.com/Method-Security/networkscan/internal/pentest"
 	"github.com/Method-Security/networkscan/utils"
@@ -20,57 +26,41 @@ func (a *NetworkScan) InitPentestCommand() {
 		Long:  `Perform penetration testing operations including credential spraying and authentication testing.`,
 	}
 
-	// Spray Command
+	// Create subcommands
+	a.createSprayCommands(pentestCmd)
+	a.createServiceCommands(pentestCmd)
+
+	// Add to main command
+	a.RootCmd.AddCommand(pentestCmd)
+}
+
+// ============================================================================
+// SPRAY COMMANDS
+// ============================================================================
+
+// createSprayCommands creates the spray command and its subcommands
+func (a *NetworkScan) createSprayCommands(parent *cobra.Command) {
 	sprayCmd := &cobra.Command{
 		Use:   "spray",
 		Short: "Perform credential spraying attacks and username enumeration against network services.",
 		Long:  `Perform credential spraying attacks and username enumeration against network services.`,
 	}
 
-	// Password Spray Command
+	// Create spray subcommands
+	a.createPasswordSprayCommand(sprayCmd)
+	a.createUsernameSprayCommand(sprayCmd)
+
+	parent.AddCommand(sprayCmd)
+}
+
+// createPasswordSprayCommand creates the password spray subcommand
+func (a *NetworkScan) createPasswordSprayCommand(parent *cobra.Command) {
 	passwordCmd := &cobra.Command{
 		Use:   "password",
 		Short: "Perform password spraying attacks against specified targets and services.",
 		Long:  `Perform password spraying attacks against specified targets and services.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Target flags
-			targets, err := cmd.Flags().GetStringSlice("targets")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			if len(targets) == 0 {
-				a.OutputSignal.AddError(fmt.Errorf("at least one target must be specified"))
-				return
-			}
-
-			// Service flag
-			serviceStr, err := cmd.Flags().GetString("service")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			service, err := pentest.NewSprayTargetServiceFromString(serviceStr)
-			if err != nil {
-				a.OutputSignal.AddError(fmt.Errorf("invalid service '%s': %v", serviceStr, err))
-				return
-			}
-
-			// Create spray password config
-			config, err := createSprayPasswordConfig(cmd, targets, service)
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			// Create engine and run password spray
-			engine := pentest_internal.NewEngine()
-			report, err := engine.RunSprayPassword(cmd.Context(), config)
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			a.OutputSignal.Content = report
+			a.runPasswordSpray(cmd, args)
 		},
 	}
 
@@ -94,50 +84,17 @@ func (a *NetworkScan) InitPentestCommand() {
 	_ = passwordCmd.MarkFlagRequired("targets")
 	_ = passwordCmd.MarkFlagRequired("service")
 
-	// Username Enumeration Command
+	parent.AddCommand(passwordCmd)
+}
+
+// createUsernameSprayCommand creates the username enumeration subcommand
+func (a *NetworkScan) createUsernameSprayCommand(parent *cobra.Command) {
 	usernameCmd := &cobra.Command{
 		Use:   "username",
 		Short: "Perform username enumeration against specified targets and services.",
 		Long:  `Perform username enumeration against specified targets and services.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Target flags
-			targets, err := cmd.Flags().GetStringSlice("targets")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			if len(targets) == 0 {
-				a.OutputSignal.AddError(fmt.Errorf("at least one target must be specified"))
-				return
-			}
-
-			// Service flag
-			serviceStr, err := cmd.Flags().GetString("service")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			service, err := pentest.NewSprayTargetServiceFromString(serviceStr)
-			if err != nil {
-				a.OutputSignal.AddError(fmt.Errorf("invalid service '%s': %v", serviceStr, err))
-				return
-			}
-
-			// Create spray username config
-			config, err := createSprayUsernameConfig(cmd, targets, service)
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			// Create engine and run username enumeration
-			engine := pentest_internal.NewEngine()
-			report, err := engine.RunSprayUsername(cmd.Context(), config)
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			a.OutputSignal.Content = report
+			a.runUsernameSpray(cmd, args)
 		},
 	}
 
@@ -156,17 +113,503 @@ func (a *NetworkScan) InitPentestCommand() {
 	_ = usernameCmd.MarkFlagRequired("targets")
 	_ = usernameCmd.MarkFlagRequired("service")
 
-	// Add subcommands
-	sprayCmd.AddCommand(passwordCmd)
-	sprayCmd.AddCommand(usernameCmd)
-	pentestCmd.AddCommand(sprayCmd)
-
-	// Add to main command
-	a.RootCmd.AddCommand(pentestCmd)
+	parent.AddCommand(usernameCmd)
 }
 
+// runPasswordSpray executes password spray operations
+func (a *NetworkScan) runPasswordSpray(cmd *cobra.Command, args []string) {
+	// Target flags
+	targets, err := cmd.Flags().GetStringSlice("targets")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("at least one target must be specified"))
+		return
+	}
+
+	// Service flag
+	serviceStr, err := cmd.Flags().GetString("service")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	service, err := pentest.NewSprayTargetServiceFromString(serviceStr)
+	if err != nil {
+		a.OutputSignal.AddError(fmt.Errorf("invalid service '%s': %v", serviceStr, err))
+		return
+	}
+
+	// Create spray password config
+	config, err := a.createSprayPasswordConfig(cmd, targets, service)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Create engine and run password spray
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunSprayPassword(cmd.Context(), config)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	a.OutputSignal.Content = report
+}
+
+// runUsernameSpray executes username enumeration operations
+func (a *NetworkScan) runUsernameSpray(cmd *cobra.Command, args []string) {
+	// Target flags
+	targets, err := cmd.Flags().GetStringSlice("targets")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("at least one target must be specified"))
+		return
+	}
+
+	// Service flag
+	serviceStr, err := cmd.Flags().GetString("service")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	service, err := pentest.NewSprayTargetServiceFromString(serviceStr)
+	if err != nil {
+		a.OutputSignal.AddError(fmt.Errorf("invalid service '%s': %v", serviceStr, err))
+		return
+	}
+
+	// Create spray username config
+	config, err := a.createSprayUsernameConfig(cmd, targets, service)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Create engine and run username enumeration
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunSprayUsername(cmd.Context(), config)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	a.OutputSignal.Content = report
+}
+
+// ============================================================================
+// SERVICE COMMANDS
+// ============================================================================
+
+// createServiceCommands creates the service command and its subcommands
+func (a *NetworkScan) createServiceCommands(parent *cobra.Command) {
+	serviceCmd := &cobra.Command{
+		Use:   "service",
+		Short: "Perform service-specific penetration testing operations.",
+		Long:  `Perform service-specific penetration testing operations against network services.`,
+	}
+
+	// Create service-specific subcommands
+	a.createSMBPentestCommand(serviceCmd)
+	a.createSSHPentestCommand(serviceCmd)
+	a.createTelnetPentestCommand(serviceCmd)
+
+	parent.AddCommand(serviceCmd)
+}
+
+// createSMBPentestCommand creates the SMB pentest subcommand
+func (a *NetworkScan) createSMBPentestCommand(parent *cobra.Command) {
+	smbCmd := &cobra.Command{
+		Use:   "smb",
+		Short: "Perform pentest operations against SMB services",
+		Long: `Perform pentest operations against SMB services.
+		
+Base enumeration is always performed to extract server info, domain, OS version, etc.
+Additional actions can be specified to layer more functionality on top.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			a.runSMBPentest(cmd, args)
+		},
+	}
+
+	// Target configuration
+	smbCmd.Flags().StringSlice("targets", []string{}, "Target hosts (required)")
+	_ = smbCmd.MarkFlagRequired("targets")
+
+	// Action flags
+	smbCmd.Flags().StringSlice("actions", []string{}, fmt.Sprintf("Actions to perform: %s", strings.Join(utils.GetSMBParser().GetValidActions(), ",")))
+
+	// Authentication flags
+	smbCmd.Flags().StringSliceP("usernames", "u", []string{}, "Usernames for authentication")
+	smbCmd.Flags().StringSliceP("passwords", "p", []string{}, "Passwords for authentication")
+	smbCmd.Flags().String("username-file", "", "File containing usernames (one per line)")
+	smbCmd.Flags().String("password-file", "", "File containing passwords (one per line)")
+	smbCmd.Flags().String("credentials", "", "Credentials in user:pass format")
+	smbCmd.Flags().StringP("domain", "d", "", "Domain for authentication")
+
+	// Command execution flags
+	smbCmd.Flags().StringSliceP("execute", "x", []string{}, "Commands to execute on successful auth")
+	smbCmd.Flags().String("command-file", "", "File containing commands to execute")
+
+	// Behavior flags
+	smbCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
+	smbCmd.Flags().Int("retries", 2, "Number of retry attempts")
+	smbCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
+	smbCmd.Flags().Bool("successful-only", false, "Show only successful results")
+	smbCmd.Flags().Bool("verbose", false, "Verbose output")
+
+	parent.AddCommand(smbCmd)
+}
+
+// createSSHPentestCommand creates the SSH pentest subcommand
+func (a *NetworkScan) createSSHPentestCommand(parent *cobra.Command) {
+	sshCmd := &cobra.Command{
+		Use:   "ssh",
+		Short: "Perform pentest operations against SSH services",
+		Long: `Perform pentest operations against SSH services.
+		
+Base enumeration is always performed to extract server info, supported auth methods, etc.
+Additional actions can be specified to layer more functionality on top.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			a.runSSHPentest(cmd, args)
+		},
+	}
+
+	// Target configuration
+	sshCmd.Flags().StringSlice("targets", []string{}, "Target hosts (required)")
+	_ = sshCmd.MarkFlagRequired("targets")
+
+	// Action flags
+	sshCmd.Flags().StringSlice("actions", []string{}, fmt.Sprintf("Actions to perform: %s", strings.Join(utils.GetSSHParser().GetValidActions(), ",")))
+
+	// Authentication flags
+	sshCmd.Flags().StringSliceP("usernames", "u", []string{}, "Usernames for authentication")
+	sshCmd.Flags().StringSliceP("passwords", "p", []string{}, "Passwords for authentication")
+	sshCmd.Flags().String("username-file", "", "File containing usernames (one per line)")
+	sshCmd.Flags().String("password-file", "", "File containing passwords (one per line)")
+	sshCmd.Flags().String("key-file", "", "SSH private key file")
+
+	// Command execution flags
+	sshCmd.Flags().StringSliceP("execute", "x", []string{}, "Commands to execute on successful auth")
+	sshCmd.Flags().String("command-file", "", "File containing commands to execute")
+
+	// File transfer flags
+	sshCmd.Flags().StringSlice("upload", []string{}, "Files to upload (local:remote format)")
+	sshCmd.Flags().StringSlice("download", []string{}, "Remote files to download")
+
+	// Behavior flags
+	sshCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
+	sshCmd.Flags().Int("retries", 2, "Number of retry attempts")
+	sshCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
+	sshCmd.Flags().Bool("successful-only", false, "Show only successful results")
+
+	parent.AddCommand(sshCmd)
+}
+
+// createTelnetPentestCommand creates the Telnet pentest subcommand
+func (a *NetworkScan) createTelnetPentestCommand(parent *cobra.Command) {
+	telnetCmd := &cobra.Command{
+		Use:   "telnet",
+		Short: "Perform pentest operations against Telnet services",
+		Long: `Perform pentest operations against Telnet services.
+		
+Base enumeration is always performed to extract banner, prompts, etc.
+Additional actions can be specified to layer more functionality on top.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			a.runTelnetPentest(cmd, args)
+		},
+	}
+
+	// Target configuration
+	telnetCmd.Flags().StringSlice("targets", []string{}, "Target hosts (required)")
+	_ = telnetCmd.MarkFlagRequired("targets")
+
+	// Action flags
+	telnetCmd.Flags().StringSlice("actions", []string{}, fmt.Sprintf("Actions to perform: %s", strings.Join(utils.GetTelnetParser().GetValidActions(), ",")))
+
+	// Authentication flags
+	telnetCmd.Flags().StringSliceP("usernames", "u", []string{}, "Usernames for authentication")
+	telnetCmd.Flags().StringSliceP("passwords", "p", []string{}, "Passwords for authentication")
+	telnetCmd.Flags().String("username-file", "", "File containing usernames (one per line)")
+	telnetCmd.Flags().String("password-file", "", "File containing passwords (one per line)")
+
+	// Command execution flags
+	telnetCmd.Flags().StringSliceP("execute", "x", []string{}, "Commands to execute on successful auth")
+	telnetCmd.Flags().String("command-file", "", "File containing commands to execute")
+
+	// Behavior flags
+	telnetCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
+	telnetCmd.Flags().Int("retries", 2, "Number of retry attempts")
+	telnetCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
+	telnetCmd.Flags().Bool("successful-only", false, "Show only successful results")
+
+	parent.AddCommand(telnetCmd)
+}
+
+// runSMBPentest executes SMB pentest operations
+func (a *NetworkScan) runSMBPentest(cmd *cobra.Command, args []string) {
+	// Get targets from flag
+	targets, _ := cmd.Flags().GetStringSlice("targets")
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
+		return
+	}
+
+	// Parse SMB actions
+	actionStrings, _ := cmd.Flags().GetStringSlice("actions")
+	actions, err := utils.GetSMBParser().ParseActions(actionStrings)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Parse authentication options
+	usernames, _ := cmd.Flags().GetStringSlice("usernames")
+	passwords, _ := cmd.Flags().GetStringSlice("passwords")
+	usernameFile, _ := cmd.Flags().GetString("username-file")
+	passwordFile, _ := cmd.Flags().GetString("password-file")
+	credentials, _ := cmd.Flags().GetString("credentials")
+	domain, _ := cmd.Flags().GetString("domain")
+
+	// Parse command execution options
+	commands, _ := cmd.Flags().GetStringSlice("execute")
+	commandFile, _ := cmd.Flags().GetString("command-file")
+
+	// Parse behavior options
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	retries, _ := cmd.Flags().GetInt("retries")
+	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
+	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
+
+	// Load credentials from files if specified
+	if usernameFile != "" {
+		fileUsernames, err := utils.GetEntriesFromTXTFiles([]string{usernameFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		usernames = append(usernames, fileUsernames...)
+	}
+
+	if passwordFile != "" {
+		filePasswords, err := utils.GetEntriesFromTXTFiles([]string{passwordFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		passwords = append(passwords, filePasswords...)
+	}
+
+	// Parse credentials in user:pass format
+	if credentials != "" {
+		parts := strings.Split(credentials, ":")
+		if len(parts) == 2 {
+			usernames = append(usernames, parts[0])
+			passwords = append(passwords, parts[1])
+		}
+	}
+
+	// Load commands from file if specified
+	if commandFile != "" {
+		fileCommands, err := utils.GetEntriesFromTXTFiles([]string{commandFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		commands = append(commands, fileCommands...)
+	}
+
+	// Set Config
+	config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, timeout, retries, stopFirstSuccess, successfulOnly, domain)
+
+	// Create engine and run pentest
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunSMBPentest(cmd.Context(), config)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Use the report directly since it already has the consolidated structure
+	a.OutputSignal.Content = report
+}
+
+// runSSHPentest executes SSH pentest operations
+func (a *NetworkScan) runSSHPentest(cmd *cobra.Command, args []string) {
+	// Get targets from flag
+	targets, _ := cmd.Flags().GetStringSlice("targets")
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
+		return
+	}
+
+	// Parse SSH actions
+	actionStrings, _ := cmd.Flags().GetStringSlice("actions")
+	actions, err := utils.GetSSHParser().ParseActions(actionStrings)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Parse authentication options
+	usernames, _ := cmd.Flags().GetStringSlice("usernames")
+	passwords, _ := cmd.Flags().GetStringSlice("passwords")
+	usernameFile, _ := cmd.Flags().GetString("username-file")
+	passwordFile, _ := cmd.Flags().GetString("password-file")
+	keyFile, _ := cmd.Flags().GetString("key-file")
+
+	// Parse command execution options
+	commands, _ := cmd.Flags().GetStringSlice("execute")
+	commandFile, _ := cmd.Flags().GetString("command-file")
+
+	// Parse file transfer options
+	uploads, _ := cmd.Flags().GetStringSlice("upload")
+	downloads, _ := cmd.Flags().GetStringSlice("download")
+
+	// Parse behavior options
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	retries, _ := cmd.Flags().GetInt("retries")
+	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
+	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
+
+	// Load credentials from files if specified
+	if usernameFile != "" {
+		fileUsernames, err := utils.GetEntriesFromTXTFiles([]string{usernameFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		usernames = append(usernames, fileUsernames...)
+	}
+
+	if passwordFile != "" {
+		filePasswords, err := utils.GetEntriesFromTXTFiles([]string{passwordFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		passwords = append(passwords, filePasswords...)
+	}
+
+	// Load commands from file if specified
+	if commandFile != "" {
+		fileCommands, err := utils.GetEntriesFromTXTFiles([]string{commandFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		commands = append(commands, fileCommands...)
+	}
+
+	// Parse upload/download mappings
+	uploadFiles := make(map[string]string)
+	for _, upload := range uploads {
+		parts := strings.Split(upload, ":")
+		if len(parts) == 2 {
+			uploadFiles[parts[0]] = parts[1]
+		}
+	}
+
+	// Set Config
+	config := getSSHPentestConfig(targets, actions, usernames, passwords, commands, uploadFiles, downloads, timeout, retries, stopFirstSuccess, successfulOnly, keyFile)
+
+	// Create engine and run pentest
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunSSHPentest(cmd.Context(), config)
+	if err != nil {
+		a.OutputSignal.AddError(fmt.Errorf("SSH pentest failed: %v", err))
+		return
+	}
+
+	// Use the report directly since it already has the consolidated structure
+	a.OutputSignal.Content = report
+}
+
+// runTelnetPentest executes Telnet pentest operations
+func (a *NetworkScan) runTelnetPentest(cmd *cobra.Command, args []string) {
+	// Get targets from flag
+	targets, _ := cmd.Flags().GetStringSlice("targets")
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
+		return
+	}
+
+	// Parse Telnet actions
+	actionStrings, _ := cmd.Flags().GetStringSlice("actions")
+	actions, err := utils.GetTelnetParser().ParseActions(actionStrings)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Parse authentication options
+	usernames, _ := cmd.Flags().GetStringSlice("usernames")
+	passwords, _ := cmd.Flags().GetStringSlice("passwords")
+	usernameFile, _ := cmd.Flags().GetString("username-file")
+	passwordFile, _ := cmd.Flags().GetString("password-file")
+
+	// Parse command execution options
+	commands, _ := cmd.Flags().GetStringSlice("execute")
+	commandFile, _ := cmd.Flags().GetString("command-file")
+
+	// Parse behavior options
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	retries, _ := cmd.Flags().GetInt("retries")
+	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
+	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
+
+	// Load credentials from files if specified
+	if usernameFile != "" {
+		fileUsernames, err := utils.GetEntriesFromTXTFiles([]string{usernameFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		usernames = append(usernames, fileUsernames...)
+	}
+
+	if passwordFile != "" {
+		filePasswords, err := utils.GetEntriesFromTXTFiles([]string{passwordFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		passwords = append(passwords, filePasswords...)
+	}
+
+	// Load commands from file if specified
+	if commandFile != "" {
+		fileCommands, err := utils.GetEntriesFromTXTFiles([]string{commandFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		commands = append(commands, fileCommands...)
+	}
+
+	// Set Config
+	config := getTelnetPentestConfig(targets, actions, usernames, passwords, commands, timeout, retries, stopFirstSuccess, successfulOnly)
+
+	// Create engine and run pentest
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunTelnetPentest(cmd.Context(), config)
+	if err != nil {
+		a.OutputSignal.AddError(fmt.Errorf("Telnet pentest failed: %v", err))
+		return
+	}
+
+	// Use the report directly since it already has the consolidated structure
+	a.OutputSignal.Content = report
+}
+
+// ============================================================================
+// CONFIG HELPER FUNCTIONS
+// ============================================================================
+
 // createSprayPasswordConfig creates a SprayPasswordConfig from command flags
-func createSprayPasswordConfig(cmd *cobra.Command, targets []string, service pentest.SprayTargetService) (*pentest.SprayPasswordConfig, error) {
+func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []string, service pentest.SprayTargetService) (*pentest.SprayPasswordConfig, error) {
 	// Authentication flags
 	usernames, err := cmd.Flags().GetStringSlice("usernames")
 	if err != nil {
@@ -266,41 +709,14 @@ func createSprayPasswordConfig(cmd *cobra.Command, targets []string, service pen
 		return nil, fmt.Errorf("failed to get successful-only: %v", err)
 	}
 
-	// Create config
-	var usernameFilePtr, passwordFilePtr, domainPtr *string
-	if usernameFile != "" {
-		usernameFilePtr = &usernameFile
-	}
-	if passwordFile != "" {
-		passwordFilePtr = &passwordFile
-	}
-	if domain != "" {
-		domainPtr = &domain
-	}
-
-	config := &pentest.SprayPasswordConfig{
-		Targets:            targets,
-		Service:            service,
-		Usernames:          usernames,
-		Passwords:          passwords,
-		UsernameFile:       usernameFilePtr,
-		PasswordFile:       passwordFilePtr,
-		UsernameLists:      usernameListEnums,
-		PasswordLists:      passwordListEnums,
-		Domain:             domainPtr,
-		Timeout:            timeout,
-		Sleep:              sleep,
-		Retries:            retries,
-		StopOnFirstSuccess: stopFirstSuccess,
-		SuccessfulOnly:     successfulOnly,
-		ContinueOnError:    true,
-	}
+	// Set Config
+	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, timeout, sleep, retries, stopFirstSuccess, successfulOnly)
 
 	return config, nil
 }
 
 // createSprayUsernameConfig creates a SprayUsernameConfig from command flags
-func createSprayUsernameConfig(cmd *cobra.Command, targets []string, service pentest.SprayTargetService) (*pentest.SprayUsernameConfig, error) {
+func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []string, service pentest.SprayTargetService) (*pentest.SprayUsernameConfig, error) {
 	// Authentication flags
 	usernames, err := cmd.Flags().GetStringSlice("usernames")
 	if err != nil {
@@ -362,16 +778,57 @@ func createSprayUsernameConfig(cmd *cobra.Command, targets []string, service pen
 		return nil, fmt.Errorf("retries must be at least 1")
 	}
 
+	// Set Config
+	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, domain, timeout, sleep, retries)
+
+	return config, nil
+}
+
+// getSprayPasswordConfig creates a configuration for password spray operations with the provided parameters.
+func getSprayPasswordConfig(targets []string, service pentest.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentest.WordlistType, passwordLists []pentest.WordlistType, domain string, timeout int, sleep int, retries int, stopFirstSuccess bool, successfulOnly bool) *pentest.SprayPasswordConfig {
+	// Create config
+	var usernameFilePtr, passwordFilePtr, domainPtr *string
+	if usernameFile != "" {
+		usernameFilePtr = &usernameFile
+	}
+	if passwordFile != "" {
+		passwordFilePtr = &passwordFile
+	}
+	if domain != "" {
+		domainPtr = &domain
+	}
+
+	return &pentest.SprayPasswordConfig{
+		Targets:            targets,
+		Service:            service,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		UsernameFile:       usernameFilePtr,
+		PasswordFile:       passwordFilePtr,
+		UsernameLists:      usernameLists,
+		PasswordLists:      passwordLists,
+		Domain:             domainPtr,
+		Timeout:            timeout,
+		Sleep:              sleep,
+		Retries:            retries,
+		StopOnFirstSuccess: stopFirstSuccess,
+		SuccessfulOnly:     successfulOnly,
+		ContinueOnError:    true,
+	}
+}
+
+// getSprayUsernameConfig creates a configuration for username enumeration operations with the provided parameters.
+func getSprayUsernameConfig(targets []string, service pentest.SprayTargetService, usernameLists []pentest.WordlistType, usernames []string, domain string, timeout int, sleep int, retries int) *pentest.SprayUsernameConfig {
 	// Create config
 	var domainPtr *string
 	if domain != "" {
 		domainPtr = &domain
 	}
 
-	config := &pentest.SprayUsernameConfig{
+	return &pentest.SprayUsernameConfig{
 		Targets:         targets,
 		Service:         service,
-		UsernameLists:   usernameListEnums,
+		UsernameLists:   usernameLists,
 		Usernames:       usernames,
 		Domain:          domainPtr,
 		Timeout:         timeout,
@@ -379,6 +836,53 @@ func createSprayUsernameConfig(cmd *cobra.Command, targets []string, service pen
 		Retries:         retries,
 		ContinueOnError: true,
 	}
+}
 
-	return config, nil
+// getSMBPentestConfig creates a configuration for SMB pentest operations with the provided parameters.
+func getSMBPentestConfig(targets []string, actions []*pentest.PentestServiceAction, usernames []string, passwords []string, commands []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, domain string) *smbfern.PentestSmbConfig {
+	return &smbfern.PentestSmbConfig{
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		ExecuteCommands:    commands,
+		Timeout:            timeout,
+		Retries:            retries,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
+		Domain:             &domain,
+	}
+}
+
+// getSSHPentestConfig creates a configuration for SSH pentest operations with the provided parameters.
+func getSSHPentestConfig(targets []string, actions []*pentest.PentestServiceAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
+	return &sshfern.PentestSshConfig{
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		ExecuteCommands:    commands,
+		UploadFiles:        uploadFiles,
+		DownloadFiles:      downloads,
+		Timeout:            timeout,
+		Retries:            retries,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
+		KeyFile:            &keyFile,
+	}
+}
+
+// getTelnetPentestConfig creates a configuration for Telnet pentest operations with the provided parameters.
+func getTelnetPentestConfig(targets []string, actions []*pentest.PentestServiceAction, usernames []string, passwords []string, commands []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
+	return &telnetfern.PentestTelnetConfig{
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		ExecuteCommands:    commands,
+		Timeout:            timeout,
+		Retries:            retries,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
+	}
 }


### PR DESCRIPTION
### TL;DR

Refactored the pentest command structure to add service-specific penetration testing capabilities for SMB, SSH, and Telnet.

### What changed?

- Restructured the pentest command code into logical sections with helper functions
- Added new service-specific commands under `pentest service` for SMB, SSH, and Telnet
- Implemented configuration helpers for each service type
- Added support for various authentication methods, command execution, and file transfers
- Improved code organization with separate functions for command creation and execution
- Added new imports for service-specific generated code

### How to test?

Test the new service commands:

```bash
# SMB pentest
networkscan pentest service smb --targets 192.168.1.100 --actions enum,auth --usernames admin --passwords password123 --domain WORKGROUP

# SSH pentest
networkscan pentest service ssh --targets 192.168.1.100 --actions enum,auth --usernames root --passwords password123 --execute "id;whoami"

# Telnet pentest
networkscan pentest service telnet --targets 192.168.1.100 --actions enum,auth --usernames admin --passwords password123
```

Verify the existing spray commands still work:
```bash
networkscan pentest spray password --targets 192.168.1.100 --service ssh --usernames admin --passwords password123
networkscan pentest spray username --targets 192.168.1.100 --service smb --usernames admin
```

### Why make this change?

This change enhances the penetration testing capabilities of the tool by adding service-specific commands that provide more targeted functionality. The refactoring improves code organization and maintainability while expanding the tool's feature set to include more comprehensive testing options for common network services.