### PR TITLE
Make domain object properties optional in LDAP domain dump

### DIFF
--- a/fern/definition/pentest/ldap/domaindump.yml
+++ b/fern/definition/pentest/ldap/domaindump.yml
@@ -3,7 +3,7 @@ imports:
 
 types:
   # ENUMs for Domain Dumping
-  
+
   # Collection Methods - only the ones we currently implement
   CollectionMethod:
     enum:
@@ -26,13 +26,13 @@ types:
   # Domain User Objects
   DomainUserProperties:
     properties:
-      name: string
-      domain: string
-      domainsid: string
-      distinguishedname: string
-      unconstraineddelegation: boolean
-      trustedtoauth: boolean
-      passwordnotreqd: boolean
+      name: optional<string>
+      domain: optional<string>
+      domainsid: optional<string>
+      distinguishedname: optional<string>
+      unconstraineddelegation: optional<boolean>
+      trustedtoauth: optional<boolean>
+      passwordnotreqd: optional<boolean>
       enabled: optional<boolean>
       lastlogon: optional<string>
       pwdlastset: optional<string>
@@ -48,61 +48,61 @@ types:
 
   DomainUser:
     properties:
-      AllowedToDelegate: list<string>
-      ObjectIdentifier: string
+      AllowedToDelegate: optional<list<string>>
+      ObjectIdentifier: optional<string>
       PrimaryGroupSID: optional<string>
-      Properties: DomainUserProperties
-      Aces: list<string>
-      SPNTargets: list<string>
-      HasSIDHistory: list<string>
-      IsDeleted: boolean
+      Properties: optional<DomainUserProperties>
+      Aces: optional<list<string>>
+      SPNTargets: optional<list<string>>
+      HasSIDHistory: optional<list<string>>
+      IsDeleted: optional<boolean>
       IsACLProtected: optional<boolean>
 
   # Domain Group Objects
   DomainGroupProperties:
     properties:
-      domain: string
-      domainsid: string
-      highvalue: boolean
-      name: string
-      distinguishedname: string
+      domain: optional<string>
+      domainsid: optional<string>
+      highvalue: optional<boolean>
+      name: optional<string>
+      distinguishedname: optional<string>
       admincount: optional<integer>
       description: optional<string>
 
   GroupMember:
     properties:
-      ObjectIdentifier: string
-      ObjectType: string
+      ObjectIdentifier: optional<string>
+      ObjectType: optional<string>
 
   DomainGroup:
     properties:
-      ObjectIdentifier: string
-      Properties: DomainGroupProperties
-      Members: list<GroupMember>
-      Aces: list<string>
-      IsDeleted: boolean
+      ObjectIdentifier: optional<string>
+      Properties: optional<DomainGroupProperties>
+      Members: optional<list<GroupMember>>
+      Aces: optional<list<string>>
+      IsDeleted: optional<boolean>
 
   # Domain Computer Objects
   DomainComputer:
     properties:
-      distinguishedName: string
-      samAccountName: string
+      distinguishedName: optional<string>
+      samAccountName: optional<string>
       dnsHostName: optional<string>
       description: optional<string>
-      objectSid: string
+      objectSid: optional<string>
       operatingSystem: optional<string>
       operatingSystemVersion: optional<string>
-      enabled: boolean
+      enabled: optional<boolean>
       lastLogon: optional<string>
       servicePrincipalNames: optional<list<string>>
-      isDomainController: boolean
+      isDomainController: optional<boolean>
 
   # Domain Controller Objects
   DomainController:
     properties:
-      distinguishedName: string
-      samAccountName: string
-      dnsHostName: string
+      distinguishedName: optional<string>
+      samAccountName: optional<string>
+      dnsHostName: optional<string>
       siteName: optional<string>
       operatingSystem: optional<string>
       operatingSystemVersion: optional<string>
