### PR TITLE
Port Scan Validation Functionaility

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -9,6 +9,8 @@ import (
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 	// Internal
 	discover "github.com/Method-Security/networkscan/internal/discover"
+	discoverport "github.com/Method-Security/networkscan/internal/discover/port"
+
 	// External
 	privileges "github.com/projectdiscovery/naabu/v2/pkg/privileges"
 	cobra "github.com/spf13/cobra"
@@ -152,12 +154,45 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			validate, err := cmd.Flags().GetBool("validate")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			var validateHostname *string
+			var validateAttemptTimeout *int
+			var validateThreads *int
+			if validate {
+				// Validate hostname
+				validateHostnameString, err := cmd.Flags().GetString("validate-hostname")
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
+				}
+				if validateHostnameString != "" {
+					validateHostname = &validateHostnameString
+				}
+				// Validate attempt timeout
+				validateAttemptTimeoutInt, err := cmd.Flags().GetInt("validate-attempt-timeout")
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
+				}
+				validateAttemptTimeout = &validateAttemptTimeoutInt
+				// Validate threads
+				validateThreadsInt, err := cmd.Flags().GetInt("validate-threads")
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
+				}
+				validateThreads = &validateThreadsInt
+			}
 
 			// Set Config
-			config := getDiscoverPortConfig(target, ports, topPorts, threads, scanTypeEnum)
+			config := getDiscoverPortConfig(target, ports, topPorts, threads, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads)
 
 			// Generate the report
