### PR TITLE
Add successful-only flag and make domain required for username spray

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -109,10 +109,12 @@ func (a *NetworkScan) createUsernameSprayCommand(parent *cobra.Command) {
 	usernameCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
 	usernameCmd.Flags().Int("sleep", 0, "Delay between attempts in seconds")
 	usernameCmd.Flags().Int("retries", 1, "Number of retries per username")
+	usernameCmd.Flags().Bool("successful-only", false, "Only show successful username enumerations in output")
 
 	// Mark required flags
 	_ = usernameCmd.MarkFlagRequired("targets")
 	_ = usernameCmd.MarkFlagRequired("service")
+	_ = usernameCmd.MarkFlagRequired("domain")
 
 	parent.AddCommand(usernameCmd)
 }
@@ -865,8 +867,13 @@ func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []st
 		return nil, fmt.Errorf("retries must be at least 1")
 	}
 
+	successfulOnly, err := cmd.Flags().GetBool("successful-only")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get successful-only: %v", err)
+	}
+
 	// Set Config
-	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, domain, timeout, sleep, retries)
+	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, domain, timeout, sleep, retries, successfulOnly)
 
 	return config, nil
 }
@@ -908,13 +915,7 @@ func getSprayPasswordConfig(targets []string, service pentest.SprayTargetService
 }
 
 // getSprayUsernameConfig creates a configuration for username enumeration operations with the provided parameters.