@@ -111,16 +111,16 @@ types:
   # Organizational Unit Objects
   OrganizationalUnit:
     properties:
-      distinguishedName: string
-      name: string
+      distinguishedName: optional<string>
+      name: optional<string>
       description: optional<string>
       gpoLinks: optional<list<string>>
 
   # Group Policy Object Objects
   GroupPolicyObject:
     properties:
-      distinguishedName: string
-      displayName: string
+      distinguishedName: optional<string>
+      displayName: optional<string>
       description: optional<string>
       gpcFileSysPath: optional<string>
       versionNumber: optional<integer>
@@ -128,29 +128,29 @@ types:
   # Domain Trust Objects
   DomainTrust:
     properties:
-      sourceDomain: string
-      targetDomain: string
-      trustDirection: string
-      trustType: string
+      sourceDomain: optional<string>
+      targetDomain: optional<string>
+      trustDirection: optional<string>
+      trustType: optional<string>
       trustAttributes: optional<string>
 
   # Result Types - matching BloodHound reference structure
   DomainDataMeta:
     properties:
-      methods: integer
-      type: string
-      count: integer
-      version: integer
+      methods: optional<integer>
+      type: optional<string>
+      count: optional<integer>
+      version: optional<integer>
 
   DomainUsersResult:
     properties:
-      data: list<DomainUser>
-      meta: DomainDataMeta
+      data: optional<list<DomainUser>>
+      meta: optional<DomainDataMeta>
 
   DomainGroupsResult:
     properties:
-      data: list<DomainGroup>
-      meta: DomainDataMeta
+      data: optional<list<DomainGroup>>
+      meta: optional<DomainDataMeta>
 
   # Domain Dump Result
   DomainDumpResult:
@@ -162,7 +162,7 @@ types:
       organizationalUnits: optional<list<OrganizationalUnit>>
       groupPolicyObjects: optional<list<GroupPolicyObject>>
       domainTrusts: optional<list<DomainTrust>>
-      totalObjects: integer
+      totalObjects: optional<integer>
 
   # Domain Dump Config
   DomainDumpConfig:

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -70,7 +70,7 @@ types:
     properties:
       target: string # Target host:port
       service: SprayTargetService