-			report, err := discover.RunPortScan(cmd.Context(), config)
+			report, err := discoverport.RunPortScan(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -170,6 +205,10 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverPortCmd.Flags().String("top-ports", "", "Scan the top N most common TCP ports (options: full, 100, 1000)")
 	discoverPortCmd.Flags().Int("threads", 25, "Number of concurrent threads to use during port scanning")
 	discoverPortCmd.Flags().String("scan-type", "SYN", "Port scan type: SYN (default, requires root) or CONNECT")
+	discoverPortCmd.Flags().Bool("validate", false, "Validate open ports by using service detection techniques")
+	discoverPortCmd.Flags().String("validate-hostname", "", "Hostname to validate against (e.g., example.com)")
+	discoverPortCmd.Flags().Int("validate-attempt-timeout", 10, "Timeout in seconds for each service detection attempt")
+	discoverPortCmd.Flags().Int("validate-threads", 0, "Number of concurrent threads to use during service detection")
 
 	// Mark Required Flags
 	_ = discoverPortCmd.MarkFlagRequired("target")
@@ -304,14 +343,25 @@ func (a *NetworkScan) InitDiscoverCommand() {
 
 // getDiscoverPortConfig creates a configuration for port scanning with the provided parameters.
 // It handles both specific port ranges and top ports scanning modes.
-func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, scanType discoverfern.PortScanType) discoverfern.DiscoverPortConfig {
-	return discoverfern.DiscoverPortConfig{
+func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int) discoverfern.DiscoverPortConfig {
+	config := discoverfern.DiscoverPortConfig{
 		Target:   target,
 		Ports:    &ports,
 		TopPorts: &topPorts,
 		Threads:  threads,
 		ScanType: scanType,
+		Validate: validate,
 	}
+	if validateHostname != nil {
+		config.ValidateHostname = validateHostname
+	}
+	if validateAttemptTimeout != nil {
+		config.ValidateAttemptTimeout = validateAttemptTimeout
+	}
+	if validateThreads != nil {
+		config.ValidateThreads = validateThreads
+	}
+	return config
 }
 
 // getDiscoverServiceConfig creates a configuration for service fingerprinting with the provided parameters.

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -27,6 +27,10 @@ types:
       topPorts: optional<string>
       threads: integer
       scanType: PortScanType
+      validate: boolean
+      validateHostname: optional<string>
+      validateAttemptTimeout: optional<integer>
+      validateThreads: optional<integer>
   # Final report
   DiscoverPortReport:
     properties:

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -1,4 +1,3 @@
-// Package discover implements network discovery functionality for finding live hosts and services.
 package discover
 
 import (
@@ -20,11 +19,19 @@ import (
 // RunPortScan performs a port scan on the specified target using the provided configuration.
 // It returns a report containing discovered open ports and any errors encountered during the process.
 func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*discoverfern.DiscoverPortReport, error) {
+
 	errors := []string{}
 
 	portscanResult, err := getPortScan(ctx, config)
 	if err != nil {
 		errors = append(errors, err.Error())
+	}
+
+	// Filter ports by service validation if requested
+	if config.Validate {
+		validatedPorts, validationErrors := validatePortScan(ctx, config, portscanResult)
+		portscanResult = validatedPorts
+		errors = append(errors, validationErrors...)
 	}
 
 	return &discoverfern.DiscoverPortReport{

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -5,22 +5,34 @@ import (
 	"context"
 	"flag"
 	"os"
+	"strconv"
+	"strings"
 
 	// Generated
 	common "github.com/Method-Security/networkscan/generated/go/common"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 
 	// External
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	goflags "github.com/projectdiscovery/goflags"
 	result "github.com/projectdiscovery/naabu/v2/pkg/result"
 	runner "github.com/projectdiscovery/naabu/v2/pkg/runner"
 )
 
+var requiredPorts = []string{"1", "65535"}
+
 // RunPortScan performs a port scan on the specified target using the provided configuration.
 // It returns a report containing discovered open ports and any errors encountered during the process.
 func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*discoverfern.DiscoverPortReport, error) {
-
+	log := svc1log.FromContext(ctx)
 	errors := []string{}
+
+	log.Info("Running port scan", svc1log.SafeParam("validate", config.Validate))
+
+	// Ensure required ports are included in the scan if validation is enabled
+	if config.Validate {
+		config = ensureRequiredPorts(config, requiredPorts)
+	}
 
 	portscanResult, err := getPortScan(ctx, config)
 	if err != nil {
@@ -29,6 +41,16 @@ func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*
 
 	// Filter ports by service validation if requested
 	if config.Validate {
+		// Check if either of the required ports are open
+		if !hasOpenRequiredPorts(portscanResult, requiredPorts) {
+			log.Info("Required validation ports are closed, skipping validation", svc1log.SafeParam("requiredPorts", requiredPorts))
+			// Required ports are not open, consider everything validated (skip validation)
+			return &discoverfern.DiscoverPortReport{
+				Config: &config, Result: &discoverfern.DiscoverPortResult{Sockets: portscanResult}, Errors: errors}, nil
+		}
+		log.Info("Required validation ports are open, proceeding with validation", svc1log.SafeParam("requiredPorts", requiredPorts))
+
+		// Required ports are open, proceed with validation
 		validatedPorts, validationErrors := validatePortScan(ctx, config, portscanResult)
 		portscanResult = validatedPorts
 		errors = append(errors, validationErrors...)
@@ -110,6 +132,63 @@ func parsePortScanResult(result *result.HostResult) *discoverfern.SocketDetails 
 		Ports: ports,
 	}
 	return &host
+}
+
+// ensureRequiredPorts modifies the scan configuration to include required ports
+func ensureRequiredPorts(config discoverfern.DiscoverPortConfig, requiredPorts []string) discoverfern.DiscoverPortConfig {
+	// If specific ports are already configured, add required ports to them
+	if config.Ports != nil && *config.Ports != "" {
+		existingPorts := *config.Ports
+		for _, port := range requiredPorts {
+			if !strings.Contains(existingPorts, port) {
+				existingPorts += "," + port
+			}
+		}
+		config.Ports = &existingPorts
+	} else if config.TopPorts != nil {
+		// If using top ports, we need to switch to specific ports that include required ports
+		requiredPortsStr := ""
+		for i, port := range requiredPorts {
+			if i > 0 {
+				requiredPortsStr += ","
+			}
+			requiredPortsStr += port
+		}
+		config.Ports = &requiredPortsStr
+		// Keep TopPorts as well, naabu will scan both
+	} else {
+		// No specific ports configured, add required ports
+		requiredPortsStr := ""
+		for i, port := range requiredPorts {
+			if i > 0 {
+				requiredPortsStr += ","
+			}
+			requiredPortsStr += port
+		}
+		config.Ports = &requiredPortsStr
+	}
+
+	return config
+}
+
+// hasOpenRequiredPorts checks if any of the required ports (as strings) are open in the scan results
+func hasOpenRequiredPorts(scanResults []*discoverfern.SocketDetails, requiredPorts []string) bool {
+	requiredPortsMap := make(map[string]bool)
+	for _, port := range requiredPorts {
+		requiredPortsMap[port] = true
+	}
+
+	for _, socket := range scanResults {
+		if socket != nil && socket.Ports != nil {
+			for _, port := range socket.Ports {
+				if port != nil && requiredPortsMap[strconv.Itoa(port.Port)] {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 // hideOsArgsFromNaabu prevents Naabu from processing command line arguments.

--- a/internal/discover/port/validate.go
+++ b/internal/discover/port/validate.go
@@ -1,0 +1,192 @@
+package discover
+
+import (
+	// Standard
+	"context"
+	"runtime"
+	"strings"
+	"sync"
+
+	// Generated
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+
+	// Internal
+	discover "github.com/Method-Security/networkscan/internal/discover"
+
+	// External
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// validatePortScan verifies that discovered ports actually have legitimate services running on them.
+//
+// Many port scanners report false positives - ports that appear open but don't actually host services,
+// or services that are blocked by CDNs. This function performs service fingerprinting on each
+// discovered port to confirm genuine service availability and filters out protected or non-responsive endpoints.
+//
+// Validation steps:
+// 1. Performs service fingerprinting on each discovered port
+// 2. Filters out ports that don't respond to service detection probes
+// 3. Detects and removes CDN protected services that return blocking responses
+// 4. Returns only sockets containing ports with confirmed active services
+func validatePortScan(ctx context.Context, config discoverfern.DiscoverPortConfig, sockets []*discoverfern.SocketDetails) ([]*discoverfern.SocketDetails, []string) {
+	log := svc1log.FromContext(ctx)
+	log.Info("Validating ports", svc1log.SafeParam("threads", config.ValidateThreads))
+
+	var errorsMutex sync.Mutex
+	errors := []string{}
+	validatedSockets := []*discoverfern.SocketDetails{}
+
+	// Determine number of validation threads (use CPU cores if 0 or not specified)
+	maxThreads := runtime.NumCPU()
+	if config.ValidateThreads != nil && *config.ValidateThreads > 0 {
+		maxThreads = *config.ValidateThreads
+	}
+
+	for _, socket := range sockets {
+		if socket == nil || socket.Ports == nil {
+			continue
+		}
+
+		var portsMutex sync.Mutex
+		validatedPorts := []*discoverfern.PortDetails{}
+
+		// Create channel for work distribution
+		portChan := make(chan *discoverfern.PortDetails, len(socket.Ports))
+		var wg sync.WaitGroup
+
+		// Start worker goroutines
+		for i := 0; i < maxThreads && i < len(socket.Ports); i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for port := range portChan {
+					log.Info("Validating port", svc1log.SafeParam("port", port.Port))
+
+					// Use RunServiceFingerprint to check if there's a service on this port
+					var targetStr string
+					if config.ValidateHostname != nil {
+						targetStr = *config.ValidateHostname
+					} else {
+						targetStr = socket.Ip
+					}
+					serviceConfig := discoverfern.DiscoverServiceConfig{
+						Target:  targetStr,
+						Port:    port.Port,
+						Timeout: *config.ValidateAttemptTimeout,
+					}
+
+					serviceReport, err := discover.RunServiceFingerprint(ctx, serviceConfig)
+					if err != nil {
+						// Don't fail validation on errors, just log them
+						errorsMutex.Lock()
+						errors = append(errors, err.Error())
+						errorsMutex.Unlock()
+						continue
+					}
+
+					// If we found any services on this port, check if they're real services or just CDN responses
+					if serviceReport != nil && serviceReport.Result != nil && serviceReport.Result.Services != nil && len(serviceReport.Result.Services) > 0 {
+						hasValidService := false
+						for _, service := range serviceReport.Result.Services {
+							// Skip services that are only CDN responses
+							if !isCDNResponse(ctx, service) {
+								hasValidService = true
+								break
+							}
+						}
+
+						if hasValidService {
+							log.Info("Valid service detected", svc1log.SafeParam("port", port.Port))
+							// Valid service detected - keep this port
+							portsMutex.Lock()
+							validatedPorts = append(validatedPorts, port)
+							portsMutex.Unlock()
+						} else {
+							log.Info("Only CDN responses detected, filtering out port", svc1log.SafeParam("port", port.Port))
+						}
+					}
+				}
+			}()
+		}
+
+		// Send all ports to workers
+		for _, port := range socket.Ports {
+			if port != nil {
+				portChan <- port
+			}
+		}
+		close(portChan)
+
+		// Wait for all workers to complete
+		wg.Wait()
+
+		// Only include the socket if it has validated ports
+		if len(validatedPorts) > 0 {
+			validatedSocket := &discoverfern.SocketDetails{
+				Host:  socket.Host,
+				Ip:    socket.Ip,
+				Ports: validatedPorts,
+			}
+			validatedSockets = append(validatedSockets, validatedSocket)
+		}
+	}
+
+	return validatedSockets, errors
+}
+
+// isCDNResponse detects if a service response indicates a CDN blocking access.
+// It checks for common patterns in HTTP/HTTPS responses that indicate CDN protection.
+func isCDNResponse(ctx context.Context, service *discoverfern.ServiceDetails) bool {
+	if service == nil || service.Metadata == nil {
+		return false
+	}
+
+	protocol := strings.ToLower(string(service.Protocol))
+
+	// Only check HTTP and HTTPS services
+	if protocol != "http" && protocol != "https" {
+		return false
+	}
+
+	// Check for specific CDN indicators regardless of status code
+	return hasCDNIndicators(ctx, service.Port, service.Metadata)
+}
+
+// hasCDNIndicators checks for specific headers and content patterns that indicate CDN responses.
+func hasCDNIndicators(ctx context.Context, port int, metadata map[string]string) bool {
+	log := svc1log.FromContext(ctx)
+	if metadata == nil {
+		return false
+	}
+	log.Info("Checking for CDN indicators", svc1log.SafeParam("port", port), svc1log.SafeParam("metadata", metadata))
+
+	// Create case-insensitive metadata map for lookups
+	normalizedMetadata := make(map[string]string)
+	for key, value := range metadata {
+		normalizedMetadata[strings.ToLower(key)] = value
+	}
+
+	// Check response status patterns that commonly indicate firewall blocking
+	firewallStatusPatterns := []string{
+		"service unavailable",
+		"forbidden",
+		"access denied",
+		"blocked",
+		"unauthorized",
+		"too many requests",
+		"rate limit",
+		"security block",
+	}
+	if status, exists := normalizedMetadata["status"]; exists {
+		status = strings.ToLower(status)
+
+		for _, pattern := range firewallStatusPatterns {
+			if strings.Contains(status, pattern) {
+				log.Info("CDN detected via status", svc1log.SafeParam("port", port), svc1log.SafeParam("status", status), svc1log.SafeParam("pattern", pattern))
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
### TL;DR

Added port validation functionality to the port scanning feature, allowing users to verify if discovered ports actually have services running on them.

### What changed?

- Added new `--validate` flag to the port scanning command to enable service validation
- Added supporting flags for validation configuration:
  - `--validate-hostname`: Hostname to validate against
  - `--validate-attempt-timeout`: Timeout for service detection attempts (default: 10s)
  - `--validate-threads`: Number of concurrent threads for validation
- Implemented service validation logic that filters out ports that don't respond to service detection probes
- Added CDN response detection to avoid false positives from security services
- Moved port scanning functionality to a dedicated package (`internal/discover/port`)
- Updated the Fern definition to include new validation configuration options