### PR TITLE
Make PentestLdapResult optional in PentestLdapReport

### DIFF
--- a/fern/definition/pentest/ldap/ldap.yml
+++ b/fern/definition/pentest/ldap/ldap.yml
@@ -25,7 +25,7 @@ types:
   LdapAuthResult:
     properties:
       target: string
-      domain: string  
+      domain: string
       successful: boolean
       username: string
       message: string
@@ -41,5 +41,5 @@ types:
   PentestLdapReport:
     properties:
       config: PentestLdapConfig
-      result: PentestLdapResult
+      result: optional<PentestLdapResult>
       errors: optional<list<string>>


### PR DESCRIPTION
### TL;DR

Made `result` field optional in `PentestLdapReport` type.

### What changed?

Modified the `PentestLdapReport` type definition in the LDAP schema to make the `result` field optional by changing it from `result: PentestLdapResult` to `result: optional<PentestLdapResult>`.

### How to test?

1. Verify that the API still accepts requests with a `result` field in the `PentestLdapReport`
2. Verify that the API now accepts requests without a `result` field in the `PentestLdapReport`
3. Ensure that clients consuming the API can handle cases where `result` is not present

### Why make this change?

This change allows for more flexibility in the API, particularly in error scenarios where a valid result might not be available but we still want to return the configuration and any errors. Making the `result` field optional improves error handling and makes the API more robust.