-      attempts: list<SprayAttempt>
+      attempts: optional<list<SprayAttempt>>
       statistics: SprayStatistics
       successfulCredentials: optional<list<Credential>>
       errors: optional<list<string>>

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -15,6 +15,11 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+// Helper functions for creating pointers to primitive values
+func stringPtr(s string) *string { return &s }
+func intPtr(i int) *int          { return &i }
+func boolPtr(b bool) *bool       { return &b }
+
 type LibraryPentestLdap struct{}
 
 func (l *LibraryPentestLdap) DomainDump(ctx context.Context, config ldapfern.PentestLdapConfig) (*ldapfern.PentestLdapResult, []string) {
@@ -194,7 +199,7 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 		if sidBytes := entry.GetRawAttributeValue("objectSid"); len(sidBytes) > 0 {
 			objectSID = l.convertSIDToString(string(sidBytes))
 		}
-		user.ObjectIdentifier = objectSID
+		user.ObjectIdentifier = &objectSID
 
 		// Set PrimaryGroupSID
 		if primaryGroupID := entry.GetAttributeValue("primaryGroupID"); primaryGroupID != "" {
@@ -208,28 +213,28 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 		// Required fields
 		samAccountName := entry.GetAttributeValue("sAMAccountName")
 		if upn := entry.GetAttributeValue("userPrincipalName"); upn != "" {
-			properties.Name = strings.ToUpper(upn)
+			properties.Name = stringPtr(strings.ToUpper(upn))
 		} else {
-			properties.Name = fmt.Sprintf("%s@%s", strings.ToUpper(samAccountName), domain)
+			properties.Name = stringPtr(fmt.Sprintf("%s@%s", strings.ToUpper(samAccountName), domain))
 		}
-		properties.Domain = domain
-		properties.Domainsid = domainSID
-		properties.Distinguishedname = strings.ToUpper(entry.GetAttributeValue("distinguishedName"))
+		properties.Domain = stringPtr(domain)
+		properties.Domainsid = stringPtr(domainSID)
+		properties.Distinguishedname = stringPtr(strings.ToUpper(entry.GetAttributeValue("distinguishedName")))
 
 		// Set defaults for required boolean fields
-		properties.Unconstraineddelegation = false
-		properties.Trustedtoauth = false
-		properties.Passwordnotreqd = false
+		properties.Unconstraineddelegation = boolPtr(false)
+		properties.Trustedtoauth = boolPtr(false)
+		properties.Passwordnotreqd = boolPtr(false)
 
 		// Optional fields
 		if displayName := entry.GetAttributeValue("displayName"); displayName != "" {
-			properties.Displayname = &displayName
+			properties.Displayname = stringPtr(displayName)
 		}
 		if description := entry.GetAttributeValue("description"); description != "" {
-			properties.Description = &description
+			properties.Description = stringPtr(description)
 		}
 		if samAccountName != "" {
-			properties.Samaccountname = &samAccountName
+			properties.Samaccountname = stringPtr(samAccountName)
 		}
 
 		// Parse userAccountControl for security flags (following Active Directory best practices)
@@ -237,41 +242,41 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 			if uac, err := strconv.Atoi(uacStr); err == nil {
 				// Account enabled check
 				enabled := (uac & 0x0002) == 0 // UF_ACCOUNTDISABLE = 0x0002
-				properties.Enabled = &enabled
+				properties.Enabled = boolPtr(enabled)
 
 				// Password flags
 				passwordNotReqd := (uac & 0x0020) != 0 // UF_PASSWD_NOTREQD = 0x0020
-				properties.Passwordnotreqd = passwordNotReqd
+				properties.Passwordnotreqd = boolPtr(passwordNotReqd)
 
 				// Kerberos flags (standard security analysis)
 				dontReqPreauth := (uac & 0x00400000) != 0 // UF_DONT_REQUIRE_PREAUTH
-				properties.Dontreqpreauth = &dontReqPreauth
+				properties.Dontreqpreauth = boolPtr(dontReqPreauth)
 
 				// Account sensitivity
 				sensitive := (uac & 0x00100000) != 0 // UF_NOT_DELEGATED
-				properties.Sensitive = &sensitive
+				properties.Sensitive = boolPtr(sensitive)
 
 				// Delegation flags
 				trustedForDelegation := (uac & 0x00080000) != 0 // UF_TRUSTED_FOR_DELEGATION
-				properties.Unconstraineddelegation = trustedForDelegation
+				properties.Unconstraineddelegation = boolPtr(trustedForDelegation)
 
 				trustedToAuth := (uac & 0x01000000) != 0 // UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION
-				properties.Trustedtoauth = trustedToAuth
+				properties.Trustedtoauth = boolPtr(trustedToAuth)
 			}
 		}
 
 		// Keep timestamps as raw values like reference
 		if lastLogon := entry.GetAttributeValue("lastLogon"); lastLogon != "" {
-			properties.Lastlogon = &lastLogon
+			properties.Lastlogon = stringPtr(lastLogon)
 		}
 		if pwdLastSet := entry.GetAttributeValue("pwdLastSet"); pwdLastSet != "" {
-			properties.Pwdlastset = &pwdLastSet
+			properties.Pwdlastset = stringPtr(pwdLastSet)
 		}
 
 		// Get admin count
 		if adminCountStr := entry.GetAttributeValue("adminCount"); adminCountStr != "" {
 			if adminCount, err := strconv.Atoi(adminCountStr); err == nil {
-				properties.Admincount = &adminCount
+				properties.Admincount = intPtr(adminCount)
 			}
 		}
 
@@ -308,7 +313,7 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 		user.Aces = []string{}
 		user.SpnTargets = []string{}
 		user.HasSidHistory = sidHistory
-		user.IsDeleted = isDeleted
+		user.IsDeleted = boolPtr(isDeleted)
 
 		users = append(users, user)
 	}