-func getSprayUsernameConfig(targets []string, service pentest.SprayTargetService, usernameLists []pentest.WordlistType, usernames []string, domain string, timeout int, sleep int, retries int) *pentest.PentestSprayConfig {
-	// Create config
-	var domainPtr *string
-	if domain != "" {
-		domainPtr = &domain
-	}
-
+func getSprayUsernameConfig(targets []string, service pentest.SprayTargetService, usernameLists []pentest.WordlistType, usernames []string, domain string, timeout int, sleep int, retries int, successfulOnly bool) *pentest.PentestSprayConfig {
 	return &pentest.PentestSprayConfig{
 		SprayMode: strings.ToLower(string(pentest.SprayModeUsername)),
 		Username: &pentest.SprayUsernameConfig{
@@ -922,11 +923,12 @@ func getSprayUsernameConfig(targets []string, service pentest.SprayTargetService
 			Service:         service,
 			UsernameLists:   usernameLists,
 			Usernames:       usernames,
-			Domain:          domainPtr,
+			Domain:          domain,
 			Timeout:         timeout,
 			Sleep:           sleep,
 			Retries:         retries,
 			ContinueOnError: true,
+			SuccessfulOnly:  successfulOnly,
 		},
 	}
 }

--- a/fern/definition/common/protocol/smb.yml
+++ b/fern/definition/common/protocol/smb.yml
@@ -1,0 +1,80 @@
+types:
+  # SMB Protocol ENUMs
+  SmbVersion:
+    enum:
+      - SMB1
+      - SMB2_0
+      - SMB2_1
+      - SMB3_0
+      - SMB3_0_2
+      - SMB3_1_1
+
+  AuthMethod:
+    enum:
+      - NTLM
+      - KERBEROS
+
+  ShareType:
+    enum:
+      - DISK
+      - PRINT
+      - DEVICE
+      - IPC
+      - UNKNOWN
+
+  ShareAccess:
+    enum:
+      - READ_ONLY
+      - READ_WRITE
+      - NO_ACCESS
+      - UNKNOWN
+
+  # Core SMB Protocol Objects
+  SmbServerInfo:
+    properties:
+      # Basic server identification
+      serverName: optional<string>
+      domain: optional<string>
+      netBIOSDomainName: optional<string>
+      workgroup: optional<string>
+      
+      # Version information
+      osVersion: optional<string>          # Parsed/human-readable version (e.g., "Windows Server 2019")
+      rawOsVersion: optional<string>       # Raw version from NTLM challenge (e.g., "Windows Server 2019 Build 17763")
+      lanManagerVersion: optional<string>  # LAN Manager version if available
+      
+      # SMB protocol details
+      smbVersion: optional<SmbVersion>             # Primary SMB version in use
+      supportedSmbVersions: optional<list<SmbVersion>>  # All supported SMB versions
+      
+      # Security capabilities
+      signingRequired: optional<boolean>
+      signingEnabled: optional<boolean>
+      encryptionSupported: optional<boolean>
+      encryptionRequired: optional<boolean>
+      
+      # Additional capabilities
+      capabilities: optional<list<string>>
+
+  SmbShare:
+    properties:
+      name: string
+      type: ShareType
+      comment: optional<string>
+      accessible: boolean
+      access: optional<ShareAccess>
+      anonymousAccess: boolean
+      guestAccess: boolean
+      hidden: optional<boolean>
+
+  # Authentication result for any SMB operation
+  SmbAuthAttempt:
+    properties:
+      username: string
+      password: string
+      domain: optional<string>
+      success: boolean
+      message: string
+      isAdmin: optional<boolean>  # For successful auths, indicates admin privileges
+      timestamp: datetime
+      errorCode: optional<string> # SMB/NTLM error code if applicable

--- a/fern/definition/common/protocol/ssh.yml
+++ b/fern/definition/common/protocol/ssh.yml
@@ -1,0 +1,119 @@
+types:
+  # SSH Protocol ENUMs
+  SshAuthMethod:
+    enum:
+      - PASSWORD
+      - PUBLIC_KEY
+
+  HostKeyAlgorithm:
+    enum:
+      - SSHDSS
+      - SSHRSA
+      - RSASHA2256
+      - RSASHA2512
+      - ECDSASHA2NISTP256
+      - ECDSASHA2NISTP384
+      - ECDSASHA2NISTP521
+      - SSHED25519
+      - ECDSASHA2NISTP224
+      - ED25519SHA256
+
+  KeyExchangeAlgorithm:
+    enum:
+      - SNTRUP761X25519SHA512OPENSSH
+      - CURVE25519SHA256
+      - CURVE25519SHA256LIBSSH
+      - ECDHSHA2NISTP256
+      - ECDHSHA2NISTP384
+      - ECDHSHA2NISTP521
+      - ECDHSHA2NISTP224
+      - DIFFIEHELLMANGROUPEXCHANGESHA256
+      - DIFFIEHELLMANGROUPEXCHANGESHA512
+      - DIFFIEHELLMANGROUP16SHA512
+      - DIFFIEHELLMANGROUP18SHA512
+      - DIFFIEHELLMANGROUP14SHA256
+      - DIFFIEHELLMANGROUP14SHA512
+      - DIFFIEHELLMANGROUP1SHA1
+      - DIFFIEHELLMANGROUP1SHA256
+      - KEXSTRICTSV00OPENSSH
+      - X25519SHA256LIBSSH
+      - X448SHA512OPENSSH
+      - CURVE25519SHA512OPENSSH
+
+  CipherAlgorithm:
+    enum:
+      - CHACHA20POLY1305OPENSSH
+      - AES128CTR
+      - AES192CTR
+      - AES256CTR
+      - AES128GCMOPENSSH
+      - AES256GCMOPENSSH
+      - AES128CBC
+      - AES192CBC
+      - AES256CBC
+      - THREEDESCBC
+      - BLOWFISHCBC
+      - AES128CBCOPENSSL
+      - AES128GCM
+      - AES256GCM
+
+  MACAlgorithm:
+    enum:
+      - UMAC1
+      - UMAC64ETMOPENSSH
+      - UMAC128ETMOPENSSH
+      - HMACSHA2256ETMOPENSSH
+      - HMACSHA2512ETMOPENSSH
+      - HMACSHA1ETMOPENSSH
+      - UMAC64OPENSSH
+      - UMAC128OPENSSH
+      - HMACSHA2256
+      - HMACSHA2512
+      - HMACSHA1
+      - HMACMD5
+      - HMACRIPEMD160
+      - HMACSHA3256
+      - HMACSHA3512
+
+  # Core SSH Protocol Objects
+  SshServerInfo:
+    properties:
+      # Basic server identification
+      serverVersion: optional<string>
+      target: optional<string>
+      
+      # Protocol capabilities
+      supportedAuthMethods: optional<list<SshAuthMethod>>
+      supportedCiphers: optional<list<CipherAlgorithm>>
+      supportedMacs: optional<list<MACAlgorithm>>
+      supportedKex: optional<list<KeyExchangeAlgorithm>>
+      hostKeyAlgos: optional<list<HostKeyAlgorithm>>
+      
+      # Raw protocol information
+      rawASCII: optional<string>
+
+  # Authentication result for any SSH operation  
+  SshAuthAttempt:
+    properties:
+      username: string
+      password: string
+      success: boolean
+      message: string
+      timestamp: datetime
+
+  # Command execution result
+  SshCommandExecution:
+    properties:
+      command: string
+      output: string
+      exitCode: optional<integer>
+      timestamp: datetime
+
+  # File transfer result (for future use)
+  SshFileTransfer:
+    properties:
+      localPath: string
+      remotePath: string
+      direction: string # "upload" or "download"  
+      success: boolean
+      timestamp: datetime

--- a/fern/definition/discover/domain.yml
+++ b/fern/definition/discover/domain.yml
@@ -1,10 +1,14 @@
+imports:
+  smbProtocol: ../common/protocol/smb.yml
+
 types:
   # Common Objects
   DomainControllerInfo:
     properties:
       hostname: optional<string>
       ipAddress: optional<string>
-      serverVersion: optional<string>
+      # Use common SMB server info for consistency across modules
+      smbServerInfo: optional<smbProtocol.SmbServerInfo>
 
   DomainInfo:
     properties:

--- a/fern/definition/enumerate/smb/smb.yml
+++ b/fern/definition/enumerate/smb/smb.yml
@@ -1,76 +1,20 @@
 imports:
-  pentestSmb: ../../pentest/smb/smb.yml
+  smbProtocol: ../../common/protocol/smb.yml
 
 types:
-  # Authentication methods
-  AuthMethod:
-    enum:
-      - NTLM
-      - KERBEROS
-  
-  
-  # Share types
-  ShareType:
-    enum:
-      - DISK
-      - PRINT
-      - DEVICE
-      - IPC
-      - UNKNOWN
-  
-  # SMB versions
-  SmbVersion:
-    enum:
-      - SMB1
-      - SMB2_0
-      - SMB2_1
-      - SMB3_0
-      - SMB3_0_2
-      - SMB3_1_1
-  
-  # Share access levels
-  ShareAccess:
-    enum:
-      - READ_ONLY
-      - READ_WRITE
-      - NO_ACCESS
-      - UNKNOWN
-  
-  # SMB share information
-  SmbShare:
-    properties:
-      name: string
-      type: ShareType
-      comment: optional<string>
-      accessible: boolean
-      access: optional<ShareAccess>
-      anonymousAccess: boolean
-      guestAccess: boolean
-  
-  # Server information
-  ServerInfo:
-    properties:
-      workgroup: optional<string>
-      domain: optional<string>
-      serverName: optional<string>
-      osVersion: optional<string>
-      lanManagerVersion: optional<string>
-      capabilities: optional<list<string>>
-  
-  
   # Main enumeration details
   EnumerateSmbDetails:
     properties:
       target: string
-      version: optional<SmbVersion>
-      supportedVersions: optional<list<SmbVersion>>
-      shares: optional<list<SmbShare>>
-      authMethods: optional<list<AuthMethod>>
-      serverInfo: optional<ServerInfo>
+      version: optional<smbProtocol.SmbVersion>
+      supportedVersions: optional<list<smbProtocol.SmbVersion>>
+      shares: optional<list<smbProtocol.SmbShare>>
+      authMethods: optional<list<smbProtocol.AuthMethod>>
+      serverInfo: optional<smbProtocol.SmbServerInfo>
       anonymousLoginAllowed: optional<boolean>
       guestLoginAllowed: optional<boolean>
       nullSessionAllowed: optional<boolean>
       signingRequired: optional<boolean>
       encryptionSupported: optional<boolean>
-      authAttempts: optional<list<pentestSmb.AuthAttempt>>
+      authAttempts: optional<list<smbProtocol.SmbAuthAttempt>>
       rawResponse: optional<string>

--- a/fern/definition/enumerate/ssh/ssh.yml
+++ b/fern/definition/enumerate/ssh/ssh.yml
@@ -1,83 +1,8 @@
+imports:
+  sshProtocol: ../../common/protocol/ssh.yml
+
 types:
-  # ENUMs
-  AuthMethod:
-    enum:
-      - PASSWORD
-      - PUBLIC_KEY
-  HostKeyAlgorithm:
-    enum:
-      - SSHDSS
-      - SSHRSA
-      - RSASHA2256
-      - RSASHA2512
-      - ECDSASHA2NISTP256
-      - ECDSASHA2NISTP384
-      - ECDSASHA2NISTP521
-      - SSHED25519
-      - ECDSASHA2NISTP224
-      - ED25519SHA256
-  KeyExchangeAlgorithm:
-    enum:
-      - SNTRUP761X25519SHA512OPENSSH
-      - CURVE25519SHA256
-      - CURVE25519SHA256LIBSSH
-      - ECDHSHA2NISTP256
-      - ECDHSHA2NISTP384
-      - ECDHSHA2NISTP521
-      - ECDHSHA2NISTP224
-      - DIFFIEHELLMANGROUPEXCHANGESHA256
-      - DIFFIEHELLMANGROUPEXCHANGESHA512
-      - DIFFIEHELLMANGROUP16SHA512
-      - DIFFIEHELLMANGROUP18SHA512
-      - DIFFIEHELLMANGROUP14SHA256
-      - DIFFIEHELLMANGROUP14SHA512
-      - DIFFIEHELLMANGROUP1SHA1
-      - DIFFIEHELLMANGROUP1SHA256
-      - KEXSTRICTSV00OPENSSH
-      - X25519SHA256LIBSSH
-      - X448SHA512OPENSSH
-      - CURVE25519SHA512OPENSSH
-  CipherAlgorithm:
-    enum:
-      - CHACHA20POLY1305OPENSSH
-      - AES128CTR
-      - AES192CTR
-      - AES256CTR
-      - AES128GCMOPENSSH
-      - AES256GCMOPENSSH
-      - AES128CBC
-      - AES192CBC
-      - AES256CBC
-      - THREEDESCBC
-      - BLOWFISHCBC
-      - AES128CBCOPENSSL
-      - AES128GCM
-      - AES256GCM
-  MACAlgorithm:
-    enum:
-      - UMAC1
-      - UMAC64ETMOPENSSH
-      - UMAC128ETMOPENSSH
-      - HMACSHA2256ETMOPENSSH
-      - HMACSHA2512ETMOPENSSH
-      - HMACSHA1ETMOPENSSH
-      - UMAC64OPENSSH
-      - UMAC128OPENSSH
-      - HMACSHA2256
-      - HMACSHA2512
-      - HMACSHA1
-      - HMACMD5
-      - HMACRIPEMD160
-      - HMACSHA3256
-      - HMACSHA3512
-  # Report structs
+  # SSH Enumeration Details - uses common protocol structures
   EnumerateSshDetails:
     properties:
-      target: string
-      version: optional<string>
-      authMethods: optional<list<AuthMethod>>
-      keyExchangeAlgos: optional<list<KeyExchangeAlgorithm>>
-      hostKeyAlgos: optional<list<HostKeyAlgorithm>>
-      ciphers: optional<list<CipherAlgorithm>>
-      macs: optional<list<MACAlgorithm>>
-      rawASCII: optional<string>
+      serverInfo: optional<sshProtocol.SshServerInfo>

--- a/fern/definition/pentest/smb/lsadump.yml
+++ b/fern/definition/pentest/smb/lsadump.yml
@@ -1,0 +1,41 @@
+types:
+  # LSA dump specific result types
+  LsaSecretEntry:
+    properties:
+      key: string
+      value: string
+
+  LsaSecret:
+    properties:
+      name: string
+      entries: list<LsaSecretEntry>
+      description: optional<string>
+
+  # DCC secrets (for future use)
+  DccSecret:
+    properties:
+      domain: string
+      username: string
+      hash: string
+
+  # Config Types
+  LsadumpConfig:
+    properties:
+      target: string
+      username: string
+      password: string
+      domain: optional<string>
+      timeout: integer
+
+  # Result Types
+  LsadumpResult:
+    properties:
+      lsaSecrets: optional<list<LsaSecret>>
+      dccSecrets: optional<list<DccSecret>>
+
+  # Report Types
+  LsadumpReport:
+    properties:
+      config: LsadumpConfig
+      result: LsadumpResult
+      errors: optional<list<string>>

--- a/fern/definition/pentest/smb/samdump.yml
+++ b/fern/definition/pentest/smb/samdump.yml
@@ -1,0 +1,29 @@
+types:
+  # SAM dump specific result types
+  SamSecret:
+    properties:
+      username: string
+      rid: integer
+      ntHash: string
+      lmHash: optional<string>
+
+  # Config Types
+  SamdumpConfig:
+    properties:
+      target: string
+      username: string
+      password: string
+      domain: optional<string>
+      timeout: integer
+
+  # Result Types  
+  SamdumpResult:
+    properties:
+      samSecrets: optional<list<SamSecret>>
+
+  # Report Types
+  SamdumpReport:
+    properties:
+      config: SamdumpConfig
+      result: SamdumpResult
+      errors: optional<list<string>>

--- a/fern/definition/pentest/smb/smb.yml
+++ b/fern/definition/pentest/smb/smb.yml
@@ -1,75 +1,19 @@
 imports:
   common: ../common.yml
+  smbProtocol: ../../common/protocol/smb.yml
+  samdump: ./samdump.yml
+  lsadump: ./lsadump.yml
 
 types:
-  # Server information from base SMB connection
-  SmbServerInfo:
-    properties:
-      serverName: optional<string>
-      domain: optional<string>
-      osVersion: optional<string>
-      signingRequired: optional<boolean>
-      encryptionSupported: optional<boolean>
-
-  # Authentication attempt information
-  AuthAttempt:
-    properties:
-      username: string
-      password: string
-      domain: optional<string> # Domain used for authentication attempt
-      success: boolean
-      message: string
-      isAdmin: optional<boolean> # For successful auths, check if user has admin privileges
-      timestamp: datetime
-
-  # SAM dump specific result types
-  SamSecret:
-    properties:
-      username: string
-      rid: integer
-      ntHash: string
-      lmHash: optional<string>
-
-  SamdumpDetails:
-    properties:
-      target: string
-      samSecrets: list<SamSecret>
-      errors: optional<list<string>>
-
-  # LSA dump specific result types
-  LsaSecretEntry:
-    properties:
-      key: string
-      value: string
-
-  LsaSecret:
-    properties:
-      name: string
-      entries: list<LsaSecretEntry>
-      description: optional<string>
-
-  LsadumpDetails:
-    properties:
-      target: string
-      lsaSecrets: list<LsaSecret>
-      errors: optional<list<string>>
-
-  # DCC secrets (future use)
-  DccSecret:
-    properties:
-      domain: string
-      username: string
-      hash: string
-
   # Main SMB pentest result that aggregates all activities
   PentestSmbDetails:
     properties:
       target: string
-      serverInfo: optional<SmbServerInfo> # Always extracted from base connection
-      authAttempts: optional<list<AuthAttempt>> # Only if auth attempts were made
-      successfulAuths: optional<list<AuthAttempt>> # Successful authentication attempts
-      samdumpDetails: optional<SamdumpDetails> # Only if samdump was performed
-      lsadumpDetails: optional<LsadumpDetails> # Only if lsadump was performed
+      serverInfo: optional<smbProtocol.SmbServerInfo> # Always extracted from base connection
+      authAttempts: optional<list<smbProtocol.SmbAuthAttempt>> # Only if auth attempts were made
+      successfulAuths: optional<list<smbProtocol.SmbAuthAttempt>> # Successful authentication attempts
+      samdumpDetails: optional<samdump.SamdumpResult> # Only if samdump was performed
+      lsadumpDetails: optional<lsadump.LsadumpResult> # Only if lsadump was performed
       errors: optional<list<string>>
 
   # Config for SMB pentest operations - extends general config
@@ -88,3 +32,7 @@ types:
       config: PentestSmbConfig
       result: list<PentestSmbDetails>
       errors: optional<list<string>>
+
+  # Legacy type aliases for backward compatibility during transition
+  AuthAttempt: smbProtocol.SmbAuthAttempt
+  SmbServerInfo: smbProtocol.SmbServerInfo

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -119,7 +119,7 @@ types:
       usernames: optional<list<string>>
 
       # Service-specific configuration
-      domain: optional<string>
+      domain: string
 
       # Attack configuration
       timeout: integer
@@ -128,6 +128,7 @@ types:
 
       # Behavior configuration
       continueOnError: boolean
+      successfulOnly: boolean
 
   # Report Types (following three-part pattern: config, result, errors)
   PentestSprayConfig:

--- a/fern/definition/pentest/ssh/ssh.yml
+++ b/fern/definition/pentest/ssh/ssh.yml
@@ -1,51 +1,17 @@
 imports:
   common: ../common.yml
+  sshProtocol: ../../common/protocol/ssh.yml
 
 types:
-  # Server information from base SSH connection
-  SshServerInfo:
-    properties:
-      serverVersion: optional<string>
-      supportedAuthMethods: optional<list<string>>
-      supportedCiphers: optional<list<string>>
-      supportedMacs: optional<list<string>>
-      supportedKex: optional<list<string>>
-
-  # Authentication attempt information
-  AuthAttempt:
-    properties:
-      username: string
-      password: string
-      success: boolean
-      message: string
-      timestamp: datetime
-
-  # Command execution result
-  CommandExecution:
-    properties:
-      command: string
-      output: string
-      exitCode: optional<integer>
-      timestamp: datetime
-
-  # File transfer result (for future use)
-  FileTransfer:
-    properties:
-      localPath: string
-      remotePath: string
-      direction: string # "upload" or "download"
-      success: boolean
-      timestamp: datetime
-
   # Main SSH pentest result that aggregates all activities
   PentestSshDetails:
     properties:
       target: string
-      serverInfo: optional<SshServerInfo> # Always extracted from base connection
-      authAttempts: optional<list<AuthAttempt>> # Only if auth attempts were made
-      successfulAuths: optional<list<AuthAttempt>> # Successful authentication attempts
-      commandExecutions: optional<list<CommandExecution>> # Only if commands were executed
-      fileTransfers: optional<list<FileTransfer>> # Only if file transfers were performed
+      serverInfo: optional<sshProtocol.SshServerInfo> # Always extracted from base connection
+      authAttempts: optional<list<sshProtocol.SshAuthAttempt>> # Only if auth attempts were made
+      successfulAuths: optional<list<sshProtocol.SshAuthAttempt>> # Successful authentication attempts
+      commandExecutions: optional<list<sshProtocol.SshCommandExecution>> # Only if commands were executed
+      fileTransfers: optional<list<sshProtocol.SshFileTransfer>> # Only if file transfers were performed
       errors: optional<list<string>>
 
   # Config for SSH pentest operations - extends general config

--- a/internal/discover/domain.go
+++ b/internal/discover/domain.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 	ldappentest "github.com/Method-Security/networkscan/internal/pentest/ldap"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
@@ -343,7 +343,7 @@ func enumerateDomainControllers(ctx context.Context, host string, domainName str
 
 // domainControllerDetails holds detailed information about a domain controller
 type domainControllerDetails struct {
-	smbServerInfo *commonprotocol.SmbServerInfo
+	smbServerInfo *commonprotocolfern.SmbServerInfo
 	ipAddress     string
 }
 
@@ -416,12 +416,12 @@ func gatherDomainControllerDetails(ctx context.Context, hostname, ipAddress stri
 }
 
 // convertToSmbServerInfo converts protocol library ServerInfo to common SMB ServerInfo
-func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocol.SmbServerInfo {
+func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocolfern.SmbServerInfo {
 	if serverInfo == nil {
 		return nil
 	}
 
-	result := &commonprotocol.SmbServerInfo{
+	result := &commonprotocolfern.SmbServerInfo{
 		ServerName:        &serverInfo.ServerName,
 		Domain:            &serverInfo.Domain,
 		NetBiosDomainName: &serverInfo.NetBIOSDomainName,

--- a/internal/discover/domain.go
+++ b/internal/discover/domain.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 	ldappentest "github.com/Method-Security/networkscan/internal/pentest/ldap"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
@@ -312,9 +313,9 @@ func enumerateDomainControllers(ctx context.Context, host string, domainName str
 			dcDetails := gatherDomainControllerDetails(ctx, hostname, ipAddress)
 
 			if dcDetails != nil {
-				if dcDetails.serverVersion != "" {
-					dcInfo.ServerVersion = &dcDetails.serverVersion
-				}
+				// Store the complete SMB server info in the new structure
+				dcInfo.SmbServerInfo = dcDetails.smbServerInfo
+
 				// Use the IP from SMB if we didn't get it from DNS resolution
 				if dcInfo.IpAddress == nil && dcDetails.ipAddress != "" {
 					dcInfo.IpAddress = &dcDetails.ipAddress
@@ -322,10 +323,14 @@ func enumerateDomainControllers(ctx context.Context, host string, domainName str
 			}
 
 			domainControllers = append(domainControllers, dcInfo)
+			var serverVersion string
+			if dcInfo.SmbServerInfo != nil && dcInfo.SmbServerInfo.OsVersion != nil {
+				serverVersion = *dcInfo.SmbServerInfo.OsVersion
+			}
 			log.Debug("Found domain controller",
 				svc1log.SafeParam("hostname", hostname),
 				svc1log.SafeParam("ip", dcInfo.IpAddress),
-				svc1log.SafeParam("serverVersion", dcInfo.ServerVersion))
+				svc1log.SafeParam("serverVersion", serverVersion))
 		}
 	}
 
@@ -338,7 +343,7 @@ func enumerateDomainControllers(ctx context.Context, host string, domainName str
 
 // domainControllerDetails holds detailed information about a domain controller
 type domainControllerDetails struct {
-	serverVersion string
+	smbServerInfo *commonprotocol.SmbServerInfo
 	ipAddress     string
 }
 
@@ -382,17 +387,24 @@ func gatherDomainControllerDetails(ctx context.Context, hostname, ipAddress stri
 			continue // Try next target
 		}
 
+		// Convert the internal server info to the common protocol structure
+		smbServerInfo := convertToSmbServerInfo(serverInfo)
+
 		details := &domainControllerDetails{
-			serverVersion: serverInfo.OSVersion,
+			smbServerInfo: smbServerInfo,
 			ipAddress:     target, // Store the target we used to connect
 		}
 
 		// Close the client
 		_ = client.Close()
 
+		var osVersion string
+		if smbServerInfo.OsVersion != nil {
+			osVersion = *smbServerInfo.OsVersion
+		}
 		log.Debug("Successfully gathered DC details",
 			svc1log.SafeParam("target", target),
-			svc1log.SafeParam("serverVersion", details.serverVersion))
+			svc1log.SafeParam("serverVersion", osVersion))
 
 		return details
 	}
@@ -401,6 +413,30 @@ func gatherDomainControllerDetails(ctx context.Context, hostname, ipAddress stri
 		svc1log.SafeParam("hostname", hostname),
 		svc1log.SafeParam("ipAddress", ipAddress))
 	return nil
+}
+
+// convertToSmbServerInfo converts protocol library ServerInfo to common SMB ServerInfo
+func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocol.SmbServerInfo {
+	if serverInfo == nil {
+		return nil
+	}
+
+	result := &commonprotocol.SmbServerInfo{
+		ServerName:        &serverInfo.ServerName,
+		Domain:            &serverInfo.Domain,
+		NetBiosDomainName: &serverInfo.NetBIOSDomainName,
+		Workgroup:         &serverInfo.Domain, // Use domain as workgroup fallback
+		OsVersion:         &serverInfo.OSVersion,
+		Capabilities:      serverInfo.Capabilities,
+		SigningRequired:   &serverInfo.SigningRequired,
+	}
+
+	// Include raw OS version if available
+	if serverInfo.RawOSVersion != "" {
+		result.RawOsVersion = &serverInfo.RawOSVersion
+	}
+
+	return result
 }
 
 // Helper functions

--- a/internal/discover/port/validate.go
+++ b/internal/discover/port/validate.go
@@ -9,10 +9,8 @@ import (
 
 	// Generated
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
-
 	// Internal
 	discover "github.com/Method-Security/networkscan/internal/discover"
-
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	smb "github.com/Method-Security/networkscan/generated/go/enumerate/smb"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
@@ -21,7 +21,7 @@ type authTestResult struct {
 	success       bool
 	client        *smbclient.Client
 	serverInfo    *smbclient.ServerInfo
-	authAttempt   *commonprotocol.SmbAuthAttempt
+	authAttempt   *commonprotocolfern.SmbAuthAttempt
 	allowedMethod bool
 }
 
@@ -63,7 +63,7 @@ func (s *LibraryEnumerateSMB) testGuestAuthentication(ctx context.Context, host 
 		func(c *smbclient.Client) { c.SetCredentials("guest", "", "") },
 		"Guest authentication", target)
 
-	authAttempt := &commonprotocol.SmbAuthAttempt{
+	authAttempt := &commonprotocolfern.SmbAuthAttempt{
 		Username:  "guest",
 		Password:  "",
 		Success:   guestResult.Success,
@@ -90,7 +90,7 @@ func (s *LibraryEnumerateSMB) testGuestAuthentication(ctx context.Context, host 
 // authenticationState holds the collective results of all authentication tests
 type authenticationState struct {
 	serverInfo           *smbclient.ServerInfo
-	authAttempts         []*commonprotocol.SmbAuthAttempt
+	authAttempts         []*commonprotocolfern.SmbAuthAttempt
 	nullSessionAllowed   bool
 	anonymousAllowed     bool
 	guestAllowed         bool
@@ -182,7 +182,7 @@ func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *smbclient.ServerInfo
 
 		// Set supported versions from server capabilities if available
 		if len(serverInfo.SupportedVersions) > 0 {
-			var smbVersions []commonprotocol.SmbVersion
+			var smbVersions []commonprotocolfern.SmbVersion
 			for _, version := range serverInfo.SupportedVersions {
 				if smbVersion, ok := smbclient.MapProtocolVersionToEnum(version); ok {
 					smbVersions = append(smbVersions, smbVersion)
@@ -198,15 +198,15 @@ func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *smbclient.ServerInfo
 
 	// Set defaults if server info wasn't available or didn't have version info
 	if details.Version == nil {
-		version := commonprotocol.SmbVersionSmb302
+		version := commonprotocolfern.SmbVersionSmb302
 		details.Version = &version
 	}
 	if len(details.SupportedVersions) == 0 {
-		details.SupportedVersions = []commonprotocol.SmbVersion{
-			commonprotocol.SmbVersionSmb302,
-			commonprotocol.SmbVersionSmb30,
-			commonprotocol.SmbVersionSmb21,
-			commonprotocol.SmbVersionSmb20,
+		details.SupportedVersions = []commonprotocolfern.SmbVersion{
+			commonprotocolfern.SmbVersionSmb302,
+			commonprotocolfern.SmbVersionSmb30,
+			commonprotocolfern.SmbVersionSmb21,
+			commonprotocolfern.SmbVersionSmb20,
 		}
 	}
 }
@@ -237,7 +237,7 @@ func (s *LibraryEnumerateSMB) enumerateShares(ctx context.Context, client *smbcl
 // assembleResponse builds the final enumeration response
 func (s *LibraryEnumerateSMB) assembleResponse(details *smb.EnumerateSmbDetails, state authenticationState, serverInfo *smbclient.ServerInfo) {
 	// Set authentication method information
-	authMethods := []commonprotocol.AuthMethod{commonprotocol.AuthMethodNtlm}
+	authMethods := []commonprotocolfern.AuthMethod{commonprotocolfern.AuthMethodNtlm}
 	details.AuthMethods = authMethods
 
 	// Set authentication capabilities
@@ -305,12 +305,12 @@ func (s *LibraryEnumerateSMB) EnumerateTarget(ctx context.Context, target string
 }
 
 // convertToSmbServerInfo converts protocol library ServerInfo to common SMB ServerInfo
-func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocol.SmbServerInfo {
+func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocolfern.SmbServerInfo {
 	if serverInfo == nil {
 		return nil
 	}
 
-	result := &commonprotocol.SmbServerInfo{
+	result := &commonprotocolfern.SmbServerInfo{
 		ServerName:        &serverInfo.ServerName,
 		Domain:            &serverInfo.Domain,
 		NetBiosDomainName: &serverInfo.NetBIOSDomainName,
@@ -329,14 +329,14 @@ func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocol.Sm
 }
 
 // convertToSmbShares converts protocol library ShareInfo to common SMB Share
-func convertToSmbShares(shares []*smbclient.ShareInfo) []*commonprotocol.SmbShare {
-	var smbShares []*commonprotocol.SmbShare
+func convertToSmbShares(shares []*smbclient.ShareInfo) []*commonprotocolfern.SmbShare {
+	var smbShares []*commonprotocolfern.SmbShare
 
 	for _, share := range shares {
 		shareType := convertShareType(share.Type)
 		shareAccess := convertShareAccess(share.Access)
 
-		smbShare := &commonprotocol.SmbShare{
+		smbShare := &commonprotocolfern.SmbShare{
 			Name:            share.Name,
 			Type:            shareType,
 			Accessible:      share.Accessible,
@@ -357,27 +357,27 @@ func convertToSmbShares(shares []*smbclient.ShareInfo) []*commonprotocol.SmbShar
 }
 
 // convertShareType converts string share type to common ShareType
-func convertShareType(shareType string) commonprotocol.ShareType {
+func convertShareType(shareType string) commonprotocolfern.ShareType {
 	switch shareType {
 	case "IPC":
-		return commonprotocol.ShareTypeIpc
+		return commonprotocolfern.ShareTypeIpc
 	case "Print":
-		return commonprotocol.ShareTypePrint
+		return commonprotocolfern.ShareTypePrint
 	case "Disk":
-		return commonprotocol.ShareTypeDisk
+		return commonprotocolfern.ShareTypeDisk
 	default:
-		return commonprotocol.ShareTypeDisk
+		return commonprotocolfern.ShareTypeDisk
 	}
 }
 
 // convertShareAccess converts string share access to common ShareAccess
-func convertShareAccess(access string) commonprotocol.ShareAccess {
+func convertShareAccess(access string) commonprotocolfern.ShareAccess {
 	switch access {
 	case "Read":
-		return commonprotocol.ShareAccessReadOnly
+		return commonprotocolfern.ShareAccessReadOnly
 	case "Write", "Full":
-		return commonprotocol.ShareAccessReadWrite
+		return commonprotocolfern.ShareAccessReadWrite
 	default:
-		return commonprotocol.ShareAccessNoAccess
+		return commonprotocolfern.ShareAccessNoAccess
 	}
 }

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	smb "github.com/Method-Security/networkscan/generated/go/enumerate/smb"
-	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -21,7 +21,7 @@ type authTestResult struct {
 	success       bool
 	client        *smbclient.Client
 	serverInfo    *smbclient.ServerInfo
-	authAttempt   *smbfern.AuthAttempt
+	authAttempt   *commonprotocol.SmbAuthAttempt
 	allowedMethod bool
 }
 
@@ -63,7 +63,7 @@ func (s *LibraryEnumerateSMB) testGuestAuthentication(ctx context.Context, host 
 		func(c *smbclient.Client) { c.SetCredentials("guest", "", "") },
 		"Guest authentication", target)
 
-	authAttempt := &smbfern.AuthAttempt{
+	authAttempt := &commonprotocol.SmbAuthAttempt{
 		Username:  "guest",
 		Password:  "",
 		Success:   guestResult.Success,
@@ -90,7 +90,7 @@ func (s *LibraryEnumerateSMB) testGuestAuthentication(ctx context.Context, host 
 // authenticationState holds the collective results of all authentication tests
 type authenticationState struct {
 	serverInfo           *smbclient.ServerInfo
-	authAttempts         []*smbfern.AuthAttempt
+	authAttempts         []*commonprotocol.SmbAuthAttempt
 	nullSessionAllowed   bool
 	anonymousAllowed     bool
 	guestAllowed         bool
@@ -182,7 +182,7 @@ func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *smbclient.ServerInfo
 
 		// Set supported versions from server capabilities if available
 		if len(serverInfo.SupportedVersions) > 0 {
-			var smbVersions []smb.SmbVersion
+			var smbVersions []commonprotocol.SmbVersion
 			for _, version := range serverInfo.SupportedVersions {
 				if smbVersion, ok := smbclient.MapProtocolVersionToEnum(version); ok {
 					smbVersions = append(smbVersions, smbVersion)
@@ -198,15 +198,15 @@ func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *smbclient.ServerInfo
 
 	// Set defaults if server info wasn't available or didn't have version info
 	if details.Version == nil {
-		version := smb.SmbVersionSmb302
+		version := commonprotocol.SmbVersionSmb302
 		details.Version = &version
 	}
 	if len(details.SupportedVersions) == 0 {
-		details.SupportedVersions = []smb.SmbVersion{
-			smb.SmbVersionSmb302,
-			smb.SmbVersionSmb30,
-			smb.SmbVersionSmb21,
-			smb.SmbVersionSmb20,
+		details.SupportedVersions = []commonprotocol.SmbVersion{
+			commonprotocol.SmbVersionSmb302,
+			commonprotocol.SmbVersionSmb30,
+			commonprotocol.SmbVersionSmb21,
+			commonprotocol.SmbVersionSmb20,
 		}
 	}
 }
@@ -237,7 +237,7 @@ func (s *LibraryEnumerateSMB) enumerateShares(ctx context.Context, client *smbcl
 // assembleResponse builds the final enumeration response
 func (s *LibraryEnumerateSMB) assembleResponse(details *smb.EnumerateSmbDetails, state authenticationState, serverInfo *smbclient.ServerInfo) {
 	// Set authentication method information
-	authMethods := []smb.AuthMethod{smb.AuthMethodNtlm}
+	authMethods := []commonprotocol.AuthMethod{commonprotocol.AuthMethodNtlm}
 	details.AuthMethods = authMethods
 
 	// Set authentication capabilities
@@ -304,35 +304,50 @@ func (s *LibraryEnumerateSMB) EnumerateTarget(ctx context.Context, target string
 	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmbDetails(&details), errors
 }
 
-// convertToSmbServerInfo converts protocol library ServerInfo to fern ServerInfo
-func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *smb.ServerInfo {
+// convertToSmbServerInfo converts protocol library ServerInfo to common SMB ServerInfo
+func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocol.SmbServerInfo {
 	if serverInfo == nil {
 		return nil
 	}
 
-	return &smb.ServerInfo{
-		ServerName:   &serverInfo.ServerName,
-		Domain:       &serverInfo.Domain,
-		OsVersion:    &serverInfo.OSVersion,
-		Capabilities: serverInfo.Capabilities,
+	result := &commonprotocol.SmbServerInfo{
+		ServerName:        &serverInfo.ServerName,
+		Domain:            &serverInfo.Domain,
+		NetBiosDomainName: &serverInfo.NetBIOSDomainName,
+		Workgroup:         &serverInfo.Domain, // Use domain as workgroup fallback
+		OsVersion:         &serverInfo.OSVersion,
+		Capabilities:      serverInfo.Capabilities,
+		SigningRequired:   &serverInfo.SigningRequired,
 	}
+
+	// Include raw OS version if available
+	if serverInfo.RawOSVersion != "" {
+		result.RawOsVersion = &serverInfo.RawOSVersion
+	}
+
+	return result
 }
 
-// convertToSmbShares converts protocol library ShareInfo to fern SmbShare
-func convertToSmbShares(shares []*smbclient.ShareInfo) []*smb.SmbShare {
-	var smbShares []*smb.SmbShare
+// convertToSmbShares converts protocol library ShareInfo to common SMB Share
+func convertToSmbShares(shares []*smbclient.ShareInfo) []*commonprotocol.SmbShare {
+	var smbShares []*commonprotocol.SmbShare
 
 	for _, share := range shares {
 		shareType := convertShareType(share.Type)
 		shareAccess := convertShareAccess(share.Access)
 
-		smbShare := &smb.SmbShare{
+		smbShare := &commonprotocol.SmbShare{
 			Name:            share.Name,
 			Type:            shareType,
 			Accessible:      share.Accessible,
 			Access:          &shareAccess,
 			AnonymousAccess: share.AnonymousAccess,
 			GuestAccess:     share.GuestAccess,
+			Hidden:          &share.Hidden,
+		}
+
+		if share.Comment != "" {
+			smbShare.Comment = &share.Comment
 		}
 
 		smbShares = append(smbShares, smbShare)
@@ -341,28 +356,28 @@ func convertToSmbShares(shares []*smbclient.ShareInfo) []*smb.SmbShare {
 	return smbShares
 }
 
-// convertShareType converts string share type to fern ShareType
-func convertShareType(shareType string) smb.ShareType {
+// convertShareType converts string share type to common ShareType
+func convertShareType(shareType string) commonprotocol.ShareType {
 	switch shareType {
 	case "IPC":
-		return smb.ShareTypeIpc
+		return commonprotocol.ShareTypeIpc
 	case "Print":
-		return smb.ShareTypePrint
+		return commonprotocol.ShareTypePrint
 	case "Disk":
-		return smb.ShareTypeDisk
+		return commonprotocol.ShareTypeDisk
 	default:
-		return smb.ShareTypeDisk
+		return commonprotocol.ShareTypeDisk
 	}
 }
 
-// convertShareAccess converts string share access to fern ShareAccess
-func convertShareAccess(access string) smb.ShareAccess {
+// convertShareAccess converts string share access to common ShareAccess
+func convertShareAccess(access string) commonprotocol.ShareAccess {
 	switch access {
 	case "Read":
-		return smb.ShareAccessReadOnly
+		return commonprotocol.ShareAccessReadOnly
 	case "Write", "Full":
-		return smb.ShareAccessReadWrite
+		return commonprotocol.ShareAccessReadWrite
 	default:
-		return smb.ShareAccessNoAccess
+		return commonprotocol.ShareAccessNoAccess
 	}
 }

--- a/internal/enumerate/ssh/constants.go
+++ b/internal/enumerate/ssh/constants.go
@@ -1,79 +1,79 @@
 package ssh
 
 import (
-	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 )
 
 var (
 
 	// Key Exchange Algorithms mapped to their enum values
-	commonKeyExchangeAlgos = map[string]commonprotocol.KeyExchangeAlgorithm{
-		"sntrup761x25519-sha512@openssh.com":   commonprotocol.KeyExchangeAlgorithmSntrup761X25519Sha512Openssh,
-		"curve25519-sha256":                    commonprotocol.KeyExchangeAlgorithmCurve25519Sha256,
-		"curve25519-sha256@libssh.org":         commonprotocol.KeyExchangeAlgorithmCurve25519Sha256Libssh,
-		"ecdh-sha2-nistp256":                   commonprotocol.KeyExchangeAlgorithmEcdhsha2Nistp256,
-		"ecdh-sha2-nistp384":                   commonprotocol.KeyExchangeAlgorithmEcdhsha2Nistp384,
-		"ecdh-sha2-nistp521":                   commonprotocol.KeyExchangeAlgorithmEcdhsha2Nistp521,
-		"ecdh-sha2-nistp224":                   commonprotocol.KeyExchangeAlgorithmEcdhsha2Nistp224,
-		"diffie-hellman-group-exchange-sha256": commonprotocol.KeyExchangeAlgorithmDiffiehellmangroupexchangesha256,
-		"diffie-hellman-group-exchange-sha512": commonprotocol.KeyExchangeAlgorithmDiffiehellmangroupexchangesha512,
-		"diffie-hellman-group16-sha512":        commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup16Sha512,
-		"diffie-hellman-group18-sha512":        commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup18Sha512,
-		"diffie-hellman-group14-sha256":        commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup14Sha256,
-		"diffie-hellman-group14-sha512":        commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup14Sha512,
-		"diffie-hellman-group1-sha1":           commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup1Sha1, // Deprecated
-		"diffie-hellman-group1-sha256":         commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup1Sha256,
-		"kex-strict-s-v00@openssh.com":         commonprotocol.KeyExchangeAlgorithmKexstrictsv00Openssh,
-		"x25519-sha256@libssh.org":             commonprotocol.KeyExchangeAlgorithmX25519Sha256Libssh,
-		"x448-sha512@openssh.com":              commonprotocol.KeyExchangeAlgorithmX448Sha512Openssh,
-		"curve25519-sha512@openssh.com":        commonprotocol.KeyExchangeAlgorithmCurve25519Sha512Openssh,
+	commonKeyExchangeAlgos = map[string]commonprotocolfern.KeyExchangeAlgorithm{
+		"sntrup761x25519-sha512@openssh.com":   commonprotocolfern.KeyExchangeAlgorithmSntrup761X25519Sha512Openssh,
+		"curve25519-sha256":                    commonprotocolfern.KeyExchangeAlgorithmCurve25519Sha256,
+		"curve25519-sha256@libssh.org":         commonprotocolfern.KeyExchangeAlgorithmCurve25519Sha256Libssh,
+		"ecdh-sha2-nistp256":                   commonprotocolfern.KeyExchangeAlgorithmEcdhsha2Nistp256,
+		"ecdh-sha2-nistp384":                   commonprotocolfern.KeyExchangeAlgorithmEcdhsha2Nistp384,
+		"ecdh-sha2-nistp521":                   commonprotocolfern.KeyExchangeAlgorithmEcdhsha2Nistp521,
+		"ecdh-sha2-nistp224":                   commonprotocolfern.KeyExchangeAlgorithmEcdhsha2Nistp224,
+		"diffie-hellman-group-exchange-sha256": commonprotocolfern.KeyExchangeAlgorithmDiffiehellmangroupexchangesha256,
+		"diffie-hellman-group-exchange-sha512": commonprotocolfern.KeyExchangeAlgorithmDiffiehellmangroupexchangesha512,
+		"diffie-hellman-group16-sha512":        commonprotocolfern.KeyExchangeAlgorithmDiffiehellmangroup16Sha512,
+		"diffie-hellman-group18-sha512":        commonprotocolfern.KeyExchangeAlgorithmDiffiehellmangroup18Sha512,
+		"diffie-hellman-group14-sha256":        commonprotocolfern.KeyExchangeAlgorithmDiffiehellmangroup14Sha256,
+		"diffie-hellman-group14-sha512":        commonprotocolfern.KeyExchangeAlgorithmDiffiehellmangroup14Sha512,
+		"diffie-hellman-group1-sha1":           commonprotocolfern.KeyExchangeAlgorithmDiffiehellmangroup1Sha1, // Deprecated
+		"diffie-hellman-group1-sha256":         commonprotocolfern.KeyExchangeAlgorithmDiffiehellmangroup1Sha256,
+		"kex-strict-s-v00@openssh.com":         commonprotocolfern.KeyExchangeAlgorithmKexstrictsv00Openssh,
+		"x25519-sha256@libssh.org":             commonprotocolfern.KeyExchangeAlgorithmX25519Sha256Libssh,
+		"x448-sha512@openssh.com":              commonprotocolfern.KeyExchangeAlgorithmX448Sha512Openssh,
+		"curve25519-sha512@openssh.com":        commonprotocolfern.KeyExchangeAlgorithmCurve25519Sha512Openssh,
 	}
 
 	// Host Key Algorithms mapped to their enum values
-	commonHostKeyAlgos = map[string]commonprotocol.HostKeyAlgorithm{
-		"ssh-dss":             commonprotocol.HostKeyAlgorithmSshdss, // Deprecated
-		"ssh-rsa":             commonprotocol.HostKeyAlgorithmSshrsa, // Deprecated (SHA-1)
-		"rsa-sha2-256":        commonprotocol.HostKeyAlgorithmRsasha2256,
-		"rsa-sha2-512":        commonprotocol.HostKeyAlgorithmRsasha2512,
-		"ecdsa-sha2-nistp256": commonprotocol.HostKeyAlgorithmEcdsasha2Nistp256,
-		"ecdsa-sha2-nistp384": commonprotocol.HostKeyAlgorithmEcdsasha2Nistp384,
-		"ecdsa-sha2-nistp521": commonprotocol.HostKeyAlgorithmEcdsasha2Nistp521,
-		"ecdsa-sha2-nistp224": commonprotocol.HostKeyAlgorithmEcdsasha2Nistp224,
-		"ed25519-sha256":      commonprotocol.HostKeyAlgorithmEd25519Sha256,
+	commonHostKeyAlgos = map[string]commonprotocolfern.HostKeyAlgorithm{
+		"ssh-dss":             commonprotocolfern.HostKeyAlgorithmSshdss, // Deprecated
+		"ssh-rsa":             commonprotocolfern.HostKeyAlgorithmSshrsa, // Deprecated (SHA-1)
+		"rsa-sha2-256":        commonprotocolfern.HostKeyAlgorithmRsasha2256,
+		"rsa-sha2-512":        commonprotocolfern.HostKeyAlgorithmRsasha2512,
+		"ecdsa-sha2-nistp256": commonprotocolfern.HostKeyAlgorithmEcdsasha2Nistp256,
+		"ecdsa-sha2-nistp384": commonprotocolfern.HostKeyAlgorithmEcdsasha2Nistp384,
+		"ecdsa-sha2-nistp521": commonprotocolfern.HostKeyAlgorithmEcdsasha2Nistp521,
+		"ecdsa-sha2-nistp224": commonprotocolfern.HostKeyAlgorithmEcdsasha2Nistp224,
+		"ed25519-sha256":      commonprotocolfern.HostKeyAlgorithmEd25519Sha256,
 	}
 
 	// Cipher Algorithms mapped to their enum values
-	commonCiphers = map[string]commonprotocol.CipherAlgorithm{
-		"chacha20-poly1305@openssh.com": commonprotocol.CipherAlgorithmChacha20Poly1305Openssh,
-		"aes128-ctr":                    commonprotocol.CipherAlgorithmAes128Ctr,
-		"aes192-ctr":                    commonprotocol.CipherAlgorithmAes192Ctr,
-		"aes256-ctr":                    commonprotocol.CipherAlgorithmAes256Ctr,
-		"aes128-gcm@openssh.com":        commonprotocol.CipherAlgorithmAes128Gcmopenssh,
-		"aes256-gcm@openssh.com":        commonprotocol.CipherAlgorithmAes256Gcmopenssh,
-		"3des-ede3-cbc":                 commonprotocol.CipherAlgorithmThreedescbc,
-		"aes128-cbc":                    commonprotocol.CipherAlgorithmAes128Cbc,
-		"aes192-cbc":                    commonprotocol.CipherAlgorithmAes192Cbc,
-		"aes256-cbc":                    commonprotocol.CipherAlgorithmAes256Cbc,
-		"blowfish-cbc":                  commonprotocol.CipherAlgorithmBlowfishcbc,
-		"aes128-cbc@openssl.com":        commonprotocol.CipherAlgorithmAes128Cbcopenssl,
+	commonCiphers = map[string]commonprotocolfern.CipherAlgorithm{
+		"chacha20-poly1305@openssh.com": commonprotocolfern.CipherAlgorithmChacha20Poly1305Openssh,
+		"aes128-ctr":                    commonprotocolfern.CipherAlgorithmAes128Ctr,
+		"aes192-ctr":                    commonprotocolfern.CipherAlgorithmAes192Ctr,
+		"aes256-ctr":                    commonprotocolfern.CipherAlgorithmAes256Ctr,
+		"aes128-gcm@openssh.com":        commonprotocolfern.CipherAlgorithmAes128Gcmopenssh,
+		"aes256-gcm@openssh.com":        commonprotocolfern.CipherAlgorithmAes256Gcmopenssh,
+		"3des-ede3-cbc":                 commonprotocolfern.CipherAlgorithmThreedescbc,
+		"aes128-cbc":                    commonprotocolfern.CipherAlgorithmAes128Cbc,
+		"aes192-cbc":                    commonprotocolfern.CipherAlgorithmAes192Cbc,
+		"aes256-cbc":                    commonprotocolfern.CipherAlgorithmAes256Cbc,
+		"blowfish-cbc":                  commonprotocolfern.CipherAlgorithmBlowfishcbc,
+		"aes128-cbc@openssl.com":        commonprotocolfern.CipherAlgorithmAes128Cbcopenssl,
 	}
 
 	// MAC Algorithms mapped to their enum values
-	commonMACs = map[string]commonprotocol.MacAlgorithm{
-		"umac-1":                        commonprotocol.MacAlgorithmUmac1,
-		"umac-64-etm@openssh.com":       commonprotocol.MacAlgorithmUmac64Etmopenssh,
-		"umac-128-etm@openssh.com":      commonprotocol.MacAlgorithmUmac128Etmopenssh,
-		"hmac-sha2-256-etm@openssh.com": commonprotocol.MacAlgorithmHmacsha2256Etmopenssh,
-		"hmac-sha2-512-etm@openssh.com": commonprotocol.MacAlgorithmHmacsha2512Etmopenssh,
-		"hmac-sha1-etm@openssh.com":     commonprotocol.MacAlgorithmHmacsha1Etmopenssh,
-		"umac-64@openssh.com":           commonprotocol.MacAlgorithmUmac64Openssh,
-		"umac-128@openssh.com":          commonprotocol.MacAlgorithmUmac128Openssh,
-		"hmac-sha2-256":                 commonprotocol.MacAlgorithmHmacsha2256,
-		"hmac-sha2-512":                 commonprotocol.MacAlgorithmHmacsha2512,
-		"hmac-sha1":                     commonprotocol.MacAlgorithmHmacsha1,
-		"hmac-md5":                      commonprotocol.MacAlgorithmHmacmd5,
-		"hmac-ripemd160":                commonprotocol.MacAlgorithmHmacripemd160,
-		"hmac-sha3-256":                 commonprotocol.MacAlgorithmHmacsha3256,
-		"hmac-sha3-512":                 commonprotocol.MacAlgorithmHmacsha3512,
+	commonMACs = map[string]commonprotocolfern.MacAlgorithm{
+		"umac-1":                        commonprotocolfern.MacAlgorithmUmac1,
+		"umac-64-etm@openssh.com":       commonprotocolfern.MacAlgorithmUmac64Etmopenssh,
+		"umac-128-etm@openssh.com":      commonprotocolfern.MacAlgorithmUmac128Etmopenssh,
+		"hmac-sha2-256-etm@openssh.com": commonprotocolfern.MacAlgorithmHmacsha2256Etmopenssh,
+		"hmac-sha2-512-etm@openssh.com": commonprotocolfern.MacAlgorithmHmacsha2512Etmopenssh,
+		"hmac-sha1-etm@openssh.com":     commonprotocolfern.MacAlgorithmHmacsha1Etmopenssh,
+		"umac-64@openssh.com":           commonprotocolfern.MacAlgorithmUmac64Openssh,
+		"umac-128@openssh.com":          commonprotocolfern.MacAlgorithmUmac128Openssh,
+		"hmac-sha2-256":                 commonprotocolfern.MacAlgorithmHmacsha2256,
+		"hmac-sha2-512":                 commonprotocolfern.MacAlgorithmHmacsha2512,
+		"hmac-sha1":                     commonprotocolfern.MacAlgorithmHmacsha1,
+		"hmac-md5":                      commonprotocolfern.MacAlgorithmHmacmd5,
+		"hmac-ripemd160":                commonprotocolfern.MacAlgorithmHmacripemd160,
+		"hmac-sha3-256":                 commonprotocolfern.MacAlgorithmHmacsha3256,
+		"hmac-sha3-512":                 commonprotocolfern.MacAlgorithmHmacsha3512,
 	}
 )

--- a/internal/enumerate/ssh/constants.go
+++ b/internal/enumerate/ssh/constants.go
@@ -1,79 +1,79 @@
 package ssh
 
 import (
-	ssh "github.com/Method-Security/networkscan/generated/go/enumerate/ssh"
+	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
 )
 
 var (
 
 	// Key Exchange Algorithms mapped to their enum values
-	commonKeyExchangeAlgos = map[string]ssh.KeyExchangeAlgorithm{
-		"sntrup761x25519-sha512@openssh.com":   ssh.KeyExchangeAlgorithmSntrup761X25519Sha512Openssh,
-		"curve25519-sha256":                    ssh.KeyExchangeAlgorithmCurve25519Sha256,
-		"curve25519-sha256@libssh.org":         ssh.KeyExchangeAlgorithmCurve25519Sha256Libssh,
-		"ecdh-sha2-nistp256":                   ssh.KeyExchangeAlgorithmEcdhsha2Nistp256,
-		"ecdh-sha2-nistp384":                   ssh.KeyExchangeAlgorithmEcdhsha2Nistp384,
-		"ecdh-sha2-nistp521":                   ssh.KeyExchangeAlgorithmEcdhsha2Nistp521,
-		"ecdh-sha2-nistp224":                   ssh.KeyExchangeAlgorithmEcdhsha2Nistp224,
-		"diffie-hellman-group-exchange-sha256": ssh.KeyExchangeAlgorithmDiffiehellmangroupexchangesha256,
-		"diffie-hellman-group-exchange-sha512": ssh.KeyExchangeAlgorithmDiffiehellmangroupexchangesha512,
-		"diffie-hellman-group16-sha512":        ssh.KeyExchangeAlgorithmDiffiehellmangroup16Sha512,
-		"diffie-hellman-group18-sha512":        ssh.KeyExchangeAlgorithmDiffiehellmangroup18Sha512,
-		"diffie-hellman-group14-sha256":        ssh.KeyExchangeAlgorithmDiffiehellmangroup14Sha256,
-		"diffie-hellman-group14-sha512":        ssh.KeyExchangeAlgorithmDiffiehellmangroup14Sha512,
-		"diffie-hellman-group1-sha1":           ssh.KeyExchangeAlgorithmDiffiehellmangroup1Sha1, // Deprecated
-		"diffie-hellman-group1-sha256":         ssh.KeyExchangeAlgorithmDiffiehellmangroup1Sha256,
-		"kex-strict-s-v00@openssh.com":         ssh.KeyExchangeAlgorithmKexstrictsv00Openssh,
-		"x25519-sha256@libssh.org":             ssh.KeyExchangeAlgorithmX25519Sha256Libssh,
-		"x448-sha512@openssh.com":              ssh.KeyExchangeAlgorithmX448Sha512Openssh,
-		"curve25519-sha512@openssh.com":        ssh.KeyExchangeAlgorithmCurve25519Sha512Openssh,
+	commonKeyExchangeAlgos = map[string]commonprotocol.KeyExchangeAlgorithm{
+		"sntrup761x25519-sha512@openssh.com":   commonprotocol.KeyExchangeAlgorithmSntrup761X25519Sha512Openssh,
+		"curve25519-sha256":                    commonprotocol.KeyExchangeAlgorithmCurve25519Sha256,
+		"curve25519-sha256@libssh.org":         commonprotocol.KeyExchangeAlgorithmCurve25519Sha256Libssh,
+		"ecdh-sha2-nistp256":                   commonprotocol.KeyExchangeAlgorithmEcdhsha2Nistp256,
+		"ecdh-sha2-nistp384":                   commonprotocol.KeyExchangeAlgorithmEcdhsha2Nistp384,
+		"ecdh-sha2-nistp521":                   commonprotocol.KeyExchangeAlgorithmEcdhsha2Nistp521,
+		"ecdh-sha2-nistp224":                   commonprotocol.KeyExchangeAlgorithmEcdhsha2Nistp224,
+		"diffie-hellman-group-exchange-sha256": commonprotocol.KeyExchangeAlgorithmDiffiehellmangroupexchangesha256,
+		"diffie-hellman-group-exchange-sha512": commonprotocol.KeyExchangeAlgorithmDiffiehellmangroupexchangesha512,
+		"diffie-hellman-group16-sha512":        commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup16Sha512,
+		"diffie-hellman-group18-sha512":        commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup18Sha512,
+		"diffie-hellman-group14-sha256":        commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup14Sha256,
+		"diffie-hellman-group14-sha512":        commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup14Sha512,
+		"diffie-hellman-group1-sha1":           commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup1Sha1, // Deprecated
+		"diffie-hellman-group1-sha256":         commonprotocol.KeyExchangeAlgorithmDiffiehellmangroup1Sha256,
+		"kex-strict-s-v00@openssh.com":         commonprotocol.KeyExchangeAlgorithmKexstrictsv00Openssh,
+		"x25519-sha256@libssh.org":             commonprotocol.KeyExchangeAlgorithmX25519Sha256Libssh,
+		"x448-sha512@openssh.com":              commonprotocol.KeyExchangeAlgorithmX448Sha512Openssh,
+		"curve25519-sha512@openssh.com":        commonprotocol.KeyExchangeAlgorithmCurve25519Sha512Openssh,
 	}
 
 	// Host Key Algorithms mapped to their enum values
-	commonHostKeyAlgos = map[string]ssh.HostKeyAlgorithm{
-		"ssh-dss":             ssh.HostKeyAlgorithmSshdss, // Deprecated
-		"ssh-rsa":             ssh.HostKeyAlgorithmSshrsa, // Deprecated (SHA-1)
-		"rsa-sha2-256":        ssh.HostKeyAlgorithmRsasha2256,
-		"rsa-sha2-512":        ssh.HostKeyAlgorithmRsasha2512,
-		"ecdsa-sha2-nistp256": ssh.HostKeyAlgorithmEcdsasha2Nistp256,
-		"ecdsa-sha2-nistp384": ssh.HostKeyAlgorithmEcdsasha2Nistp384,
-		"ecdsa-sha2-nistp521": ssh.HostKeyAlgorithmEcdsasha2Nistp521,
-		"ecdsa-sha2-nistp224": ssh.HostKeyAlgorithmEcdsasha2Nistp224,
-		"ed25519-sha256":      ssh.HostKeyAlgorithmEd25519Sha256,
+	commonHostKeyAlgos = map[string]commonprotocol.HostKeyAlgorithm{
+		"ssh-dss":             commonprotocol.HostKeyAlgorithmSshdss, // Deprecated
+		"ssh-rsa":             commonprotocol.HostKeyAlgorithmSshrsa, // Deprecated (SHA-1)
+		"rsa-sha2-256":        commonprotocol.HostKeyAlgorithmRsasha2256,
+		"rsa-sha2-512":        commonprotocol.HostKeyAlgorithmRsasha2512,
+		"ecdsa-sha2-nistp256": commonprotocol.HostKeyAlgorithmEcdsasha2Nistp256,
+		"ecdsa-sha2-nistp384": commonprotocol.HostKeyAlgorithmEcdsasha2Nistp384,
+		"ecdsa-sha2-nistp521": commonprotocol.HostKeyAlgorithmEcdsasha2Nistp521,
+		"ecdsa-sha2-nistp224": commonprotocol.HostKeyAlgorithmEcdsasha2Nistp224,
+		"ed25519-sha256":      commonprotocol.HostKeyAlgorithmEd25519Sha256,
 	}
 
 	// Cipher Algorithms mapped to their enum values
-	commonCiphers = map[string]ssh.CipherAlgorithm{
-		"chacha20-poly1305@openssh.com": ssh.CipherAlgorithmChacha20Poly1305Openssh,
-		"aes128-ctr":                    ssh.CipherAlgorithmAes128Ctr,
-		"aes192-ctr":                    ssh.CipherAlgorithmAes192Ctr,
-		"aes256-ctr":                    ssh.CipherAlgorithmAes256Ctr,
-		"aes128-gcm@openssh.com":        ssh.CipherAlgorithmAes128Gcmopenssh,
-		"aes256-gcm@openssh.com":        ssh.CipherAlgorithmAes256Gcmopenssh,
-		"3des-ede3-cbc":                 ssh.CipherAlgorithmThreedescbc,
-		"aes128-cbc":                    ssh.CipherAlgorithmAes128Cbc,
-		"aes192-cbc":                    ssh.CipherAlgorithmAes192Cbc,
-		"aes256-cbc":                    ssh.CipherAlgorithmAes256Cbc,
-		"blowfish-cbc":                  ssh.CipherAlgorithmBlowfishcbc,
-		"aes128-cbc@openssl.com":        ssh.CipherAlgorithmAes128Cbcopenssl,
+	commonCiphers = map[string]commonprotocol.CipherAlgorithm{
+		"chacha20-poly1305@openssh.com": commonprotocol.CipherAlgorithmChacha20Poly1305Openssh,
+		"aes128-ctr":                    commonprotocol.CipherAlgorithmAes128Ctr,
+		"aes192-ctr":                    commonprotocol.CipherAlgorithmAes192Ctr,
+		"aes256-ctr":                    commonprotocol.CipherAlgorithmAes256Ctr,
+		"aes128-gcm@openssh.com":        commonprotocol.CipherAlgorithmAes128Gcmopenssh,
+		"aes256-gcm@openssh.com":        commonprotocol.CipherAlgorithmAes256Gcmopenssh,
+		"3des-ede3-cbc":                 commonprotocol.CipherAlgorithmThreedescbc,
+		"aes128-cbc":                    commonprotocol.CipherAlgorithmAes128Cbc,
+		"aes192-cbc":                    commonprotocol.CipherAlgorithmAes192Cbc,
+		"aes256-cbc":                    commonprotocol.CipherAlgorithmAes256Cbc,
+		"blowfish-cbc":                  commonprotocol.CipherAlgorithmBlowfishcbc,
+		"aes128-cbc@openssl.com":        commonprotocol.CipherAlgorithmAes128Cbcopenssl,
 	}
 
 	// MAC Algorithms mapped to their enum values
-	commonMACs = map[string]ssh.MacAlgorithm{
-		"umac-1":                        ssh.MacAlgorithmUmac1,
-		"umac-64-etm@openssh.com":       ssh.MacAlgorithmUmac64Etmopenssh,
-		"umac-128-etm@openssh.com":      ssh.MacAlgorithmUmac128Etmopenssh,
-		"hmac-sha2-256-etm@openssh.com": ssh.MacAlgorithmHmacsha2256Etmopenssh,
-		"hmac-sha2-512-etm@openssh.com": ssh.MacAlgorithmHmacsha2512Etmopenssh,
-		"hmac-sha1-etm@openssh.com":     ssh.MacAlgorithmHmacsha1Etmopenssh,
-		"umac-64@openssh.com":           ssh.MacAlgorithmUmac64Openssh,
-		"umac-128@openssh.com":          ssh.MacAlgorithmUmac128Openssh,
-		"hmac-sha2-256":                 ssh.MacAlgorithmHmacsha2256,
-		"hmac-sha2-512":                 ssh.MacAlgorithmHmacsha2512,
-		"hmac-sha1":                     ssh.MacAlgorithmHmacsha1,
-		"hmac-md5":                      ssh.MacAlgorithmHmacmd5,
-		"hmac-ripemd160":                ssh.MacAlgorithmHmacripemd160,
-		"hmac-sha3-256":                 ssh.MacAlgorithmHmacsha3256,
-		"hmac-sha3-512":                 ssh.MacAlgorithmHmacsha3512,
+	commonMACs = map[string]commonprotocol.MacAlgorithm{
+		"umac-1":                        commonprotocol.MacAlgorithmUmac1,
+		"umac-64-etm@openssh.com":       commonprotocol.MacAlgorithmUmac64Etmopenssh,
+		"umac-128-etm@openssh.com":      commonprotocol.MacAlgorithmUmac128Etmopenssh,
+		"hmac-sha2-256-etm@openssh.com": commonprotocol.MacAlgorithmHmacsha2256Etmopenssh,
+		"hmac-sha2-512-etm@openssh.com": commonprotocol.MacAlgorithmHmacsha2512Etmopenssh,
+		"hmac-sha1-etm@openssh.com":     commonprotocol.MacAlgorithmHmacsha1Etmopenssh,
+		"umac-64@openssh.com":           commonprotocol.MacAlgorithmUmac64Openssh,
+		"umac-128@openssh.com":          commonprotocol.MacAlgorithmUmac128Openssh,
+		"hmac-sha2-256":                 commonprotocol.MacAlgorithmHmacsha2256,
+		"hmac-sha2-512":                 commonprotocol.MacAlgorithmHmacsha2512,
+		"hmac-sha1":                     commonprotocol.MacAlgorithmHmacsha1,
+		"hmac-md5":                      commonprotocol.MacAlgorithmHmacmd5,
+		"hmac-ripemd160":                commonprotocol.MacAlgorithmHmacripemd160,
+		"hmac-sha3-256":                 commonprotocol.MacAlgorithmHmacsha3256,
+		"hmac-sha3-512":                 commonprotocol.MacAlgorithmHmacsha3512,
 	}
 )

--- a/internal/enumerate/ssh/ssh.go
+++ b/internal/enumerate/ssh/ssh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 
+	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	ssh "github.com/Method-Security/networkscan/generated/go/enumerate/ssh"
 )
@@ -34,7 +35,8 @@ type LibraryEnumerateSSH struct{}
 
 func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string) (*enumeratefern.EnumerateServiceDetails, []string) {
 	var details ssh.EnumerateSshDetails
-	details.Target = target
+	var serverInfo commonprotocol.SshServerInfo
+	serverInfo.Target = &target
 	errors := []string{}
 
 	// Create dialer with context
@@ -51,7 +53,7 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 		errors = append(errors, err.Error())
 		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
 	}
-	details.Version = version
+	serverInfo.ServerVersion = version
 
 	// Perform SSH handshake to extract KEX data
 	rawASCII, err := getSSHAlgorithms(ctx, conn)
@@ -64,13 +66,13 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 	if versionASCII != nil {
 		fullASCII = *versionASCII + fullASCII
 	}
-	details.RawAscii = &fullASCII
-	details.KeyExchangeAlgos = extractAlgorithms(fullASCII, commonKeyExchangeAlgos)
-	details.HostKeyAlgos = extractAlgorithms(fullASCII, commonHostKeyAlgos)
-	details.Ciphers = extractAlgorithms(fullASCII, commonCiphers)
-	details.Macs = extractAlgorithms(fullASCII, commonMACs)
-	if len(details.HostKeyAlgos) >= 0 {
-		details.AuthMethods = []ssh.AuthMethod{ssh.AuthMethodPublicKey}
+	serverInfo.RawAscii = &fullASCII
+	serverInfo.SupportedKex = extractAlgorithms(fullASCII, commonKeyExchangeAlgos)
+	serverInfo.HostKeyAlgos = extractAlgorithms(fullASCII, commonHostKeyAlgos)
+	serverInfo.SupportedCiphers = extractAlgorithms(fullASCII, commonCiphers)
+	serverInfo.SupportedMacs = extractAlgorithms(fullASCII, commonMACs)
+	if len(serverInfo.HostKeyAlgos) >= 0 {
+		serverInfo.SupportedAuthMethods = []commonprotocol.SshAuthMethod{commonprotocol.SshAuthMethodPublicKey}
 	}
 
 	// Check if password authentication is supported
@@ -79,13 +81,16 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 		errors = append(errors, err.Error())
 	}
 	if passwordSupported != nil && *passwordSupported {
-		details.AuthMethods = append(details.AuthMethods, ssh.AuthMethodPassword)
+		serverInfo.SupportedAuthMethods = append(serverInfo.SupportedAuthMethods, commonprotocol.SshAuthMethodPassword)
 	}
 
 	err = conn.Close()
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
+
+	// Set the server info in the details
+	details.ServerInfo = &serverInfo
 
 	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
 }

--- a/internal/enumerate/ssh/ssh.go
+++ b/internal/enumerate/ssh/ssh.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	ssh "github.com/Method-Security/networkscan/generated/go/enumerate/ssh"
 )
@@ -35,7 +35,7 @@ type LibraryEnumerateSSH struct{}
 
 func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string) (*enumeratefern.EnumerateServiceDetails, []string) {
 	var details ssh.EnumerateSshDetails
-	var serverInfo commonprotocol.SshServerInfo
+	var serverInfo commonprotocolfern.SshServerInfo
 	serverInfo.Target = &target
 	errors := []string{}
 
@@ -72,7 +72,7 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 	serverInfo.SupportedCiphers = extractAlgorithms(fullASCII, commonCiphers)
 	serverInfo.SupportedMacs = extractAlgorithms(fullASCII, commonMACs)
 	if len(serverInfo.HostKeyAlgos) >= 0 {
-		serverInfo.SupportedAuthMethods = []commonprotocol.SshAuthMethod{commonprotocol.SshAuthMethodPublicKey}
+		serverInfo.SupportedAuthMethods = []commonprotocolfern.SshAuthMethod{commonprotocolfern.SshAuthMethodPublicKey}
 	}
 
 	// Check if password authentication is supported
@@ -81,7 +81,7 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 		errors = append(errors, err.Error())
 	}
 	if passwordSupported != nil && *passwordSupported {
-		serverInfo.SupportedAuthMethods = append(serverInfo.SupportedAuthMethods, commonprotocol.SshAuthMethodPassword)
+		serverInfo.SupportedAuthMethods = append(serverInfo.SupportedAuthMethods, commonprotocolfern.SshAuthMethodPassword)
 	}
 
 	err = conn.Close()

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	"github.com/Method-Security/networkscan/generated/go/pentest"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
@@ -47,9 +47,9 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(config.Timeout) * time.Millisecond
 
-	var serverInfo *commonprotocol.SmbServerInfo
+	var serverInfo *commonprotocolfern.SmbServerInfo
 	if clientServerInfo, err := client.ExtractServerInfoFromChallenge(ctx); err == nil && clientServerInfo != nil {
-		serverInfo = &commonprotocol.SmbServerInfo{
+		serverInfo = &commonprotocolfern.SmbServerInfo{
 			ServerName:        &clientServerInfo.ServerName,
 			Domain:            &clientServerInfo.Domain,
 			NetBiosDomainName: &clientServerInfo.NetBIOSDomainName,
@@ -83,10 +83,10 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 // performAuthAttemptsWithContext performs credential-based authentication attempts with context
 func performAuthAttemptsWithContext(ctx context.Context, host string, port int, config *smbfern.PentestSmbConfig) (
-	[]*commonprotocol.SmbAuthAttempt, []*commonprotocol.SmbAuthAttempt, []string) {
+	[]*commonprotocolfern.SmbAuthAttempt, []*commonprotocolfern.SmbAuthAttempt, []string) {
 
-	var allAttempts []*commonprotocol.SmbAuthAttempt
-	var successfulAttempts []*commonprotocol.SmbAuthAttempt
+	var allAttempts []*commonprotocolfern.SmbAuthAttempt
+	var successfulAttempts []*commonprotocolfern.SmbAuthAttempt
 	var errors []string
 
 	// Generate credential pairs
@@ -174,7 +174,7 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 }
 
 // attemptAuthenticationWithContext performs a single authentication attempt with context
-func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*commonprotocol.SmbAuthAttempt, error) {
+func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*commonprotocolfern.SmbAuthAttempt, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
 
@@ -182,7 +182,7 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 	client.SetCredentials(username, password, domain)
 
 	timestamp := time.Now()
-	attempt := &commonprotocol.SmbAuthAttempt{
+	attempt := &commonprotocolfern.SmbAuthAttempt{
 		Username:  username,
 		Password:  password,
 		Domain:    &domain,

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	"github.com/Method-Security/networkscan/generated/go/pentest"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
@@ -46,13 +47,20 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(config.Timeout) * time.Millisecond
 
-	var serverInfo *smbfern.SmbServerInfo
+	var serverInfo *commonprotocol.SmbServerInfo
 	if clientServerInfo, err := client.ExtractServerInfoFromChallenge(ctx); err == nil && clientServerInfo != nil {
-		serverInfo = &smbfern.SmbServerInfo{
-			ServerName:      &clientServerInfo.ServerName,
-			Domain:          &clientServerInfo.Domain,
-			OsVersion:       &clientServerInfo.OSVersion,
-			SigningRequired: &clientServerInfo.SigningRequired,
+		serverInfo = &commonprotocol.SmbServerInfo{
+			ServerName:        &clientServerInfo.ServerName,
+			Domain:            &clientServerInfo.Domain,
+			NetBiosDomainName: &clientServerInfo.NetBIOSDomainName,
+			Workgroup:         &clientServerInfo.Domain, // Use domain as workgroup fallback
+			OsVersion:         &clientServerInfo.OSVersion,
+			Capabilities:      clientServerInfo.Capabilities,
+			SigningRequired:   &clientServerInfo.SigningRequired,
+		}
+		// Include raw OS version if available
+		if clientServerInfo.RawOSVersion != "" {
+			serverInfo.RawOsVersion = &clientServerInfo.RawOSVersion
 		}
 	}
 	result.ServerInfo = serverInfo
@@ -75,10 +83,10 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 // performAuthAttemptsWithContext performs credential-based authentication attempts with context
 func performAuthAttemptsWithContext(ctx context.Context, host string, port int, config *smbfern.PentestSmbConfig) (
-	[]*smbfern.AuthAttempt, []*smbfern.AuthAttempt, []string) {
+	[]*commonprotocol.SmbAuthAttempt, []*commonprotocol.SmbAuthAttempt, []string) {
 
-	var allAttempts []*smbfern.AuthAttempt
-	var successfulAttempts []*smbfern.AuthAttempt
+	var allAttempts []*commonprotocol.SmbAuthAttempt
+	var successfulAttempts []*commonprotocol.SmbAuthAttempt
 	var errors []string
 
 	// Generate credential pairs
@@ -166,7 +174,7 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 }
 
 // attemptAuthenticationWithContext performs a single authentication attempt with context
-func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*smbfern.AuthAttempt, error) {
+func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*commonprotocol.SmbAuthAttempt, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
 
@@ -174,7 +182,7 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 	client.SetCredentials(username, password, domain)
 
 	timestamp := time.Now()
-	attempt := &smbfern.AuthAttempt{
+	attempt := &commonprotocol.SmbAuthAttempt{
 		Username:  username,
 		Password:  password,
 		Domain:    &domain,

--- a/internal/pentest/smb/lsadump.go
+++ b/internal/pentest/smb/lsadump.go
@@ -15,13 +15,9 @@ import (
 )
 
 // PerformLsadump performs LSA secrets dumping
-func PerformLsadump(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authenticatedSession *gosmb.Connection) (*smbfern.LsadumpDetails, error) {
+func PerformLsadump(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authenticatedSession *gosmb.Connection) (*smbfern.LsadumpResult, error) {
 
-	details := &smbfern.LsadumpDetails{
-		Target: target,
-	}
-
-	var errors []string
+	result := &smbfern.LsadumpResult{}
 
 	host, port := utils.ParseHostPort(target, 445)
 
@@ -32,23 +28,17 @@ func PerformLsadump(ctx context.Context, target string, config *smbfern.PentestS
 
 	// Validate authenticated session is provided
 	if authenticatedSession == nil {
-		err := fmt.Errorf("LSA dump requires an authenticated SMB session")
-		errors = append(errors, err.Error())
-		details.Errors = errors
-		return details, err
+		return result, fmt.Errorf("LSA dump requires an authenticated SMB session")
 	}
 
 	// Perform LSA dump operation using the authenticated session
 	lsaResults, dumpErrors := performLsaDumpOperation(ctx, host, port, authenticatedSession, config.Timeout)
 
-	details.LsaSecrets = lsaResults
+	result.LsaSecrets = lsaResults
 
+	// Return errors if any occurred during dumping
 	if len(dumpErrors) > 0 {
-		errors = append(errors, dumpErrors...)
-	}
-
-	if len(errors) > 0 {
-		details.Errors = errors
+		return result, fmt.Errorf("LSA dump errors: %v", dumpErrors)
 	}
 
 	log.Info("LSA dump operation completed",
@@ -59,7 +49,7 @@ func PerformLsadump(ctx context.Context, target string, config *smbfern.PentestS
 		svc1log.SafeParam("operation", "LSA_DUMP"),
 		svc1log.SafeParam("target", host))
 
-	return details, nil
+	return result, nil
 }
 
 // performLsaDumpOperation performs the actual LSA dumping operations

--- a/internal/pentest/smb/samdump.go
+++ b/internal/pentest/smb/samdump.go
@@ -15,13 +15,9 @@ import (
 )
 
 // PerformSamdump performs SAM secrets dumping
-func PerformSamdump(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authenticatedSession *gosmb.Connection) (*smbfern.SamdumpDetails, error) {
+func PerformSamdump(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authenticatedSession *gosmb.Connection) (*smbfern.SamdumpResult, error) {
 
-	details := &smbfern.SamdumpDetails{
-		Target: target,
-	}
-
-	var errors []string
+	result := &smbfern.SamdumpResult{}
 
 	host, port := utils.ParseHostPort(target, 445)
 
@@ -32,23 +28,17 @@ func PerformSamdump(ctx context.Context, target string, config *smbfern.PentestS
 
 	// Validate authenticated session is provided
 	if authenticatedSession == nil {
-		err := fmt.Errorf("SAM dump requires an authenticated SMB session")
-		errors = append(errors, err.Error())
-		details.Errors = errors
-		return details, err
+		return result, fmt.Errorf("SAM dump requires an authenticated SMB session")
 	}
 
 	// Perform SAM dump operation using the authenticated session
 	samResults, dumpErrors := performSamDumpOperation(ctx, host, port, authenticatedSession, config.Timeout)
 
-	details.SamSecrets = samResults
+	result.SamSecrets = samResults
 
+	// Return errors if any occurred during dumping
 	if len(dumpErrors) > 0 {
-		errors = append(errors, dumpErrors...)
-	}
-
-	if len(errors) > 0 {
-		details.Errors = errors
+		return result, fmt.Errorf("SAM dump errors: %v", dumpErrors)
 	}
 
 	log.Info("SAM dump operation completed",
@@ -59,7 +49,7 @@ func PerformSamdump(ctx context.Context, target string, config *smbfern.PentestS
 		svc1log.SafeParam("operation", "SAM_DUMP"),
 		svc1log.SafeParam("target", host))
 
-	return details, nil
+	return result, nil
 }
 
 // performSamDumpOperation performs the actual SAM dumping operations

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -114,13 +114,16 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 				errors = append(errors, err.Error())
 			}
 
-			attempts = append(attempts, attempt)
+			// Only include attempt in output if not filtering to successful only, or if attempt was successful
+			if !config.SuccessfulOnly || attempt.Response.Success {
+				attempts = append(attempts, attempt)
+			}
 
 			if attempt.Response.Success {
 				targetWithPort := fmt.Sprintf("%s:%d", host, port)
 				validUsernames = append(validUsernames, &pentest.Credential{
 					Username: username,
-					Domain:   config.Domain,
+					Domain:   &config.Domain,
 					Target:   &targetWithPort,
 					Service:  &config.Service,
 				})
@@ -158,7 +161,7 @@ func (e *Engine) performUsernameEnumAttempt(ctx context.Context, target string, 
 	request := &pentest.SprayRequest{
 		Credential: &pentest.Credential{
 			Username: username,
-			Domain:   config.Domain,
+			Domain:   &config.Domain,
 		},
 	}
 
@@ -203,8 +206,8 @@ func (e *Engine) performKerberosUsernameEnum(ctx context.Context, target, userna
 	}
 
 	// If domain is specified in config, use it; otherwise use extracted domain
-	if config.Domain != nil && *config.Domain != "" {
-		kerberosTarget.Domain = strings.ToUpper(*config.Domain)
+	if config.Domain != "" {
+		kerberosTarget.Domain = strings.ToUpper(config.Domain)
 	}
 
 	// Perform username enumeration
@@ -273,7 +276,10 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 					errors = append(errors, err.Error())
 				}
 
-				attempts = append(attempts, attempt)
+				// Only include attempt in output if not filtering to successful only, or if attempt was successful
+				if !config.SuccessfulOnly || attempt.Response.Success {
+					attempts = append(attempts, attempt)
+				}
 
 				if attempt.Response.Success {
 					targetWithPort := fmt.Sprintf("%s:%d", host, port)

--- a/internal/pentest/ssh/auth.go
+++ b/internal/pentest/ssh/auth.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -54,7 +55,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 }
 
 // extractBaseServerInfoWithContext extracts basic server information from SSH connection with context
-func extractBaseServerInfoWithContext(ctx context.Context, host string, port int, timeout int) (*sshfern.SshServerInfo, error) {
+func extractBaseServerInfoWithContext(ctx context.Context, host string, port int, timeout int) (*commonprotocol.SshServerInfo, error) {
 	sshConfig := &ssh.ClientConfig{
 		User:            "probe",            // Use a dummy user for probing
 		Auth:            []ssh.AuthMethod{}, // No auth methods
@@ -67,7 +68,7 @@ func extractBaseServerInfoWithContext(ctx context.Context, host string, port int
 	// This will fail auth but give us server info
 	conn, err := ssh.Dial("tcp", targetAddr, sshConfig)
 
-	serverInfo := &sshfern.SshServerInfo{}
+	serverInfo := &commonprotocol.SshServerInfo{}
 
 	if err != nil {
 		// Parse server version and supported methods from error
@@ -85,7 +86,9 @@ func extractBaseServerInfoWithContext(ctx context.Context, host string, port int
 		}
 
 		// Default supported auth methods (common ones)
-		authMethods := []string{"password", "publickey", "keyboard-interactive"}
+		var authMethods []commonprotocol.SshAuthMethod
+		authMethods = append(authMethods, commonprotocol.SshAuthMethodPassword)
+		authMethods = append(authMethods, commonprotocol.SshAuthMethodPublicKey)
 		serverInfo.SupportedAuthMethods = authMethods
 	} else {
 		// Successful connection (unlikely with dummy user)
@@ -107,10 +110,10 @@ func extractBaseServerInfoWithContext(ctx context.Context, host string, port int
 
 // performAuthAttemptsWithContext performs credential-based authentication attempts with context
 func performAuthAttemptsWithContext(ctx context.Context, host string, port int, config *sshfern.PentestSshConfig) (
-	[]*sshfern.AuthAttempt, []*sshfern.AuthAttempt, []string) {
+	[]*commonprotocol.SshAuthAttempt, []*commonprotocol.SshAuthAttempt, []string) {
 
-	var allAttempts []*sshfern.AuthAttempt
-	var successfulAttempts []*sshfern.AuthAttempt
+	var allAttempts []*commonprotocol.SshAuthAttempt
+	var successfulAttempts []*commonprotocol.SshAuthAttempt
 	var errors []string
 
 	// Generate credential pairs
@@ -177,9 +180,9 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 }
 
 // attemptAuthenticationWithContext performs a single SSH authentication attempt with context
-func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*sshfern.AuthAttempt, error) {
+func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*commonprotocol.SshAuthAttempt, error) {
 	timestamp := time.Now()
-	attempt := &sshfern.AuthAttempt{
+	attempt := &commonprotocol.SshAuthAttempt{
 		Username:  username,
 		Password:  password,
 		Success:   false,

--- a/internal/pentest/ssh/auth.go
+++ b/internal/pentest/ssh/auth.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -55,7 +55,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 }
 
 // extractBaseServerInfoWithContext extracts basic server information from SSH connection with context
-func extractBaseServerInfoWithContext(ctx context.Context, host string, port int, timeout int) (*commonprotocol.SshServerInfo, error) {
+func extractBaseServerInfoWithContext(ctx context.Context, host string, port int, timeout int) (*commonprotocolfern.SshServerInfo, error) {
 	sshConfig := &ssh.ClientConfig{
 		User:            "probe",            // Use a dummy user for probing
 		Auth:            []ssh.AuthMethod{}, // No auth methods
@@ -68,7 +68,7 @@ func extractBaseServerInfoWithContext(ctx context.Context, host string, port int
 	// This will fail auth but give us server info
 	conn, err := ssh.Dial("tcp", targetAddr, sshConfig)
 
-	serverInfo := &commonprotocol.SshServerInfo{}
+	serverInfo := &commonprotocolfern.SshServerInfo{}
 
 	if err != nil {
 		// Parse server version and supported methods from error
@@ -86,9 +86,9 @@ func extractBaseServerInfoWithContext(ctx context.Context, host string, port int
 		}
 
 		// Default supported auth methods (common ones)
-		var authMethods []commonprotocol.SshAuthMethod
-		authMethods = append(authMethods, commonprotocol.SshAuthMethodPassword)
-		authMethods = append(authMethods, commonprotocol.SshAuthMethodPublicKey)
+		var authMethods []commonprotocolfern.SshAuthMethod
+		authMethods = append(authMethods, commonprotocolfern.SshAuthMethodPassword)
+		authMethods = append(authMethods, commonprotocolfern.SshAuthMethodPublicKey)
 		serverInfo.SupportedAuthMethods = authMethods
 	} else {
 		// Successful connection (unlikely with dummy user)
@@ -110,10 +110,10 @@ func extractBaseServerInfoWithContext(ctx context.Context, host string, port int
 
 // performAuthAttemptsWithContext performs credential-based authentication attempts with context
 func performAuthAttemptsWithContext(ctx context.Context, host string, port int, config *sshfern.PentestSshConfig) (
-	[]*commonprotocol.SshAuthAttempt, []*commonprotocol.SshAuthAttempt, []string) {
+	[]*commonprotocolfern.SshAuthAttempt, []*commonprotocolfern.SshAuthAttempt, []string) {
 
-	var allAttempts []*commonprotocol.SshAuthAttempt
-	var successfulAttempts []*commonprotocol.SshAuthAttempt
+	var allAttempts []*commonprotocolfern.SshAuthAttempt
+	var successfulAttempts []*commonprotocolfern.SshAuthAttempt
 	var errors []string
 
 	// Generate credential pairs
@@ -180,9 +180,9 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 }
 
 // attemptAuthenticationWithContext performs a single SSH authentication attempt with context
-func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*commonprotocol.SshAuthAttempt, error) {
+func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*commonprotocolfern.SshAuthAttempt, error) {
 	timestamp := time.Now()
-	attempt := &commonprotocol.SshAuthAttempt{
+	attempt := &commonprotocolfern.SshAuthAttempt{
 		Username:  username,
 		Password:  password,
 		Success:   false,

--- a/internal/pentest/ssh/command.go
+++ b/internal/pentest/ssh/command.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"time"
 
-	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
+	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	"golang.org/x/crypto/ssh"
 )
 
 // ExecuteCommands executes commands on the remote SSH server using valid credentials
 // This function requires successful authentication first
-func ExecuteCommands(host string, port int, username, password string, commands []string, timeout int) ([]*sshfern.CommandExecution, error) {
-	var executions []*sshfern.CommandExecution
+func ExecuteCommands(host string, port int, username, password string, commands []string, timeout int) ([]*commonprotocol.SshCommandExecution, error) {
+	var executions []*commonprotocol.SshCommandExecution
 
 	sshConfig := &ssh.ClientConfig{
 		User:            username,
@@ -30,7 +30,7 @@ func ExecuteCommands(host string, port int, username, password string, commands 
 	for _, command := range commands {
 		execution, err := executeCommand(conn, command)
 		if err != nil {
-			execution = &sshfern.CommandExecution{
+			execution = &commonprotocol.SshCommandExecution{
 				Command:   command,
 				Output:    fmt.Sprintf("Error: %v", err),
 				ExitCode:  nil,
@@ -44,7 +44,7 @@ func ExecuteCommands(host string, port int, username, password string, commands 
 }
 
 // executeCommand executes a single command over SSH
-func executeCommand(conn *ssh.Client, command string) (*sshfern.CommandExecution, error) {
+func executeCommand(conn *ssh.Client, command string) (*commonprotocol.SshCommandExecution, error) {
 	session, err := conn.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %v", err)
@@ -53,7 +53,7 @@ func executeCommand(conn *ssh.Client, command string) (*sshfern.CommandExecution
 
 	output, err := session.CombinedOutput(command)
 
-	execution := &sshfern.CommandExecution{
+	execution := &commonprotocol.SshCommandExecution{
 		Command:   command,
 		Output:    string(output),
 		Timestamp: time.Now(),

--- a/internal/pentest/ssh/command.go
+++ b/internal/pentest/ssh/command.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"time"
 
-	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	"golang.org/x/crypto/ssh"
 )
 
 // ExecuteCommands executes commands on the remote SSH server using valid credentials
 // This function requires successful authentication first
-func ExecuteCommands(host string, port int, username, password string, commands []string, timeout int) ([]*commonprotocol.SshCommandExecution, error) {
-	var executions []*commonprotocol.SshCommandExecution
+func ExecuteCommands(host string, port int, username, password string, commands []string, timeout int) ([]*commonprotocolfern.SshCommandExecution, error) {
+	var executions []*commonprotocolfern.SshCommandExecution
 
 	sshConfig := &ssh.ClientConfig{
 		User:            username,
@@ -30,7 +30,7 @@ func ExecuteCommands(host string, port int, username, password string, commands 
 	for _, command := range commands {
 		execution, err := executeCommand(conn, command)
 		if err != nil {
-			execution = &commonprotocol.SshCommandExecution{
+			execution = &commonprotocolfern.SshCommandExecution{
 				Command:   command,
 				Output:    fmt.Sprintf("Error: %v", err),
 				ExitCode:  nil,
@@ -44,7 +44,7 @@ func ExecuteCommands(host string, port int, username, password string, commands 
 }
 
 // executeCommand executes a single command over SSH
-func executeCommand(conn *ssh.Client, command string) (*commonprotocol.SshCommandExecution, error) {
+func executeCommand(conn *ssh.Client, command string) (*commonprotocolfern.SshCommandExecution, error) {
 	session, err := conn.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %v", err)
@@ -53,7 +53,7 @@ func executeCommand(conn *ssh.Client, command string) (*commonprotocol.SshComman
 
 	output, err := session.CombinedOutput(command)
 
-	execution := &commonprotocol.SshCommandExecution{
+	execution := &commonprotocolfern.SshCommandExecution{
 		Command:   command,
 		Output:    string(output),
 		Timestamp: time.Now(),

--- a/internal/protocol/smb/client.go
+++ b/internal/protocol/smb/client.go
@@ -30,15 +30,15 @@ type Client struct {
 
 // ServerInfo contains basic server information extracted from SMB connection
 type ServerInfo struct {
-	ServerName         string
-	Domain             string
-	NetBIOSDomainName  string
-	OSVersion          string
-	ServerType         string
-	IsDomainController bool
-	Capabilities       []string
-	SigningRequired    bool
-	SupportedVersions  []string
+	ServerName        string
+	Domain            string
+	NetBIOSDomainName string
+	OSVersion         string
+	RawOSVersion      string
+	ServerType        string
+	Capabilities      []string
+	SigningRequired   bool
+	SupportedVersions []string
 }
 
 // ShareInfo represents SMB share information
@@ -155,6 +155,7 @@ func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*ServerInf
 
 	// Parse and enhance the OS version
 	if targetInfo.GuessedOSVersion != "" {
+		serverInfo.RawOSVersion = targetInfo.GuessedOSVersion
 		serverInfo.OSVersion = parseWindowsVersion(targetInfo.GuessedOSVersion)
 	} else {
 		serverInfo.OSVersion = "Windows Server"
@@ -418,6 +419,7 @@ func (c *Client) extractServerInfoWithContext(ctx context.Context) error {
 
 		// Parse and enhance the OS version
 		if targetInfo.GuessedOSVersion != "" {
+			c.serverInfo.RawOSVersion = targetInfo.GuessedOSVersion
 			c.serverInfo.OSVersion = parseWindowsVersion(targetInfo.GuessedOSVersion)
 		} else {
 			c.serverInfo.OSVersion = "Windows Server"

--- a/internal/protocol/smb/helpers.go
+++ b/internal/protocol/smb/helpers.go
@@ -3,22 +3,22 @@ package smb
 import (
 	"context"
 
-	smb "github.com/Method-Security/networkscan/generated/go/enumerate/smb"
+	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // MapProtocolVersionToEnum maps protocol version strings to Fern enum values
 // This function is shared between enumerate and pentest modules
-func MapProtocolVersionToEnum(version string) (smb.SmbVersion, bool) {
+func MapProtocolVersionToEnum(version string) (commonprotocol.SmbVersion, bool) {
 	switch version {
 	case "SMB3.0.2":
-		return smb.SmbVersionSmb302, true
+		return commonprotocol.SmbVersionSmb302, true
 	case "SMB3.0":
-		return smb.SmbVersionSmb30, true
+		return commonprotocol.SmbVersionSmb30, true
 	case "SMB2.1":
-		return smb.SmbVersionSmb21, true
+		return commonprotocol.SmbVersionSmb21, true
 	case "SMB2.0":
-		return smb.SmbVersionSmb20, true
+		return commonprotocol.SmbVersionSmb20, true
 	default:
 		return "", false // Unknown version
 	}

--- a/internal/protocol/smb/helpers.go
+++ b/internal/protocol/smb/helpers.go
@@ -3,22 +3,22 @@ package smb
 import (
 	"context"
 
-	commonprotocol "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // MapProtocolVersionToEnum maps protocol version strings to Fern enum values
 // This function is shared between enumerate and pentest modules
-func MapProtocolVersionToEnum(version string) (commonprotocol.SmbVersion, bool) {
+func MapProtocolVersionToEnum(version string) (commonprotocolfern.SmbVersion, bool) {
 	switch version {
 	case "SMB3.0.2":
-		return commonprotocol.SmbVersionSmb302, true
+		return commonprotocolfern.SmbVersionSmb302, true
 	case "SMB3.0":
-		return commonprotocol.SmbVersionSmb30, true
+		return commonprotocolfern.SmbVersionSmb30, true
 	case "SMB2.1":
-		return commonprotocol.SmbVersionSmb21, true
+		return commonprotocolfern.SmbVersionSmb21, true
 	case "SMB2.0":
-		return commonprotocol.SmbVersionSmb20, true
+		return commonprotocolfern.SmbVersionSmb20, true
 	default:
 		return "", false // Unknown version
 	}


### PR DESCRIPTION
### TL;DR

Added a new `--successful-only` flag to username spray and restructured protocol definitions to improve consistency across modules.

### What changed?

- Added a new `--successful-only` flag to the username spray command to filter output to only show successful username enumerations
- Made the `--domain` flag required for username spray operations
- Restructured protocol definitions by creating common protocol types in `fern/definition/common/protocol/`:
  - Added `smb.yml` and `ssh.yml` with standardized protocol structures
  - Updated existing modules to use these common protocol definitions
  - Refactored domain controller info to use the common SMB server info structure
- Reorganized SMB pentest definitions by creating separate files for `samdump.yml` and `lsadump.yml`

### How to test?

1. Test the username spray command with the new `--successful-only` flag:
   ```
   networkscan pentest spray username --targets 192.168.1.1 --service kerberos --domain CONTOSO --usernames user1,user2 --successful-only
   ```

2. Verify that only successful username enumerations appear in the output

3. Test that the domain flag is now properly required:
   ```
   networkscan pentest spray username --targets 192.168.1.1 --service kerberos
   ```
   This should fail with an error about the missing required domain flag.

### Why make this change?

- The `--successful-only` flag helps reduce noise in output when only successful username enumerations are needed
- Making the domain flag required prevents errors in username spray operations where the domain is necessary
- The protocol restructuring improves code organization and consistency across modules, making it easier to maintain and extend the codebase
- Common protocol definitions reduce duplication and ensure consistent handling of protocol-specific data structures