### PR TITLE
Make usernameLists optional in SprayTarget

### DIFF
--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -117,7 +117,7 @@ types:
       service: SprayTargetService
 
       # Username enumeration configuration
-      usernameLists: list<WordlistType>
+      usernameLists: optional<list<WordlistType>>
       usernames: optional<list<string>>
 
       # Service-specific configuration


### PR DESCRIPTION
### TL;DR

Made `usernameLists` field optional in the spray target configuration.

### What changed?

Updated the `usernameLists` field in the `SprayTarget` type from `list<WordlistType>` to `optional<list<WordlistType>>`, making it no longer required when configuring a spray target.

### How to test?

1. Create a spray target configuration without specifying the `usernameLists` field
2. Verify that the configuration is accepted and processed correctly
3. Ensure existing configurations with `usernameLists` continue to work as expected

### Why make this change?

This change provides more flexibility when configuring spray targets. Users can now omit the `usernameLists` field when it's not needed, particularly when they're using the already-optional `usernames` field instead. This makes the API more intuitive and reduces unnecessary requirements when setting up spray targets.