@@ -360,28 +365,28 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 		if sidBytes := entry.GetRawAttributeValue("objectSid"); len(sidBytes) > 0 {
 			objectSID = l.convertSIDToString(string(sidBytes))
 		}
-		group.ObjectIdentifier = objectSID
+		group.ObjectIdentifier = stringPtr(objectSID)
 
 		// Create properties object
 		properties := &ldapfern.DomainGroupProperties{}
 
 		// Required fields
 		samAccountName := entry.GetAttributeValue("sAMAccountName")
-		properties.Name = fmt.Sprintf("%s@%s", strings.ToUpper(samAccountName), domain)
-		properties.Domain = domain
-		properties.Domainsid = domainSID
-		properties.Distinguishedname = strings.ToUpper(entry.GetAttributeValue("distinguishedName"))
+		properties.Name = stringPtr(fmt.Sprintf("%s@%s", strings.ToUpper(samAccountName), domain))
+		properties.Domain = stringPtr(domain)
+		properties.Domainsid = stringPtr(domainSID)
+		properties.Distinguishedname = stringPtr(strings.ToUpper(entry.GetAttributeValue("distinguishedName")))
 
 		// Determine if this is a high-value group
-		properties.Highvalue = l.isHighValueGroup(objectSID)
+		properties.Highvalue = boolPtr(l.isHighValueGroup(objectSID))
 
 		// Optional fields
 		if description := entry.GetAttributeValue("description"); description != "" {
-			properties.Description = &description
+			properties.Description = stringPtr(description)
 		}
 		if adminCountStr := entry.GetAttributeValue("adminCount"); adminCountStr != "" {
 			if adminCount, err := strconv.Atoi(adminCountStr); err == nil {
-				properties.Admincount = &adminCount
+				properties.Admincount = intPtr(adminCount)
 			}
 		}
 
@@ -395,8 +400,8 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 			memberSID := l.getMemberSID(ctx, conn, memberDN)
 			if memberSID != "" {
 				member := &ldapfern.GroupMember{
-					ObjectIdentifier: memberSID,
-					ObjectType:       l.determineMemberType(ctx, conn, memberDN),
+					ObjectIdentifier: stringPtr(memberSID),
+					ObjectType:       stringPtr(l.determineMemberType(ctx, conn, memberDN)),
 				}
 				members = append(members, member)
 			}
@@ -413,7 +418,7 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 
 		// Initialize empty arrays as required by reference format
 		group.Aces = []string{}
-		group.IsDeleted = isDeleted
+		group.IsDeleted = boolPtr(isDeleted)
 
 		groups = append(groups, group)
 	}
