### PR TITLE
Refactor spray configuration to use unified PentestSprayConfig

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -696,7 +696,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 // ============================================================================
 
 // createSprayPasswordConfig creates a SprayPasswordConfig from command flags
-func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []string, service pentest.SprayTargetService) (*pentest.SprayPasswordConfig, error) {
+func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []string, service pentest.SprayTargetService) (*pentest.PentestSprayConfig, error) {
 	// Authentication flags
 	usernames, err := cmd.Flags().GetStringSlice("usernames")
 	if err != nil {
@@ -803,7 +803,7 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 }
 
 // createSprayUsernameConfig creates a SprayUsernameConfig from command flags
-func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []string, service pentest.SprayTargetService) (*pentest.SprayUsernameConfig, error) {
+func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []string, service pentest.SprayTargetService) (*pentest.PentestSprayConfig, error) {
 	// Authentication flags
 	usernames, err := cmd.Flags().GetStringSlice("usernames")
 	if err != nil {
@@ -872,7 +872,7 @@ func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []st
 }
 
 // getSprayPasswordConfig creates a configuration for password spray operations with the provided parameters.
-func getSprayPasswordConfig(targets []string, service pentest.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentest.WordlistType, passwordLists []pentest.WordlistType, domain string, timeout int, sleep int, retries int, stopFirstSuccess bool, successfulOnly bool) *pentest.SprayPasswordConfig {
+func getSprayPasswordConfig(targets []string, service pentest.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentest.WordlistType, passwordLists []pentest.WordlistType, domain string, timeout int, sleep int, retries int, stopFirstSuccess bool, successfulOnly bool) *pentest.PentestSprayConfig {
 	// Create config
 	var usernameFilePtr, passwordFilePtr, domainPtr *string
 	if usernameFile != "" {
@@ -885,43 +885,49 @@ func getSprayPasswordConfig(targets []string, service pentest.SprayTargetService
 		domainPtr = &domain
 	}
 
-	return &pentest.SprayPasswordConfig{
-		Targets:            targets,
-		Service:            service,
-		Usernames:          usernames,
-		Passwords:          passwords,
-		UsernameFile:       usernameFilePtr,
-		PasswordFile:       passwordFilePtr,
-		UsernameLists:      usernameLists,
-		PasswordLists:      passwordLists,
-		Domain:             domainPtr,
-		Timeout:            timeout,
-		Sleep:              sleep,
-		Retries:            retries,
-		StopOnFirstSuccess: stopFirstSuccess,
-		SuccessfulOnly:     successfulOnly,
-		ContinueOnError:    true,
+	return &pentest.PentestSprayConfig{
+		SprayMode: strings.ToLower(string(pentest.SprayModePassword)),
+		Password: &pentest.SprayPasswordConfig{
+			Targets:            targets,
+			Service:            service,
+			Usernames:          usernames,
+			Passwords:          passwords,
+			UsernameFile:       usernameFilePtr,
+			PasswordFile:       passwordFilePtr,
+			UsernameLists:      usernameLists,
+			PasswordLists:      passwordLists,
+			Domain:             domainPtr,
+			Timeout:            timeout,
+			Sleep:              sleep,
+			Retries:            retries,
+			StopOnFirstSuccess: stopFirstSuccess,
+			SuccessfulOnly:     successfulOnly,
+			ContinueOnError:    true,
+		},
 	}
 }
 
 // getSprayUsernameConfig creates a configuration for username enumeration operations with the provided parameters.
-func getSprayUsernameConfig(targets []string, service pentest.SprayTargetService, usernameLists []pentest.WordlistType, usernames []string, domain string, timeout int, sleep int, retries int) *pentest.SprayUsernameConfig {
+func getSprayUsernameConfig(targets []string, service pentest.SprayTargetService, usernameLists []pentest.WordlistType, usernames []string, domain string, timeout int, sleep int, retries int) *pentest.PentestSprayConfig {
 	// Create config
 	var domainPtr *string
 	if domain != "" {
 		domainPtr = &domain
 	}
 
-	return &pentest.SprayUsernameConfig{
-		Targets:         targets,
-		Service:         service,
-		UsernameLists:   usernameLists,
-		Usernames:       usernames,
-		Domain:          domainPtr,
-		Timeout:         timeout,
-		Sleep:           sleep,
-		Retries:         retries,
-		ContinueOnError: true,
+	return &pentest.PentestSprayConfig{
+		SprayMode: strings.ToLower(string(pentest.SprayModeUsername)),
+		Username: &pentest.SprayUsernameConfig{
+			Targets:         targets,
+			Service:         service,
+			UsernameLists:   usernameLists,
+			Usernames:       usernames,
+			Domain:          domainPtr,
+			Timeout:         timeout,
+			Sleep:           sleep,
+			Retries:         retries,
+			ContinueOnError: true,
+		},
 	}
 }
 

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -70,7 +70,6 @@ types:
     properties:
       target: string # Target host:port
       service: SprayTargetService
-      operationType: SprayMode # PASSWORD or USERNAME to distinguish operation type
       attempts: list<SprayAttempt>
       statistics: SprayStatistics
       successfulCredentials: optional<list<Credential>>
@@ -98,7 +97,6 @@ types:
       timeout: integer
       sleep: integer
       retries: integer
-      concurrentTargets: optional<integer>
 
       # Behavior configuration
       stopOnFirstSuccess: boolean
@@ -132,25 +130,18 @@ types:
       continueOnError: boolean
 
   # Report Types (following three-part pattern: config, result, errors)
-  SprayPasswordReport:
-    properties:
-      config: SprayPasswordConfig
-      result: list<SprayTargetResult>
-      errors: optional<list<string>>
-
-  SprayUsernameReport:
-    properties:
-      config: SprayUsernameConfig
-      result: list<SprayTargetResult>
-      errors: optional<list<string>>
-
-  # Union for different spray modes (future extensibility)
-  SprayConfig:
+  PentestSprayConfig:
+    discriminant: SprayMode
     union:
       password: SprayPasswordConfig
       username: SprayUsernameConfig
 
-  SprayReport:
-    union:
-      password: SprayPasswordReport
-      username: SprayUsernameReport
+  PentestSprayResult:
+    properties:
+      result: optional<list<SprayTargetResult>>
+
+  PentestSprayReport:
+    properties:
+      config: PentestSprayConfig
+      result: PentestSprayResult
+      errors: optional<list<string>>

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -21,17 +21,17 @@ import (
 )
 
 // RunSprayPassword executes password spraying attacks against specified targets
-func (e *Engine) RunSprayPassword(ctx context.Context, config *pentest.SprayPasswordConfig) (*pentest.SprayPasswordReport, error) {
+func (e *Engine) RunSprayPassword(ctx context.Context, config *pentest.PentestSprayConfig) (*pentest.PentestSprayReport, error) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting password spray operation",
-		svc1log.SafeParam("targets", len(config.Targets)),
-		svc1log.SafeParam("service", config.Service))
+		svc1log.SafeParam("targets", len(config.Password.Targets)),
+		svc1log.SafeParam("service", config.Password.Service))
 
 	var errors []string
 	var targetResults []*pentest.SprayTargetResult
 
-	for _, target := range config.Targets {
-		result, err := e.runSprayPasswordForTarget(ctx, target, config)
+	for _, target := range config.Password.Targets {
+		result, err := e.runSprayPasswordForTarget(ctx, target, config.Password)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("Password spray failed for %s: %v", target, err))
 			continue
@@ -39,25 +39,27 @@ func (e *Engine) RunSprayPassword(ctx context.Context, config *pentest.SprayPass
 		targetResults = append(targetResults, result)
 	}
 
-	return &pentest.SprayPasswordReport{
+	return &pentest.PentestSprayReport{
 		Config: config,
-		Result: targetResults,
+		Result: &pentest.PentestSprayResult{
+			Result: targetResults,
+		},
 		Errors: errors,
 	}, nil
 }
 
 // RunSprayUsername executes username enumeration attacks against specified targets
-func (e *Engine) RunSprayUsername(ctx context.Context, config *pentest.SprayUsernameConfig) (*pentest.SprayUsernameReport, error) {
+func (e *Engine) RunSprayUsername(ctx context.Context, config *pentest.PentestSprayConfig) (*pentest.PentestSprayReport, error) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting username enumeration operation",
-		svc1log.SafeParam("targets", len(config.Targets)),
-		svc1log.SafeParam("service", config.Service))
+		svc1log.SafeParam("targets", len(config.Username.Targets)),
+		svc1log.SafeParam("service", config.Username.Service))
 
 	var errors []string
 	var targetResults []*pentest.SprayTargetResult
 
-	for _, target := range config.Targets {
-		result, err := e.runSprayUsernameForTarget(ctx, target, config)
+	for _, target := range config.Username.Targets {
+		result, err := e.runSprayUsernameForTarget(ctx, target, config.Username)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("Username enumeration failed for %s: %v", target, err))
 			continue
@@ -65,9 +67,11 @@ func (e *Engine) RunSprayUsername(ctx context.Context, config *pentest.SprayUser
 		targetResults = append(targetResults, result)
 	}
 
-	return &pentest.SprayUsernameReport{
+	return &pentest.PentestSprayReport{
 		Config: config,
-		Result: targetResults,
+		Result: &pentest.PentestSprayResult{
+			Result: targetResults,
+		},
 		Errors: errors,
 	}, nil
 }
@@ -140,7 +144,6 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 	return &pentest.SprayTargetResult{
 		Target:                fmt.Sprintf("%s:%d", host, port),
 		Service:               config.Service,
-		OperationType:         pentest.SprayModeUsername,
 		Attempts:              attempts,
 		Statistics:            statistics,
 		SuccessfulCredentials: validUsernames,
@@ -310,7 +313,6 @@ done:
 	return &pentest.SprayTargetResult{
 		Target:                fmt.Sprintf("%s:%d", host, port),
 		Service:               config.Service,
-		OperationType:         pentest.SprayModePassword,
 		Attempts:              attempts,
 		Statistics:            statistics,
 		SuccessfulCredentials: successfulCredentials,


### PR DESCRIPTION
### TL;DR

Refactored the pentest spray configuration structure to use a unified discriminated union approach.

### What changed?

- Replaced separate `SprayPasswordConfig` and `SprayUsernameConfig` with a unified `PentestSprayConfig` that uses a discriminant pattern
- Updated return types to use the new `PentestSprayReport` structure
- Removed redundant `operationType` field from `SprayTargetResult`
- Removed unused `concurrentTargets` field from configuration
- Modified the `getSprayPasswordConfig` and `getSprayUsernameConfig` functions to return the new unified config type
- Updated the `RunSprayPassword` and `RunSprayUsername` functions to work with the new configuration structure

### How to test?

1. Run password spray operations using the CLI to verify they still work correctly
2. Run username enumeration operations to ensure they function as expected
3. Verify that the results are properly formatted and contain all the expected information

### Why make this change?

This refactoring improves the API design by using a discriminated union pattern, which makes the code more maintainable and type-safe. The unified configuration structure provides better consistency between password spray and username enumeration operations while maintaining clear separation of concerns. This change also simplifies future extensions to the spray functionality.