@@ -588,22 +593,22 @@ func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.
 
 	for _, entry := range sr.Entries {
 		computer := &ldapfern.DomainComputer{
-			DistinguishedName: entry.DN,
-			SamAccountName:    l.getAttributeValue(entry, "sAMAccountName"),
-			ObjectSid:         l.convertSIDToString(l.getAttributeValue(entry, "objectSid")),
+			DistinguishedName: stringPtr(entry.DN),
+			SamAccountName:    stringPtr(l.getAttributeValue(entry, "sAMAccountName")),
+			ObjectSid:         stringPtr(l.convertSIDToString(l.getAttributeValue(entry, "objectSid"))),
 		}
 
 		if dnsHostName := l.getAttributeValue(entry, "dNSHostName"); dnsHostName != "" {
-			computer.DnsHostName = &dnsHostName
+			computer.DnsHostName = stringPtr(dnsHostName)
 		}
 		if desc := l.getAttributeValue(entry, "description"); desc != "" {
-			computer.Description = &desc
+			computer.Description = stringPtr(desc)
 		}
 		if os := l.getAttributeValue(entry, "operatingSystem"); os != "" {
-			computer.OperatingSystem = &os
+			computer.OperatingSystem = stringPtr(os)
 		}
 		if osVer := l.getAttributeValue(entry, "operatingSystemVersion"); osVer != "" {
-			computer.OperatingSystemVersion = &osVer
+			computer.OperatingSystemVersion = stringPtr(osVer)
 		}
 
 		// Parse UserAccountControl flags (standard approach)
@@ -611,17 +616,17 @@ func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.
 		if uac != "" {
 			if uacInt, err := strconv.Atoi(uac); err == nil {
 				// Account enabled check
-				computer.Enabled = (uacInt & 0x0002) == 0 // UF_ACCOUNTDISABLE
+				computer.Enabled = boolPtr((uacInt & 0x0002) == 0) // UF_ACCOUNTDISABLE
 
 				// Domain Controller detection using UserAccountControl (standard method)
-				computer.IsDomainController = (uacInt & 0x00002000) != 0 // SERVER_TRUST_ACCOUNT
+				computer.IsDomainController = boolPtr((uacInt & 0x00002000) != 0) // SERVER_TRUST_ACCOUNT
 			}
 		}
 
 		// Process timestamps
 		if lastLogon := l.getAttributeValue(entry, "lastLogon"); lastLogon != "" {
 			convertedTime := l.convertFileTime(lastLogon)
-			computer.LastLogon = &convertedTime
+			computer.LastLogon = stringPtr(convertedTime)
 		}
 
 		// Service Principal Names
@@ -670,19 +675,19 @@ func (l *LibraryPentestLdap) enumerateDomainControllers(ctx context.Context, con
 
 	for _, entry := range sr.Entries {
 		dc := &ldapfern.DomainController{
-			DistinguishedName: entry.DN,
-			SamAccountName:    l.getAttributeValue(entry, "sAMAccountName"),
-			DnsHostName:       l.getAttributeValue(entry, "dNSHostName"),
+			DistinguishedName: stringPtr(entry.DN),
+			SamAccountName:    stringPtr(l.getAttributeValue(entry, "sAMAccountName")),
+			DnsHostName:       stringPtr(l.getAttributeValue(entry, "dNSHostName")),
 		}
 
 		if siteName := l.getAttributeValue(entry, "siteName"); siteName != "" {
-			dc.SiteName = &siteName
+			dc.SiteName = stringPtr(siteName)
 		}
 		if os := l.getAttributeValue(entry, "operatingSystem"); os != "" {
-			dc.OperatingSystem = &os
+			dc.OperatingSystem = stringPtr(os)
 		}
 		if osVer := l.getAttributeValue(entry, "operatingSystemVersion"); osVer != "" {
-			dc.OperatingSystemVersion = &osVer
+			dc.OperatingSystemVersion = stringPtr(osVer)
 		}
 
 		roles := entry.GetAttributeValues("serverReferenceBL")
@@ -729,12 +734,12 @@ func (l *LibraryPentestLdap) enumerateOrganizationalUnits(ctx context.Context, c
 
 	for _, entry := range sr.Entries {
 		ou := &ldapfern.OrganizationalUnit{
-			DistinguishedName: entry.DN,
-			Name:              l.getAttributeValue(entry, "name"),
+			DistinguishedName: stringPtr(entry.DN),
+			Name:              stringPtr(l.getAttributeValue(entry, "name")),
 		}
 
 		if desc := l.getAttributeValue(entry, "description"); desc != "" {
-			ou.Description = &desc
+			ou.Description = stringPtr(desc)
 		}
 
 		gpoLinks := entry.GetAttributeValues("gPLink")
@@ -781,19 +786,19 @@ func (l *LibraryPentestLdap) enumerateGroupPolicyObjects(ctx context.Context, co
 
 	for _, entry := range sr.Entries {
 		gpo := &ldapfern.GroupPolicyObject{
-			DistinguishedName: entry.DN,
-			DisplayName:       l.getAttributeValue(entry, "displayName"),
+			DistinguishedName: stringPtr(entry.DN),
+			DisplayName:       stringPtr(l.getAttributeValue(entry, "displayName")),
 		}
 
 		if desc := l.getAttributeValue(entry, "description"); desc != "" {
-			gpo.Description = &desc
+			gpo.Description = stringPtr(desc)
 		}
 		if gpcPath := l.getAttributeValue(entry, "gPCFileSysPath"); gpcPath != "" {
-			gpo.GpcFileSysPath = &gpcPath
+			gpo.GpcFileSysPath = stringPtr(gpcPath)
 		}
 		if version := l.getAttributeValue(entry, "versionNumber"); version != "" {
 			if versionInt, err := strconv.Atoi(version); err == nil {
-				gpo.VersionNumber = &versionInt
+				gpo.VersionNumber = intPtr(versionInt)
 			}
 		}
 
@@ -947,19 +952,19 @@ func (l *LibraryPentestLdap) enumerateDomainTrusts(ctx context.Context, conn *ld
 
 		// Extract trust information
 		if name := entry.GetAttributeValue("name"); name != "" {
-			trust.TargetDomain = name
+			trust.TargetDomain = stringPtr(name)
 		}
 		if flatName := entry.GetAttributeValue("flatName"); flatName != "" {
-			trust.SourceDomain = flatName
+			trust.SourceDomain = stringPtr(flatName)
 		}
 		if trustDirection := entry.GetAttributeValue("trustDirection"); trustDirection != "" {
-			trust.TrustDirection = trustDirection
+			trust.TrustDirection = stringPtr(trustDirection)
 		}
 		if trustType := entry.GetAttributeValue("trustType"); trustType != "" {
-			trust.TrustType = trustType
+			trust.TrustType = stringPtr(trustType)
 		}
 		if trustAttributes := entry.GetAttributeValue("trustAttributes"); trustAttributes != "" {
-			trust.TrustAttributes = &trustAttributes
+			trust.TrustAttributes = stringPtr(trustAttributes)
 		}
 
 		trusts = append(trusts, trust)
@@ -1009,7 +1014,7 @@ func (l *LibraryPentestLdap) extractDomainSID(conn *ldap.Conn, baseDN string) st
 func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn *ldap.Conn, baseDN string, config ldapfern.PentestLdapConfig) (*ldapfern.DomainDumpResult, []string) {
 	var errors []string
 	domainResult := &ldapfern.DomainDumpResult{
-		TotalObjects: 0,
+		TotalObjects: intPtr(0),
 	}
 
 	// Process each action
@@ -1068,14 +1073,14 @@ func (l *LibraryPentestLdap) processGroupCollection(ctx context.Context, conn *l
 		groupsResult := &ldapfern.DomainGroupsResult{
 			Data: *groups,
 			Meta: &ldapfern.DomainDataMeta{
-				Methods: 0,
-				Type:    "groups",
-				Count:   len(*groups),
-				Version: 5,
+				Methods: intPtr(0),
+				Type:    stringPtr("groups"),
+				Count:   intPtr(len(*groups)),
+				Version: intPtr(5),
 			},
 		}
 		domainResult.Groups = groupsResult
-		domainResult.TotalObjects += len(*groups)
+		*domainResult.TotalObjects += len(*groups)
 	}
 	*errors = append(*errors, errs...)
 
@@ -1085,14 +1090,14 @@ func (l *LibraryPentestLdap) processGroupCollection(ctx context.Context, conn *l
 		usersResult := &ldapfern.DomainUsersResult{
 			Data: *users,
 			Meta: &ldapfern.DomainDataMeta{
-				Methods: 0,
-				Type:    "users",
-				Count:   len(*users),
-				Version: 5,
+				Methods: intPtr(0),
+				Type:    stringPtr("users"),
+				Count:   intPtr(len(*users)),
+				Version: intPtr(5),
 			},
 		}
 		domainResult.Users = usersResult
-		domainResult.TotalObjects += len(*users)
+		*domainResult.TotalObjects += len(*users)
 	}
 	*errors = append(*errors, errs...)
 }
@@ -1102,7 +1107,7 @@ func (l *LibraryPentestLdap) processTrustsCollection(ctx context.Context, conn *
 	trusts, errs := l.enumerateDomainTrusts(ctx, conn, baseDN, maxResults)
 	if trusts != nil {
 		domainResult.DomainTrusts = *trusts
-		domainResult.TotalObjects += len(*trusts)
+		*domainResult.TotalObjects += len(*trusts)
 	}
 	*errors = append(*errors, errs...)
 }
@@ -1113,7 +1118,7 @@ func (l *LibraryPentestLdap) processObjectPropsCollection(ctx context.Context, c
 	ous, errs := l.enumerateOrganizationalUnits(ctx, conn, baseDN, maxResults)
 	if ous != nil {
 		domainResult.OrganizationalUnits = *ous
-		domainResult.TotalObjects += len(*ous)
+		*domainResult.TotalObjects += len(*ous)
 	}
 	*errors = append(*errors, errs...)
 
@@ -1121,7 +1126,7 @@ func (l *LibraryPentestLdap) processObjectPropsCollection(ctx context.Context, c
 	gpos, errs := l.enumerateGroupPolicyObjects(ctx, conn, baseDN, maxResults)
 	if gpos != nil {
 		domainResult.GroupPolicyObjects = *gpos
-		domainResult.TotalObjects += len(*gpos)
+		*domainResult.TotalObjects += len(*gpos)
 	}
 	*errors = append(*errors, errs...)
 }
@@ -1132,7 +1137,7 @@ func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, con
 	computers, errs := l.enumerateComputers(ctx, conn, baseDN, maxResults)
 	if computers != nil {
 		domainResult.Computers = *computers
-		domainResult.TotalObjects += len(*computers)
+		*domainResult.TotalObjects += len(*computers)
 	}
 	*errors = append(*errors, errs...)
 
@@ -1140,7 +1145,7 @@ func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, con
 	dcs, errs := l.enumerateDomainControllers(ctx, conn, baseDN, maxResults)
 	if dcs != nil {
 		domainResult.DomainControllers = *dcs
-		domainResult.TotalObjects += len(*dcs)
+		*domainResult.TotalObjects += len(*dcs)
 	}
 	*errors = append(*errors, errs...)
 }


### PR DESCRIPTION
### TL;DR

Made all fields in the LDAP domain dump API optional to improve robustness when handling incomplete data.

### What changed?

- Updated the LDAP domain dump API schema in `fern/definition/pentest/ldap/domaindump.yml` to make all fields optional using `optional<type>` notation
- Made a similar change to the `attempts` field in `fern/definition/pentest/spray.yml`
- Modified the implementation in `internal/pentest/ldap/domaindump.go` to use pointer types for all fields
- Added helper functions (`stringPtr`, `intPtr`, `boolPtr`) to simplify creating pointers to primitive values
- Updated all field assignments to use these helper functions

### How to test?

1. Run the LDAP domain dump functionality against an Active Directory environment with incomplete data
2. Verify that the API correctly handles missing fields without errors
3. Ensure that all data that is available is properly returned in the response

### Why make this change?

Active Directory environments often have incomplete or inconsistent data. Making all fields optional improves the robustness of the API by allowing it to handle missing data gracefully rather than failing when certain fields are not present. This change ensures the API can work with a wider variety of AD environments and provides more reliable results even when some data is unavailable.