### PR TITLE
Refactor authentication configuration with unified PentestAuthConfig across services

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -12,6 +12,8 @@ import (
 	telnetfern "github.com/Method-Security/networkscan/generated/go/pentest/telnet"
 
 	// Internal
+	ldapcommonfern "github.com/Method-Security/networkscan/generated/go/common/ldap"
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
 	pentest_internal "github.com/Method-Security/networkscan/internal/pentest"
 	"github.com/Method-Security/networkscan/utils"
 
@@ -934,47 +936,58 @@ func getSprayUsernameConfig(targets []string, service pentest.SprayTargetService
 }
 
 // getSMBPentestConfig creates a configuration for SMB pentest operations with the provided parameters.
-func getSMBPentestConfig(targets []string, actions []*pentest.PentestServiceAction, usernames []string, passwords []string, commands []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, domain string) *smbfern.PentestSmbConfig {
+func getSMBPentestConfig(targets []string, actions []*pentestcommonfern.PentestServiceAction, usernames []string, passwords []string, commands []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, domain string) *smbfern.PentestSmbConfig {
+	var domainPtr *string
+	if domain != "" {
+		domainPtr = &domain
+	}
+
 	return &smbfern.PentestSmbConfig{
-		Targets:            targets,
-		Actions:            actions,
-		Usernames:          usernames,
-		Passwords:          passwords,
-		ExecuteCommands:    commands,
+		Targets: targets,
+		Actions: actions,
+		AuthConfig: &pentestcommonfern.PentestAuthConfig{
+			Usernames: usernames,
+			Passwords: passwords,
+			Domain:    domainPtr,
+		},
 		Timeout:            timeout,
 		Retries:            retries,
 		StopOnFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:     &successfulOnly,
-		Domain:             &domain,
 	}
 }
 
 // getSSHPentestConfig creates a configuration for SSH pentest operations with the provided parameters.
-func getSSHPentestConfig(targets []string, actions []*pentest.PentestServiceAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
+func getSSHPentestConfig(targets []string, actions []*pentestcommonfern.PentestServiceAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
+	var keyFilePtr *string
+	if keyFile != "" {
+		keyFilePtr = &keyFile
+	}
+
 	return &sshfern.PentestSshConfig{
-		Targets:            targets,
-		Actions:            actions,
-		Usernames:          usernames,
-		Passwords:          passwords,
-		ExecuteCommands:    commands,
-		UploadFiles:        uploadFiles,
-		DownloadFiles:      downloads,
+		Targets: targets,
+		Actions: actions,
+		AuthConfig: &pentestcommonfern.PentestAuthConfig{
+			Usernames: usernames,
+			Passwords: passwords,
+			KeyFile:   keyFilePtr,
+		},
 		Timeout:            timeout,
 		Retries:            retries,
 		StopOnFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:     &successfulOnly,
-		KeyFile:            &keyFile,
 	}
 }
 
 // getTelnetPentestConfig creates a configuration for Telnet pentest operations with the provided parameters.
-func getTelnetPentestConfig(targets []string, actions []*pentest.PentestServiceAction, usernames []string, passwords []string, commands []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
+func getTelnetPentestConfig(targets []string, actions []*pentestcommonfern.PentestServiceAction, usernames []string, passwords []string, commands []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
 	return &telnetfern.PentestTelnetConfig{
-		Targets:            targets,
-		Actions:            actions,
-		Usernames:          usernames,
-		Passwords:          passwords,
-		ExecuteCommands:    commands,
+		Targets: targets,
+		Actions: actions,
+		AuthConfig: &pentestcommonfern.PentestAuthConfig{
+			Usernames: usernames,
+			Passwords: passwords,
+		},
 		Timeout:            timeout,
 		Retries:            retries,
 		StopOnFirstSuccess: &stopFirstSuccess,
@@ -983,7 +996,7 @@ func getTelnetPentestConfig(targets []string, actions []*pentest.PentestServiceA
 }
 
 // createPentestLdapConfig creates a PentestLdapConfig from command flags
-func (a *NetworkScan) createPentestLdapConfig(cmd *cobra.Command, target string, actions []ldapfern.LdapAction) (*ldapfern.PentestLdapConfig, error) {
+func (a *NetworkScan) createPentestLdapConfig(cmd *cobra.Command, target string, actions []ldapcommonfern.LdapAction) (*ldapfern.PentestLdapConfig, error) {
 	// Required flags
 	domain, err := cmd.Flags().GetString("domain")
 	if err != nil {
@@ -1018,12 +1031,14 @@ func (a *NetworkScan) createPentestLdapConfig(cmd *cobra.Command, target string,
 	}
 
 	config := &ldapfern.PentestLdapConfig{
-		Target:   target,
-		Domain:   domain,
-		Username: username,
-		Password: password,
-		Timeout:  timeout,
-		Actions:  actions,
+		Target:  target,
+		Timeout: timeout,
+		Actions: actions,
+		AuthConfig: &pentestcommonfern.PentestAuthConfig{
+			Usernames: []string{username},
+			Passwords: []string{password},
+			Domain:    &domain,
+		},
 	}
 
 	return config, nil

--- a/fern/definition/common/protocol/telnet.yml
+++ b/fern/definition/common/protocol/telnet.yml
@@ -1,0 +1,7 @@
+types:
+  # Telnet Protocol Objects
+  TelnetServerInfo:
+    properties:
+      target: optional<string>         # Target host:port
+      banner: optional<string>         # Server banner information
+      prompts: optional<list<string>>  # Login prompts observed

--- a/fern/definition/pentest/auth.yml
+++ b/fern/definition/pentest/auth.yml
@@ -1,0 +1,44 @@
+types:
+  # Unified Authentication Configuration
+  PentestAuthConfig:
+    properties:
+      # Primary authentication methods
+      usernames: optional<list<string>> # Multiple usernames for flexibility
+      passwords: optional<list<string>> # Multiple passwords for flexibility
+      domain: optional<string> # Domain for domain-based authentication (SMB, LDAP, Kerberos)
+
+      # Advanced authentication methods
+      ntlmv2Hash: optional<string> # NTLM v2 hash for pass-the-hash attacks
+      kerberosTicket: optional<string> # Kerberos ticket for ticket-based auth
+
+      # File-based credentials
+      usernameFile: optional<string> # Path to file containing usernames
+      passwordFile: optional<string> # Path to file containing passwords
+      credentials: optional<string> # Credential pairs in user:pass format
+      keyFile: optional<string> # SSH private key file path
+
+      # Authentication behavior
+      useKerberos: optional<boolean> # Prefer Kerberos over NTLM when available
+
+      # Legacy authentication options
+      disableSigning: optional<boolean> # Disable SMB signing for older systems
+
+  # Unified Authentication Attempt - used across all services
+  AuthAttempt:
+    properties:
+      username: string
+      password: optional<string>         # Optional for key-based auth
+      domain: optional<string>           # For domain authentication (SMB, LDAP, Kerberos)
+      keyFile: optional<string>          # For SSH key-based authentication  
+      success: boolean                   # Whether this attempt succeeded
+      message: string                    # Result message or error
+      isAdmin: optional<boolean>         # For successful auths, indicates admin privileges
+      timestamp: datetime                # When the attempt was made
+      errorCode: optional<string>        # Service-specific error code if applicable
+
+  # Unified Authentication Result - used across all services  
+  AuthResult:
+    properties:
+      target: string                     # Target host:port
+      authAttempts: optional<list<AuthAttempt>>  # All authentication attempts made
+      errors: optional<list<string>>     # General errors not tied to specific attempts

--- a/fern/definition/pentest/auth.yml
+++ b/fern/definition/pentest/auth.yml
@@ -1,3 +1,6 @@
+imports:
+  smbProtocol: ../common/protocol/smb.yml
+
 types:
   # Unified Authentication Configuration
   PentestAuthConfig:
@@ -41,4 +44,5 @@ types:
     properties:
       target: string                     # Target host:port
       authAttempts: optional<list<AuthAttempt>>  # All authentication attempts made
+      serverInfo: optional<smbProtocol.SmbServerInfo>  # Server information extracted from NTLM challenge or other means
       errors: optional<list<string>>     # General errors not tied to specific attempts

--- a/fern/definition/pentest/common.yml
+++ b/fern/definition/pentest/common.yml
@@ -1,34 +1,21 @@
+imports:
+  smbService: ./smb/smb.yml
+  sshService: ./ssh/ssh.yml
+  telnetService: ./telnet/telnet.yml
+  ldapService: ./ldap/ldap.yml
+  unifiedAuth: ./auth.yml
+
 types:
-  # Service-specific action enums
-  PentestSMBAction:
-    enum:
-      - AUTH # Authentication/credential testing (bruteforce)
-      - SAMDUMP # Extract SAM hashes from Windows registry
-      - LSADUMP # Extract LSA secrets from Windows registry
-
-  PentestSSHAction:
-    enum:
-      - AUTH # Authentication/credential testing (bruteforce)
-      - COMMAND # Execute commands on remote system
-      - FILE_TRANSFER # Upload/download files
-
-  PentestTelnetAction:
-    enum:
-      - AUTH # Authentication/credential testing (bruteforce)
+  # Service-specific action enums are now defined in their respective service files
 
   # Union type for service-specific actions
   PentestServiceAction:
     union:
-      smb: PentestSMBAction
-      ssh: PentestSSHAction
-      telnet: PentestTelnetAction
+      smb: smbService.PentestSMBAction
+      ssh: sshService.PentestSSHAction
+      telnet: telnetService.PentestTelnetAction
+      ldap: ldapService.LdapAction
 
-  # Service types for pentest operations
-  PentestServiceType:
-    enum:
-      - SMB
-      - SSH
-      - TELNET
 
   # General configuration that applies to all pentest actions
   PentestGeneralConfig:
@@ -36,23 +23,11 @@ types:
       # Target configuration
       targets: list<string>
 
-      # Authentication configuration (used by AUTH action and others that need creds)
-      usernames: optional<list<string>>
-      passwords: optional<list<string>>
-      usernameFile: optional<string> # Maps to --username-file flag
-      passwordFile: optional<string> # Maps to --password-file flag
-      credentials: optional<string> # Maps to --credentials flag (user:pass format)
+      # Unified authentication configuration
+      authConfig: optional<unifiedAuth.PentestAuthConfig>
 
       # Action configuration
       actions: list<PentestServiceAction>
-
-      # Command execution configuration (used by COMMAND action)
-      executeCommands: optional<list<string>> # Maps to --execute/-x flag
-      commandFile: optional<string> # Maps to --command-file flag
-
-      # File transfer configuration (used by FILE_TRANSFER action)
-      uploadFiles: optional<map<string, string>> # Maps to --upload flag (local:remote format)
-      downloadFiles: optional<list<string>> # Maps to --download flag
 
       # General options
       timeout: integer

--- a/fern/definition/pentest/ldap/auth.yml
+++ b/fern/definition/pentest/ldap/auth.yml
@@ -1,0 +1,7 @@
+imports:
+  unifiedAuth: ../auth.yml
+
+types:
+  # Authentication result
+  AuthResult:
+    extends: unifiedAuth.AuthResult

--- a/fern/definition/pentest/ldap/ldap.yml
+++ b/fern/definition/pentest/ldap/ldap.yml
@@ -1,6 +1,8 @@
 imports:
+  common: ../common.yml
   ldapProtocol: ../../common/protocol/ldap.yml
   domaindump: ./domaindump.yml
+  auth: ../auth.yml
 
 types:
   # LDAP Actions
@@ -13,33 +15,29 @@ types:
   PentestLdapConfig:
     properties:
       target: string
-      domain: string
-      username: string
-      password: string
       timeout: integer
       actions: list<LdapAction>
+      
+      # Unified authentication configuration
+      authConfig: optional<auth.PentestAuthConfig>
+      
       # Action-specific config
       domaindumpConfig: optional<domaindump.DomainDumpConfig>
-
-  # Authentication result for LDAP
-  LdapAuthResult:
-    properties:
-      target: string
-      domain: string
-      successful: boolean
-      username: string
-      message: string
-      errors: optional<list<string>>
 
   # LDAP Result Types
   PentestLdapResult:
     union:
-      LdapAuthResult: LdapAuthResult
+      AuthResult: auth.AuthResult
       DomainDumpResult: domaindump.DomainDumpResult
+
+  # Container for optional LDAP result
+  PentestLdapResultContainer:
+    properties:
+      result: optional<PentestLdapResult>
 
   # LDAP Report Types
   PentestLdapReport:
     properties:
       config: PentestLdapConfig
-      result: optional<PentestLdapResult>
+      result: PentestLdapResultContainer
       errors: optional<list<string>>

--- a/fern/definition/pentest/smb/auth.yml
+++ b/fern/definition/pentest/smb/auth.yml
@@ -1,0 +1,7 @@
+imports:
+  unifiedAuth: ../auth.yml
+
+types:
+  # Authentication result
+  AuthResult:
+    extends: unifiedAuth.AuthResult

--- a/fern/definition/pentest/smb/smb.yml
+++ b/fern/definition/pentest/smb/smb.yml
@@ -1,38 +1,41 @@
 imports:
   common: ../common.yml
   smbProtocol: ../../common/protocol/smb.yml
+  auth: ./auth.yml
   samdump: ./samdump.yml
   lsadump: ./lsadump.yml
 
 types:
-  # Main SMB pentest result that aggregates all activities
-  PentestSmbDetails:
+  # SMB Actions
+  PentestSMBAction:
+    enum:
+      - AUTH # Authentication/credential testing (bruteforce)
+      - SAMDUMP # Extract SAM hashes from Windows registry
+      - LSADUMP # Extract LSA secrets from Windows registry
+
+  # SMB Result Types - union of all action results
+  PentestSmbResult:
+    union:
+      AuthResult: auth.AuthResult
+      SamdumpResult: samdump.SamdumpResult
+      LsadumpResult: lsadump.LsadumpResult
+
+  # Container for optional SMB result
+  PentestSmbResultContainer:
     properties:
-      target: string
-      serverInfo: optional<smbProtocol.SmbServerInfo> # Always extracted from base connection
-      authAttempts: optional<list<smbProtocol.SmbAuthAttempt>> # Only if auth attempts were made
-      successfulAuths: optional<list<smbProtocol.SmbAuthAttempt>> # Successful authentication attempts
-      samdumpDetails: optional<samdump.SamdumpResult> # Only if samdump was performed
-      lsadumpDetails: optional<lsadump.LsadumpResult> # Only if lsadump was performed
-      errors: optional<list<string>>
+      result: optional<PentestSmbResult>
 
   # Config for SMB pentest operations - extends general config
   PentestSmbConfig:
     extends: common.PentestGeneralConfig
     properties:
       # SMB-specific configuration
-      domain: optional<string>
-      useKerberos: optional<boolean>
-      disableSigning: optional<boolean>
-      forceNtlmv1: optional<boolean>
+      # All authentication fields are now in authConfig
 
   # Final report structure
   PentestSmbReport:
     properties:
       config: PentestSmbConfig
-      result: list<PentestSmbDetails>
+      result: PentestSmbResultContainer
       errors: optional<list<string>>
 
-  # Legacy type aliases for backward compatibility during transition
-  AuthAttempt: smbProtocol.SmbAuthAttempt
-  SmbServerInfo: smbProtocol.SmbServerInfo

--- a/fern/definition/pentest/ssh/auth.yml
+++ b/fern/definition/pentest/ssh/auth.yml
@@ -1,0 +1,7 @@
+imports:
+  unifiedAuth: ../auth.yml
+
+types:
+  # Authentication result
+  AuthResult:
+    extends: unifiedAuth.AuthResult

--- a/fern/definition/pentest/ssh/command.yml
+++ b/fern/definition/pentest/ssh/command.yml
@@ -1,0 +1,16 @@
+imports:
+  sshProtocol: ../../common/protocol/ssh.yml
+
+types:
+  # Command execution configuration
+  CommandConfig:
+    properties:
+      executeCommands: optional<list<string>> # Commands to execute (maps to --execute/-x flag)
+      commandFile: optional<string> # File containing commands to execute (maps to --command-file flag)
+
+  # Command execution result
+  CommandResult:
+    properties:
+      target: string
+      commandExecutions: optional<list<sshProtocol.SshCommandExecution>> # Commands executed
+      errors: optional<list<string>>

--- a/fern/definition/pentest/ssh/filetransfer.yml
+++ b/fern/definition/pentest/ssh/filetransfer.yml
@@ -1,0 +1,16 @@
+imports:
+  sshProtocol: ../../common/protocol/ssh.yml
+
+types:
+  # File transfer configuration
+  FileTransferConfig:
+    properties:
+      uploadFiles: optional<map<string, string>> # Files to upload in local:remote format (maps to --upload flag)
+      downloadFiles: optional<list<string>> # Files to download (maps to --download flag)
+
+  # File transfer result
+  FileTransferResult:
+    properties:
+      target: string
+      fileTransfers: optional<list<sshProtocol.SshFileTransfer>> # File transfers performed
+      errors: optional<list<string>>

--- a/fern/definition/pentest/ssh/ssh.yml
+++ b/fern/definition/pentest/ssh/ssh.yml
@@ -1,32 +1,46 @@
 imports:
   common: ../common.yml
   sshProtocol: ../../common/protocol/ssh.yml
+  auth: ./auth.yml
+  command: ./command.yml
+  filetransfer: ./filetransfer.yml
 
 types:
-  # Main SSH pentest result that aggregates all activities
-  PentestSshDetails:
+  # SSH Actions
+  PentestSSHAction:
+    enum:
+      - AUTH # Authentication/credential testing (bruteforce)
+      - COMMAND # Execute commands on remote system
+      - FILE_TRANSFER # Upload/download files
+
+  # SSH Result Types - union of all action results
+  PentestSshResult:
+    union:
+      AuthResult: auth.AuthResult
+      CommandResult: command.CommandResult
+      FileTransferResult: filetransfer.FileTransferResult
+
+  # Container for optional SSH result
+  PentestSshResultContainer:
     properties:
-      target: string
-      serverInfo: optional<sshProtocol.SshServerInfo> # Always extracted from base connection
-      authAttempts: optional<list<sshProtocol.SshAuthAttempt>> # Only if auth attempts were made
-      successfulAuths: optional<list<sshProtocol.SshAuthAttempt>> # Successful authentication attempts
-      commandExecutions: optional<list<sshProtocol.SshCommandExecution>> # Only if commands were executed
-      fileTransfers: optional<list<sshProtocol.SshFileTransfer>> # Only if file transfers were performed
-      errors: optional<list<string>>
+      result: optional<PentestSshResult>
 
   # Config for SSH pentest operations - extends general config
   PentestSshConfig:
     extends: common.PentestGeneralConfig
     properties:
       # SSH-specific configuration
-      keyFile: optional<string> # Maps to --key-file flag
       port: optional<integer>
-      useKeys: optional<boolean>
       algorithm: optional<string>
+      # Note: keyFile is now in authConfig.keyFile
+      
+      # Action-specific configurations
+      commandConfig: optional<command.CommandConfig>
+      fileTransferConfig: optional<filetransfer.FileTransferConfig>
 
   # Final report structure
   PentestSshReport:
     properties:
       config: PentestSshConfig
-      result: list<PentestSshDetails>
+      result: PentestSshResultContainer
       errors: optional<list<string>>

--- a/fern/definition/pentest/telnet/auth.yml
+++ b/fern/definition/pentest/telnet/auth.yml
@@ -1,0 +1,7 @@
+imports:
+  unifiedAuth: ../auth.yml
+
+types:
+  # Authentication result
+  AuthResult:
+    extends: unifiedAuth.AuthResult

--- a/fern/definition/pentest/telnet/telnet.yml
+++ b/fern/definition/pentest/telnet/telnet.yml
@@ -1,38 +1,22 @@
 imports:
   common: ../common.yml
+  auth: ./auth.yml
 
 types:
-  # Server information from base Telnet connection
-  TelnetServerInfo:
-    properties:
-      banner: optional<string>
-      prompts: optional<list<string>>
+  # Telnet Actions
+  PentestTelnetAction:
+    enum:
+      - AUTH # Authentication/credential testing (bruteforce)
 
-  # Authentication attempt information
-  AuthAttempt:
-    properties:
-      username: string
-      password: string
-      success: boolean
-      message: string
-      timestamp: datetime
+  # Telnet Result Types - union of all action results
+  PentestTelnetResult:
+    union:
+      AuthResult: auth.AuthResult
 
-  # Command execution result
-  CommandExecution:
+  # Container for optional Telnet result
+  PentestTelnetResultContainer:
     properties:
-      command: string
-      output: string
-      timestamp: datetime
-
-  # Main Telnet pentest result that aggregates all activities
-  PentestTelnetDetails:
-    properties:
-      target: string
-      serverInfo: optional<TelnetServerInfo> # Always extracted from base connection
-      authAttempts: optional<list<AuthAttempt>> # Only if auth attempts were made
-      successfulAuths: optional<list<AuthAttempt>> # Successful authentication attempts
-      commandExecutions: optional<list<CommandExecution>> # Only if commands were executed
-      errors: optional<list<string>>
+      result: optional<PentestTelnetResult>
 
   # Config for Telnet pentest operations - extends general config
   PentestTelnetConfig:
@@ -47,5 +31,5 @@ types:
   PentestTelnetReport:
     properties:
       config: PentestTelnetConfig
-      result: list<PentestTelnetDetails>
+      result: PentestTelnetResultContainer
       errors: optional<list<string>>

--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 	"time"
 
-	pentest "github.com/Method-Security/networkscan/generated/go/pentest"
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
+	smbcommonfern "github.com/Method-Security/networkscan/generated/go/common/smb"
 	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
@@ -34,7 +35,7 @@ func NewEngine() *Engine {
 // RunSMBPentest performs SMB pentest operations
 func (e *Engine) RunSMBPentest(ctx context.Context, config *smbfern.PentestSmbConfig) (*smbfern.PentestSmbReport, error) {
 	// Create single consolidated report with list of results
-	var allResults []*smbfern.PentestSmbDetails
+	var allResults []*smbfern.PentestSmbResult
 	var allErrors []string
 
 	// Loop over all targets in config
@@ -49,8 +50,8 @@ func (e *Engine) RunSMBPentest(ctx context.Context, config *smbfern.PentestSmbCo
 		}
 
 		// Accumulate results
-		if report.Result != nil {
-			allResults = append(allResults, report.Result...)
+		if report.Result != nil && report.Result.Result != nil {
+			allResults = append(allResults, report.Result.Result)
 		}
 
 		// Accumulate errors
@@ -59,10 +60,18 @@ func (e *Engine) RunSMBPentest(ctx context.Context, config *smbfern.PentestSmbCo
 		}
 	}
 
-	// Return single consolidated report
+	// Return single consolidated report with result container
+	var resultContainer *smbfern.PentestSmbResultContainer
+	if len(allResults) > 0 {
+		// For now, return the first result - this could be enhanced to merge results
+		resultContainer = &smbfern.PentestSmbResultContainer{
+			Result: allResults[0],
+		}
+	}
+
 	return &smbfern.PentestSmbReport{
 		Config: config,
-		Result: allResults,
+		Result: resultContainer,
 		Errors: allErrors,
 	}, nil
 }
@@ -70,19 +79,29 @@ func (e *Engine) RunSMBPentest(ctx context.Context, config *smbfern.PentestSmbCo
 // runSMBPentestForTarget performs SMB pentest operations for a single target
 func (e *Engine) runSMBPentestForTarget(ctx context.Context, target string, config *smbfern.PentestSmbConfig) (*smbfern.PentestSmbReport, error) {
 	// Perform authentication (includes base server info extraction)
-	details, err := smbpentest.PerformAuthenticationWithContext(ctx, target, config)
+	authResult, err := smbpentest.PerformAuthenticationWithContext(ctx, target, config)
 	if err != nil {
 		return &smbfern.PentestSmbReport{
 			Config: config,
-			Result: []*smbfern.PentestSmbDetails{details},
+			Result: &smbfern.PentestSmbResultContainer{
+				Result: smbfern.NewPentestSmbResultFromAuthResult(authResult),
+			},
 			Errors: []string{err.Error()},
 		}, err
 	}
 
+	// Find successful auth attempts
+	successfulAuths := make([]*pentestcommonfern.AuthAttempt, 0)
+	for _, attempt := range authResult.AuthAttempts {
+		if attempt.Success {
+			successfulAuths = append(successfulAuths, attempt)
+		}
+	}
+
 	// If samdump/lsadump is requested and we have successful auth, perform operations
-	if (utils.GetSMBParser().ContainsAction(config.Actions, pentest.PentestSmbActionSamdump) ||
-		utils.GetSMBParser().ContainsAction(config.Actions, pentest.PentestSmbActionLsadump)) &&
-		details.SuccessfulAuths != nil && len(details.SuccessfulAuths) > 0 {
+	if (utils.GetSMBParser().ContainsAction(config.Actions, smbcommonfern.PentestSmbActionSamdump) ||
+		utils.GetSMBParser().ContainsAction(config.Actions, smbcommonfern.PentestSmbActionLsadump)) &&
+		len(successfulAuths) > 0 {
 
 		log := svc1log.FromContext(ctx)
 
@@ -90,10 +109,10 @@ func (e *Engine) runSMBPentestForTarget(ctx context.Context, target string, conf
 		actionNames := []string{}
 		for _, action := range config.Actions {
 			switch action.GetSmb() {
-			case pentest.PentestSmbActionSamdump:
-				actionNames = append(actionNames, string(pentest.PentestSmbActionSamdump))
-			case pentest.PentestSmbActionLsadump:
-				actionNames = append(actionNames, string(pentest.PentestSmbActionLsadump))
+			case smbcommonfern.PentestSmbActionSamdump:
+				actionNames = append(actionNames, string(smbcommonfern.PentestSmbActionSamdump))
+			case smbcommonfern.PentestSmbActionLsadump:
+				actionNames = append(actionNames, string(smbcommonfern.PentestSmbActionLsadump))
 			}
 		}
 		if len(actionNames) > 0 {
@@ -104,7 +123,7 @@ func (e *Engine) runSMBPentestForTarget(ctx context.Context, target string, conf
 		var authenticatedSession *gosmb.Connection = nil
 
 		// Create a temporary client to get the authenticated session
-		successfulAuth := details.SuccessfulAuths[0]
+		successfulAuth := successfulAuths[0]
 		host, port := utils.ParseHostPort(target, 445)
 
 		// Create SMB client and authenticate to get session
@@ -116,7 +135,11 @@ func (e *Engine) runSMBPentestForTarget(ctx context.Context, target string, conf
 		if successfulAuth.Domain != nil {
 			authDomain = *successfulAuth.Domain
 		}
-		tempClient.SetCredentials(successfulAuth.Username, successfulAuth.Password, authDomain)
+		var password string
+		if successfulAuth.Password != nil {
+			password = *successfulAuth.Password
+		}
+		tempClient.SetCredentials(successfulAuth.Username, password, authDomain)
 
 		err = tempClient.ConnectWithContext(ctx)
 		if err == nil {
@@ -125,47 +148,64 @@ func (e *Engine) runSMBPentestForTarget(ctx context.Context, target string, conf
 			defer func() { _ = tempClient.Close() }()
 		}
 
-		// Execute each requested action
+		// Execute each requested action - return separate results for each
 		for _, action := range config.Actions {
 			switch action.GetSmb() {
-			case pentest.PentestSmbActionSamdump:
-				log.Debug("Performing " + string(pentest.PentestSmbActionSamdump))
+			case smbcommonfern.PentestSmbActionSamdump:
+				log.Debug("Performing " + string(smbcommonfern.PentestSmbActionSamdump))
 				samdumpDetails, err := smbpentest.PerformSamdump(ctx, target, config, authenticatedSession)
 				if err != nil {
-					if details.Errors == nil {
-						details.Errors = []string{}
+					if authResult.Errors == nil {
+						authResult.Errors = []string{}
 					}
-					details.Errors = append(details.Errors, fmt.Sprintf("%s failed: %v", string(pentest.PentestSmbActionSamdump), err))
+					authResult.Errors = append(authResult.Errors, fmt.Sprintf("%s failed: %v", string(smbcommonfern.PentestSmbActionSamdump), err))
 				} else {
-					details.SamdumpDetails = samdumpDetails
+					// Return samdump result
+					return &smbfern.PentestSmbReport{
+						Config: config,
+						Result: &smbfern.PentestSmbResultContainer{
+							Result: smbfern.NewPentestSmbResultFromSamdumpResult(samdumpDetails),
+						},
+						Errors: authResult.Errors,
+					}, nil
 				}
 
-			case pentest.PentestSmbActionLsadump:
-				log.Debug("Performing " + string(pentest.PentestSmbActionLsadump))
+			case smbcommonfern.PentestSmbActionLsadump:
+				log.Debug("Performing " + string(smbcommonfern.PentestSmbActionLsadump))
 				lsadumpDetails, err := smbpentest.PerformLsadump(ctx, target, config, authenticatedSession)
 				if err != nil {
-					if details.Errors == nil {
-						details.Errors = []string{}
+					if authResult.Errors == nil {
+						authResult.Errors = []string{}
 					}
-					details.Errors = append(details.Errors, fmt.Sprintf("%s failed: %v", string(pentest.PentestSmbActionLsadump), err))
+					authResult.Errors = append(authResult.Errors, fmt.Sprintf("%s failed: %v", string(smbcommonfern.PentestSmbActionLsadump), err))
 				} else {
-					details.LsadumpDetails = lsadumpDetails
+					// Return lsadump result
+					return &smbfern.PentestSmbReport{
+						Config: config,
+						Result: &smbfern.PentestSmbResultContainer{
+							Result: smbfern.NewPentestSmbResultFromLsadumpResult(lsadumpDetails),
+						},
+						Errors: authResult.Errors,
+					}, nil
 				}
 			}
 		}
 	}
 
+	// If no dump operations were requested or they failed, return auth result
 	return &smbfern.PentestSmbReport{
 		Config: config,
-		Result: []*smbfern.PentestSmbDetails{details},
-		Errors: details.Errors,
+		Result: &smbfern.PentestSmbResultContainer{
+			Result: smbfern.NewPentestSmbResultFromAuthResult(authResult),
+		},
+		Errors: authResult.Errors,
 	}, nil
 }
 
 // RunSSHPentest performs SSH pentest operations for multiple targets
 func (e *Engine) RunSSHPentest(ctx context.Context, config *sshfern.PentestSshConfig) (*sshfern.PentestSshReport, error) {
 	// Create single consolidated report with list of results
-	var allResults []*sshfern.PentestSshDetails
+	var allResults []*sshfern.PentestSshResult
 	var allErrors []string
 
 	// Loop over all targets in config
@@ -180,8 +220,8 @@ func (e *Engine) RunSSHPentest(ctx context.Context, config *sshfern.PentestSshCo
 		}
 
 		// Accumulate results
-		if report.Result != nil {
-			allResults = append(allResults, report.Result...)
+		if report.Result != nil && report.Result.Result != nil {
+			allResults = append(allResults, report.Result.Result)
 		}
 
 		// Accumulate errors
@@ -190,10 +230,18 @@ func (e *Engine) RunSSHPentest(ctx context.Context, config *sshfern.PentestSshCo
 		}
 	}
 
-	// Return single consolidated report
+	// Return single consolidated report with result container
+	var resultContainer *sshfern.PentestSshResultContainer
+	if len(allResults) > 0 {
+		// For now, return the first result - this could be enhanced to merge results
+		resultContainer = &sshfern.PentestSshResultContainer{
+			Result: allResults[0],
+		}
+	}
+
 	return &sshfern.PentestSshReport{
 		Config: config,
-		Result: allResults,
+		Result: resultContainer,
 		Errors: allErrors,
 	}, nil
 }
@@ -201,50 +249,83 @@ func (e *Engine) RunSSHPentest(ctx context.Context, config *sshfern.PentestSshCo
 // runSSHPentestForTarget performs SSH pentest operations for a single target
 func (e *Engine) runSSHPentestForTarget(ctx context.Context, target string, config *sshfern.PentestSshConfig) (*sshfern.PentestSshReport, error) {
 	// Perform authentication (includes base server info extraction)
-	details, err := sshpentest.PerformAuthenticationWithContext(ctx, target, config)
+	authResult, err := sshpentest.PerformAuthenticationWithContext(ctx, target, config)
 	if err != nil {
 		return &sshfern.PentestSshReport{
 			Config: config,
-			Result: []*sshfern.PentestSshDetails{details},
+			Result: &sshfern.PentestSshResultContainer{
+				Result: sshfern.NewPentestSshResultFromAuthResult(authResult),
+			},
 			Errors: []string{err.Error()},
 		}, err
 	}
 
-	// If command execution is requested and we have successful auth, execute commands
-	if len(config.ExecuteCommands) > 0 &&
-		details.SuccessfulAuths != nil && len(details.SuccessfulAuths) > 0 {
+	// Find successful auth attempts
+	successfulAuths := make([]*pentestcommonfern.AuthAttempt, 0)
+	for _, attempt := range authResult.AuthAttempts {
+		if attempt.Success {
+			successfulAuths = append(successfulAuths, attempt)
+		}
+	}
 
+	// If command execution is requested and we have successful auth, execute commands
+	var executeCommands []string
+	if config.CommandConfig != nil {
+		executeCommands = config.CommandConfig.ExecuteCommands
+	}
+
+	if len(executeCommands) > 0 && len(successfulAuths) > 0 {
 		// Use first successful auth for command execution
-		successfulAuth := details.SuccessfulAuths[0]
+		successfulAuth := successfulAuths[0]
 		host, port := utils.ParseHostPort(target, 22)
 
+		var password string
+		if successfulAuth.Password != nil {
+			password = *successfulAuth.Password
+		}
+
 		executions, err := sshpentest.ExecuteCommands(host, port,
-			successfulAuth.Username, successfulAuth.Password,
-			config.ExecuteCommands, config.Timeout)
+			successfulAuth.Username, password,
+			executeCommands, config.Timeout)
 
 		if err != nil {
-			if details.Errors == nil {
-				details.Errors = []string{}
+			if authResult.Errors == nil {
+				authResult.Errors = []string{}
 			}
-			details.Errors = append(details.Errors, fmt.Sprintf("Command execution failed: %v", err))
+			authResult.Errors = append(authResult.Errors, fmt.Sprintf("Command execution failed: %v", err))
 		} else {
-			details.CommandExecutions = executions
+			// Return command execution result
+			commandResult := &sshfern.CommandResult{
+				Target:            target,
+				CommandExecutions: executions,
+				Errors:            authResult.Errors,
+			}
+			return &sshfern.PentestSshReport{
+				Config: config,
+				Result: &sshfern.PentestSshResultContainer{
+					Result: sshfern.NewPentestSshResultFromCommandResult(commandResult),
+				},
+				Errors: authResult.Errors,
+			}, nil
 		}
 	}
 
 	// File transfer operations can be added if requested
 
+	// Return auth result if no other operations were performed
 	return &sshfern.PentestSshReport{
 		Config: config,
-		Result: []*sshfern.PentestSshDetails{details},
-		Errors: details.Errors,
+		Result: &sshfern.PentestSshResultContainer{
+			Result: sshfern.NewPentestSshResultFromAuthResult(authResult),
+		},
+		Errors: authResult.Errors,
 	}, nil
 }
 
 // RunTelnetPentest performs Telnet pentest operations for multiple targets
 func (e *Engine) RunTelnetPentest(ctx context.Context, config *telnetfern.PentestTelnetConfig) (*telnetfern.PentestTelnetReport, error) {
 	// Create single consolidated report with list of results
-	var allResults []*telnetfern.PentestTelnetDetails
+	var allResults []*telnetfern.PentestTelnetResult
 	var allErrors []string
 
 	// Loop over all targets in config
@@ -259,8 +340,8 @@ func (e *Engine) RunTelnetPentest(ctx context.Context, config *telnetfern.Pentes
 		}
 
 		// Accumulate results
-		if report.Result != nil {
-			allResults = append(allResults, report.Result...)
+		if report.Result != nil && report.Result.Result != nil {
+			allResults = append(allResults, report.Result.Result)
 		}
 
 		// Accumulate errors
@@ -269,10 +350,18 @@ func (e *Engine) RunTelnetPentest(ctx context.Context, config *telnetfern.Pentes
 		}
 	}
 
-	// Return single consolidated report
+	// Return single consolidated report with result container
+	var resultContainer *telnetfern.PentestTelnetResultContainer
+	if len(allResults) > 0 {
+		// For now, return the first result - this could be enhanced to merge results
+		resultContainer = &telnetfern.PentestTelnetResultContainer{
+			Result: allResults[0],
+		}
+	}
+
 	return &telnetfern.PentestTelnetReport{
 		Config: config,
-		Result: allResults,
+		Result: resultContainer,
 		Errors: allErrors,
 	}, nil
 }
@@ -280,19 +369,23 @@ func (e *Engine) RunTelnetPentest(ctx context.Context, config *telnetfern.Pentes
 // runTelnetPentestForTarget performs Telnet pentest operations for a single target
 func (e *Engine) runTelnetPentestForTarget(ctx context.Context, target string, config *telnetfern.PentestTelnetConfig) (*telnetfern.PentestTelnetReport, error) {
 	// Perform authentication (includes base server info extraction)
-	details, err := telnetpentest.PerformAuthenticationWithContext(ctx, target, config)
+	authResult, err := telnetpentest.PerformAuthenticationWithContext(ctx, target, config)
 	if err != nil {
 		return &telnetfern.PentestTelnetReport{
 			Config: config,
-			Result: []*telnetfern.PentestTelnetDetails{details},
+			Result: &telnetfern.PentestTelnetResultContainer{
+				Result: telnetfern.NewPentestTelnetResultFromAuthResult(authResult),
+			},
 			Errors: []string{err.Error()},
 		}, err
 	}
 
 	return &telnetfern.PentestTelnetReport{
 		Config: config,
-		Result: []*telnetfern.PentestTelnetDetails{details},
-		Errors: details.Errors,
+		Result: &telnetfern.PentestTelnetResultContainer{
+			Result: telnetfern.NewPentestTelnetResultFromAuthResult(authResult),
+		},
+		Errors: authResult.Errors,
 	}, nil
 }
 
@@ -303,9 +396,17 @@ func (e *Engine) RunLDAPPentest(ctx context.Context, config *ldapfern.PentestLda
 
 	result, errors := library.PentestLdap(ctx, *config)
 
+	// Wrap result in container
+	var resultContainer *ldapfern.PentestLdapResultContainer
+	if result != nil {
+		resultContainer = &ldapfern.PentestLdapResultContainer{
+			Result: result,
+		}
+	}
+
 	return &ldapfern.PentestLdapReport{
 		Config: config,
-		Result: result,
+		Result: resultContainer,
 		Errors: errors,
 	}, nil
 }

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -9,7 +9,10 @@ import (
 	"time"
 
 	// Generated
+	ldapcommonfern "github.com/Method-Security/networkscan/generated/go/common/ldap"
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
 	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
+
 	// External
 	"github.com/go-ldap/ldap/v3"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -36,7 +39,7 @@ func (l *LibraryPentestLdap) performLdapActions(ctx context.Context, config ldap
 
 	// Handle AUTH action separately - just test authentication
 	for _, action := range config.Actions {
-		if action == ldapfern.LdapActionAuth {
+		if action == ldapcommonfern.LdapActionAuth {
 			return l.performAuthAction(ctx, config)
 		}
 	}
@@ -112,10 +115,32 @@ func (l *LibraryPentestLdap) establishConnection(target *Target) (*ldap.Conn, er
 
 // authenticateConnection performs the bind operation for authentication
 func (l *LibraryPentestLdap) authenticateConnection(ctx context.Context, conn *ldap.Conn, config ldapfern.PentestLdapConfig) error {
-	bindUsername := fmt.Sprintf("%s@%s", config.Username, config.Domain)
+	// Get authentication details from the auth config
+	if config.AuthConfig == nil {
+		return fmt.Errorf("auth config is required for authentication")
+	}
+
+	if len(config.AuthConfig.Usernames) == 0 {
+		return fmt.Errorf("at least one username is required for authentication")
+	}
+
+	if len(config.AuthConfig.Passwords) == 0 {
+		return fmt.Errorf("at least one password is required for authentication")
+	}
+
+	username := config.AuthConfig.Usernames[0]
+	password := config.AuthConfig.Passwords[0]
+
+	var bindUsername string
+	if config.AuthConfig.Domain != nil && *config.AuthConfig.Domain != "" {
+		bindUsername = fmt.Sprintf("%s@%s", username, *config.AuthConfig.Domain)
+	} else {
+		bindUsername = username
+	}
+
 	logger := svc1log.FromContext(ctx)
 	logger.Info("Attempting LDAP authentication", svc1log.SafeParam("username", bindUsername))
-	return conn.Bind(bindUsername, config.Password)
+	return conn.Bind(bindUsername, password)
 }
 
 func (l *LibraryPentestLdap) getBaseDN(conn *ldap.Conn, target string) (string, error) {
@@ -1019,7 +1044,7 @@ func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn 
 
 	// Process each action
 	for _, action := range config.Actions {
-		if action == ldapfern.LdapActionDomaindump {
+		if action == ldapcommonfern.LdapActionDomaindump {
 			collectionMethods := l.getCollectionMethods(config)
 			maxResults := l.getMaxResults(config)
 
@@ -1154,19 +1179,61 @@ func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, con
 func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapfern.PentestLdapConfig) (*ldapfern.PentestLdapResult, []string) {
 	var errors []string
 
+	// Check that auth config exists
+	if config.AuthConfig == nil {
+		err := fmt.Errorf("auth config is required for authentication")
+		authResult := &pentestcommonfern.AuthResult{
+			Target: config.Target,
+			Errors: []string{err.Error()},
+		}
+		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
+		return result, []string{err.Error()}
+	}
+
+	if len(config.AuthConfig.Usernames) == 0 {
+		err := fmt.Errorf("at least one username is required for authentication")
+		authResult := &pentestcommonfern.AuthResult{
+			Target: config.Target,
+			Errors: []string{err.Error()},
+		}
+		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
+		return result, []string{err.Error()}
+	}
+
+	if len(config.AuthConfig.Passwords) == 0 {
+		err := fmt.Errorf("at least one password is required for authentication")
+		authResult := &pentestcommonfern.AuthResult{
+			Target: config.Target,
+			Errors: []string{err.Error()},
+		}
+		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
+		return result, []string{err.Error()}
+	}
+
+	username := config.AuthConfig.Usernames[0]
+	password := config.AuthConfig.Passwords[0]
+
 	// Attempt to connect and authenticate
 	conn, err := l.connectToLDAP(ctx, config)
 	if err != nil {
 		// Authentication failed
-		authResult := &ldapfern.LdapAuthResult{
-			Target:     config.Target,
-			Domain:     config.Domain,
-			Username:   config.Username,
-			Successful: false,
-			Message:    fmt.Sprintf("Authentication failed: %v", err),
-			Errors:     []string{err.Error()},
+		authAttempt := &pentestcommonfern.AuthAttempt{
+			Username:  username,
+			Password:  &password,
+			Success:   false,
+			Message:   fmt.Sprintf("Authentication failed: %v", err),
+			Timestamp: time.Now(),
 		}
-		result := ldapfern.NewPentestLdapResultFromLdapAuthResult(authResult)
+		if config.AuthConfig.Domain != nil {
+			authAttempt.Domain = config.AuthConfig.Domain
+		}
+
+		authResult := &pentestcommonfern.AuthResult{
+			Target:       config.Target,
+			AuthAttempts: []*pentestcommonfern.AuthAttempt{authAttempt},
+			Errors:       []string{err.Error()},
+		}
+		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
 		return result, []string{err.Error()}
 	}
 
@@ -1178,15 +1245,23 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 		}
 	}()
 
-	authResult := &ldapfern.LdapAuthResult{
-		Target:     config.Target,
-		Domain:     config.Domain,
-		Username:   config.Username,
-		Successful: true,
-		Message:    "Authentication successful",
-		Errors:     nil,
+	authAttempt := &pentestcommonfern.AuthAttempt{
+		Username:  username,
+		Password:  &password,
+		Success:   true,
+		Message:   "Authentication successful",
+		Timestamp: time.Now(),
+	}
+	if config.AuthConfig.Domain != nil {
+		authAttempt.Domain = config.AuthConfig.Domain
 	}
 
-	result := ldapfern.NewPentestLdapResultFromLdapAuthResult(authResult)
+	authResult := &pentestcommonfern.AuthResult{
+		Target:       config.Target,
+		AuthAttempts: []*pentestcommonfern.AuthAttempt{authAttempt},
+		Errors:       nil,
+	}
+
+	result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
 	return result, errors
 }

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -5,28 +5,61 @@ import (
 	"fmt"
 	"time"
 
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
-	"github.com/Method-Security/networkscan/generated/go/pentest"
+	smbcommonfern "github.com/Method-Security/networkscan/generated/go/common/smb"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+// convertToSmbServerInfo converts internal ServerInfo to fern SmbServerInfo
+func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocolfern.SmbServerInfo {
+	if serverInfo == nil {
+		return nil
+	}
+
+	// Convert capabilities
+	var capabilities []string
+	if serverInfo.Capabilities != nil {
+		capabilities = serverInfo.Capabilities
+	}
+
+	// Convert supported versions (note: slice of values, not pointers)
+	var supportedVersions []commonprotocolfern.SmbVersion
+	for _, version := range serverInfo.SupportedVersions {
+		if smbVersion, err := commonprotocolfern.NewSmbVersionFromString(version); err == nil {
+			supportedVersions = append(supportedVersions, smbVersion)
+		}
+	}
+
+	return &commonprotocolfern.SmbServerInfo{
+		ServerName:           &serverInfo.ServerName,
+		Domain:               &serverInfo.Domain,
+		NetBiosDomainName:    &serverInfo.NetBIOSDomainName,
+		OsVersion:            &serverInfo.OSVersion,
+		RawOsVersion:         &serverInfo.RawOSVersion,
+		SigningRequired:      &serverInfo.SigningRequired,
+		SupportedSmbVersions: supportedVersions,
+		Capabilities:         capabilities,
+	}
+}
+
 // PerformAuthentication performs authentication attempts against SMB service
 // Returns both base server info and auth results
-func PerformAuthentication(target string, config *smbfern.PentestSmbConfig) (*smbfern.PentestSmbDetails, error) {
+func PerformAuthentication(target string, config *smbfern.PentestSmbConfig) (*smbfern.AuthResult, error) {
 	return PerformAuthenticationWithContext(context.Background(), target, config)
 }
 
 // PerformAuthenticationWithContext performs authentication attempts against SMB service with context
 // Returns both base server info and auth results
-func PerformAuthenticationWithContext(ctx context.Context, target string, config *smbfern.PentestSmbConfig) (*smbfern.PentestSmbDetails, error) {
+func PerformAuthenticationWithContext(ctx context.Context, target string, config *smbfern.PentestSmbConfig) (*smbfern.AuthResult, error) {
 	if target == "" {
 		return nil, fmt.Errorf("no target provided")
 	}
 
-	result := &smbfern.PentestSmbDetails{
+	result := &smbfern.AuthResult{
 		Target: target,
 	}
 
@@ -34,43 +67,41 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 	host, port := utils.ParseHostPort(target, 445)
 
+	// Always attempt to extract server info from NTLM challenge, regardless of auth requirements
+	log := svc1log.FromContext(ctx)
+	log.Debug("Extracting SMB server info", svc1log.SafeParam("target", target))
+
+	client := smbclient.NewClient(host, port)
+	client.Timeout = time.Duration(config.Timeout) * time.Millisecond
+
+	serverInfo, err := client.ExtractServerInfoFromChallenge(ctx)
+	if err != nil {
+		log.Debug("Failed to extract server info from NTLM challenge", svc1log.SafeParam("error", err.Error()))
+		errors = append(errors, fmt.Sprintf("Failed to extract server info: %v", err))
+	} else {
+		log.Debug("Successfully extracted server info",
+			svc1log.SafeParam("serverName", serverInfo.ServerName),
+			svc1log.SafeParam("domain", serverInfo.Domain))
+		result.ServerInfo = convertToSmbServerInfo(serverInfo)
+	}
+
 	// Check if auth should be performed based on credentials or explicit actions
-	shouldPerformAuth := len(config.Usernames) > 0 || len(config.Passwords) > 0
+	shouldPerformAuth := false
+	if config.AuthConfig != nil {
+		shouldPerformAuth = len(config.AuthConfig.Usernames) > 0 || len(config.AuthConfig.Passwords) > 0
+	}
 	for _, action := range config.Actions {
-		if action.GetType() == "smb" && action.GetSmb() == pentest.PentestSmbActionAuth {
+		if action.GetType() == "smb" && action.GetSmb() == smbcommonfern.PentestSmbActionAuth {
 			shouldPerformAuth = true
 			break
 		}
 	}
 
-	// Extract server info from NTLM challenge (works regardless of auth success/failure)
-	client := smbclient.NewClient(host, port)
-	client.Timeout = time.Duration(config.Timeout) * time.Millisecond
-
-	var serverInfo *commonprotocolfern.SmbServerInfo
-	if clientServerInfo, err := client.ExtractServerInfoFromChallenge(ctx); err == nil && clientServerInfo != nil {
-		serverInfo = &commonprotocolfern.SmbServerInfo{
-			ServerName:        &clientServerInfo.ServerName,
-			Domain:            &clientServerInfo.Domain,
-			NetBiosDomainName: &clientServerInfo.NetBIOSDomainName,
-			Workgroup:         &clientServerInfo.Domain, // Use domain as workgroup fallback
-			OsVersion:         &clientServerInfo.OSVersion,
-			Capabilities:      clientServerInfo.Capabilities,
-			SigningRequired:   &clientServerInfo.SigningRequired,
-		}
-		// Include raw OS version if available
-		if clientServerInfo.RawOSVersion != "" {
-			serverInfo.RawOsVersion = &clientServerInfo.RawOSVersion
-		}
-	}
-	result.ServerInfo = serverInfo
-
 	// If credentials are provided, perform authentication
 	if shouldPerformAuth {
-		authAttempts, successfulAuths, authErrors := performAuthAttemptsWithContext(ctx, host, port, config)
+		authAttempts, authErrors := performAuthAttemptsWithContext(ctx, host, port, config)
 
 		result.AuthAttempts = authAttempts
-		result.SuccessfulAuths = successfulAuths
 		errors = append(errors, authErrors...)
 	}
 
@@ -83,25 +114,27 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 // performAuthAttemptsWithContext performs credential-based authentication attempts with context
 func performAuthAttemptsWithContext(ctx context.Context, host string, port int, config *smbfern.PentestSmbConfig) (
-	[]*commonprotocolfern.SmbAuthAttempt, []*commonprotocolfern.SmbAuthAttempt, []string) {
+	[]*pentestcommonfern.AuthAttempt, []string) {
 
-	var allAttempts []*commonprotocolfern.SmbAuthAttempt
-	var successfulAttempts []*commonprotocolfern.SmbAuthAttempt
+	var allAttempts []*pentestcommonfern.AuthAttempt
 	var errors []string
 
-	// Generate credential pairs
-	credPairs := generateCredentialPairs(config.Usernames, config.Passwords)
+	// Generate credential pairs - check if AuthConfig exists
+	if config.AuthConfig == nil {
+		return nil, []string{"no auth config provided"}
+	}
+	credPairs := generateCredentialPairs(config.AuthConfig.Usernames, config.AuthConfig.Passwords)
 
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting authentication attempts",
 		svc1log.SafeParam("credentialPairs", len(credPairs)),
-		svc1log.SafeParam("usernames", config.Usernames),
-		svc1log.SafeParam("passwords", len(config.Passwords)))
+		svc1log.SafeParam("usernames", config.AuthConfig.Usernames),
+		svc1log.SafeParam("passwords", len(config.AuthConfig.Passwords)))
 
 	// Get domain from config
 	domain := ""
-	if config.Domain != nil {
-		domain = *config.Domain
+	if config.AuthConfig.Domain != nil {
+		domain = *config.AuthConfig.Domain
 	}
 
 	// If no domain provided, attempt to discover it from server info using NTLM challenge
@@ -112,7 +145,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 			log.Info("Using discovered domain from NTLM challenge for authentication", svc1log.SafeParam("domain", domain))
 
 			// Update the config to reflect the discovered domain
-			config.Domain = &domain
+			config.AuthConfig.Domain = &domain
 		}
 	}
 
@@ -125,8 +158,6 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 		allAttempts = append(allAttempts, attempt)
 
 		if attempt.Success {
-			successfulAttempts = append(successfulAttempts, attempt)
-
 			log.Info("Authentication successful",
 				svc1log.SafeParam("username", cred.username),
 				svc1log.SafeParam("password", "[REDACTED]"))
@@ -137,11 +168,19 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 		}
 	}
 
-	log.Info("Authentication completed",
-		svc1log.SafeParam("successful", len(successfulAttempts)),
-		svc1log.SafeParam("failed", len(credPairs)-len(successfulAttempts)))
+	// Count successful attempts
+	successfulCount := 0
+	for _, attempt := range allAttempts {
+		if attempt.Success {
+			successfulCount++
+		}
+	}
 
-	return allAttempts, successfulAttempts, errors
+	log.Info("Authentication completed",
+		svc1log.SafeParam("successful", successfulCount),
+		svc1log.SafeParam("failed", len(credPairs)-successfulCount))
+
+	return allAttempts, errors
 }
 
 // credentialPair represents a username/password combination
@@ -174,7 +213,7 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 }
 
 // attemptAuthenticationWithContext performs a single authentication attempt with context
-func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*commonprotocolfern.SmbAuthAttempt, error) {
+func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*pentestcommonfern.AuthAttempt, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
 
@@ -182,9 +221,9 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 	client.SetCredentials(username, password, domain)
 
 	timestamp := time.Now()
-	attempt := &commonprotocolfern.SmbAuthAttempt{
+	attempt := &pentestcommonfern.AuthAttempt{
 		Username:  username,
-		Password:  password,
+		Password:  &password,
 		Domain:    &domain,
 		Success:   false,
 		Timestamp: timestamp,

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
 	pentest "github.com/Method-Security/networkscan/generated/go/pentest"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
@@ -401,11 +402,13 @@ func (e *Engine) performKerberosSpray(ctx context.Context, target string, cred *
 // performSSHSpray uses existing SSH auth functionality
 func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pentest.Credential, config *pentest.SprayPasswordConfig) (bool, string) {
 	sshConfig := &sshfern.PentestSshConfig{
-		Targets:   []string{target},
-		Usernames: []string{cred.Username},
-		Passwords: []string{cred.Password},
-		Timeout:   config.Timeout,
-		Retries:   1, // We handle retries at spray level
+		Targets: []string{target},
+		AuthConfig: &pentestcommonfern.PentestAuthConfig{
+			Usernames: []string{cred.Username},
+			Passwords: []string{cred.Password},
+		},
+		Timeout: config.Timeout,
+		Retries: 1, // We handle retries at spray level
 	}
 
 	details, err := sshpentest.PerformAuthenticationWithContext(ctx, target, sshConfig)
@@ -413,10 +416,14 @@ func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pente
 		return false, err.Error()
 	}
 
-	if details.SuccessfulAuths != nil && len(details.SuccessfulAuths) > 0 {
-		return true, details.SuccessfulAuths[0].Message
+	// Find successful authentication attempts
+	for _, attempt := range details.AuthAttempts {
+		if attempt.Success {
+			return true, attempt.Message
+		}
 	}
 
+	// Return first failed attempt message if no success
 	if details.AuthAttempts != nil && len(details.AuthAttempts) > 0 {
 		return false, details.AuthAttempts[0].Message
 	}
@@ -438,12 +445,14 @@ func (e *Engine) performFTPSpray(ctx context.Context, target string, cred *pente
 // performSMBSpray uses existing SMB auth functionality
 func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pentest.Credential, config *pentest.SprayPasswordConfig) (bool, string) {
 	smbConfig := &smbfern.PentestSmbConfig{
-		Targets:   []string{target},
-		Usernames: []string{cred.Username},
-		Passwords: []string{cred.Password},
-		Timeout:   config.Timeout,
-		Retries:   1, // We handle retries at spray level
-		Domain:    cred.Domain,
+		Targets: []string{target},
+		AuthConfig: &pentestcommonfern.PentestAuthConfig{
+			Usernames: []string{cred.Username},
+			Passwords: []string{cred.Password},
+			Domain:    cred.Domain,
+		},
+		Timeout: config.Timeout,
+		Retries: 1, // We handle retries at spray level
 	}
 
 	details, err := smbpentest.PerformAuthenticationWithContext(ctx, target, smbConfig)
@@ -451,10 +460,14 @@ func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pente
 		return false, err.Error()
 	}
 
-	if details.SuccessfulAuths != nil && len(details.SuccessfulAuths) > 0 {
-		return true, details.SuccessfulAuths[0].Message
+	// Find successful authentication attempts
+	for _, attempt := range details.AuthAttempts {
+		if attempt.Success {
+			return true, attempt.Message
+		}
 	}
 
+	// Return first failed attempt message if no success
 	if details.AuthAttempts != nil && len(details.AuthAttempts) > 0 {
 		return false, details.AuthAttempts[0].Message
 	}
@@ -465,11 +478,13 @@ func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pente
 // performTelnetSpray uses existing Telnet auth functionality
 func (e *Engine) performTelnetSpray(ctx context.Context, target string, cred *pentest.Credential, config *pentest.SprayPasswordConfig) (bool, string) {
 	telnetConfig := &telnetfern.PentestTelnetConfig{
-		Targets:   []string{target},
-		Usernames: []string{cred.Username},
-		Passwords: []string{cred.Password},
-		Timeout:   config.Timeout,
-		Retries:   1, // We handle retries at spray level
+		Targets: []string{target},
+		AuthConfig: &pentestcommonfern.PentestAuthConfig{
+			Usernames: []string{cred.Username},
+			Passwords: []string{cred.Password},
+		},
+		Timeout: config.Timeout,
+		Retries: 1, // We handle retries at spray level
 	}
 
 	details, err := telnetpentest.PerformAuthenticationWithContext(ctx, target, telnetConfig)
@@ -477,10 +492,14 @@ func (e *Engine) performTelnetSpray(ctx context.Context, target string, cred *pe
 		return false, err.Error()
 	}
 
-	if details.SuccessfulAuths != nil && len(details.SuccessfulAuths) > 0 {
-		return true, details.SuccessfulAuths[0].Message
+	// Find successful authentication attempts
+	for _, attempt := range details.AuthAttempts {
+		if attempt.Success {
+			return true, attempt.Message
+		}
 	}
 
+	// Return first failed attempt message if no success
 	if details.AuthAttempts != nil && len(details.AuthAttempts) > 0 {
 		return false, details.AuthAttempts[0].Message
 	}

--- a/internal/pentest/ssh/auth.go
+++ b/internal/pentest/ssh/auth.go
@@ -3,10 +3,9 @@ package ssh
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -14,16 +13,16 @@ import (
 )
 
 // PerformAuthentication performs authentication attempts against SSH service
-// Returns both base server info and auth results
-func PerformAuthentication(target string, config *sshfern.PentestSshConfig) (*sshfern.PentestSshDetails, error) {
+// Returns auth results
+func PerformAuthentication(target string, config *sshfern.PentestSshConfig) (*sshfern.AuthResult, error) {
 	return PerformAuthenticationWithContext(context.Background(), target, config)
 }
 
 // PerformAuthenticationWithContext performs authentication attempts against SSH service with context
-// Returns both base server info and auth results
-func PerformAuthenticationWithContext(ctx context.Context, target string, config *sshfern.PentestSshConfig) (*sshfern.PentestSshDetails, error) {
+// Returns auth results
+func PerformAuthenticationWithContext(ctx context.Context, target string, config *sshfern.PentestSshConfig) (*sshfern.AuthResult, error) {
 
-	details := &sshfern.PentestSshDetails{
+	result := &sshfern.AuthResult{
 		Target: target,
 	}
 
@@ -31,97 +30,40 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 	host, port := utils.ParseHostPort(target, 22)
 
-	// First, always extract base server information
-	serverInfo, err := extractBaseServerInfoWithContext(ctx, host, port, config.Timeout)
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("Failed to extract server info: %v", err))
-		details.Errors = errors
-		return details, err
-	}
-	details.ServerInfo = serverInfo
-
 	// Perform auth attempts
-	authAttempts, successfulAuths, authErrors := performAuthAttemptsWithContext(ctx, host, port, config)
+	authAttempts, authErrors := performAuthAttemptsWithContext(ctx, host, port, config)
 
-	details.AuthAttempts = authAttempts
-	details.SuccessfulAuths = successfulAuths
+	result.AuthAttempts = authAttempts
 	errors = append(errors, authErrors...)
 
 	if len(errors) > 0 {
-		details.Errors = errors
+		result.Errors = errors
 	}
 
-	return details, nil
-}
-
-// extractBaseServerInfoWithContext extracts basic server information from SSH connection with context
-func extractBaseServerInfoWithContext(ctx context.Context, host string, port int, timeout int) (*commonprotocolfern.SshServerInfo, error) {
-	sshConfig := &ssh.ClientConfig{
-		User:            "probe",            // Use a dummy user for probing
-		Auth:            []ssh.AuthMethod{}, // No auth methods
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         time.Duration(timeout) * time.Millisecond,
-	}
-
-	targetAddr := fmt.Sprintf("%s:%d", host, port)
-
-	// This will fail auth but give us server info
-	conn, err := ssh.Dial("tcp", targetAddr, sshConfig)
-
-	serverInfo := &commonprotocolfern.SshServerInfo{}
-
-	if err != nil {
-		// Parse server version and supported methods from error
-		errStr := err.Error()
-
-		// Try to extract server version from error message
-		if strings.Contains(errStr, "SSH-") {
-			if start := strings.Index(errStr, "SSH-"); start != -1 {
-				versionPart := errStr[start:]
-				if end := strings.Index(versionPart, " "); end != -1 {
-					version := versionPart[:end]
-					serverInfo.ServerVersion = &version
-				}
-			}
-		}
-
-		// Default supported auth methods (common ones)
-		var authMethods []commonprotocolfern.SshAuthMethod
-		authMethods = append(authMethods, commonprotocolfern.SshAuthMethodPassword)
-		authMethods = append(authMethods, commonprotocolfern.SshAuthMethodPublicKey)
-		serverInfo.SupportedAuthMethods = authMethods
-	} else {
-		// Successful connection (unlikely with dummy user)
-		defer func() { _ = conn.Close() }()
-
-		// Get server version
-		if conn != nil {
-			version := "SSH-2.0" // Default
-			serverInfo.ServerVersion = &version
-		}
-	}
-
-	log := svc1log.FromContext(ctx)
-	log.Info("Extracted SSH server info",
-		svc1log.SafeParam("version", getStringValue(serverInfo.ServerVersion)))
-
-	return serverInfo, nil
+	return result, nil
 }
 
 // performAuthAttemptsWithContext performs credential-based authentication attempts with context
 func performAuthAttemptsWithContext(ctx context.Context, host string, port int, config *sshfern.PentestSshConfig) (
-	[]*commonprotocolfern.SshAuthAttempt, []*commonprotocolfern.SshAuthAttempt, []string) {
+	[]*pentestcommonfern.AuthAttempt, []string) {
 
-	var allAttempts []*commonprotocolfern.SshAuthAttempt
-	var successfulAttempts []*commonprotocolfern.SshAuthAttempt
+	var allAttempts []*pentestcommonfern.AuthAttempt
 	var errors []string
 
+	// Get credentials from auth config
+	var usernames, passwords []string
+	if config.AuthConfig != nil {
+		usernames = config.AuthConfig.Usernames
+		passwords = config.AuthConfig.Passwords
+	}
+
 	// Generate credential pairs
-	credPairs := generateCredentialPairs(config.Usernames, config.Passwords)
+	credPairs := generateCredentialPairs(usernames, passwords)
 
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting SSH authentication attempts", svc1log.SafeParam("credentialPairs", len(credPairs)))
 
+	var successfulCount int
 	for _, cred := range credPairs {
 		attempt, err := attemptAuthenticationWithContext(ctx, host, port, cred.username, cred.password, config.Timeout)
 		if err != nil {
@@ -131,7 +73,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 		allAttempts = append(allAttempts, attempt)
 
 		if attempt.Success {
-			successfulAttempts = append(successfulAttempts, attempt)
+			successfulCount++
 
 			log.Info("SSH authentication successful",
 				svc1log.SafeParam("username", cred.username),
@@ -144,10 +86,10 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 	}
 
 	log.Info("SSH authentication completed",
-		svc1log.SafeParam("successful", len(successfulAttempts)),
-		svc1log.SafeParam("failed", len(credPairs)-len(successfulAttempts)))
+		svc1log.SafeParam("successful", successfulCount),
+		svc1log.SafeParam("failed", len(credPairs)-successfulCount))
 
-	return allAttempts, successfulAttempts, errors
+	return allAttempts, errors
 }
 
 // credentialPair represents a username/password combination
@@ -180,13 +122,14 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 }
 
 // attemptAuthenticationWithContext performs a single SSH authentication attempt with context
-func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*commonprotocolfern.SshAuthAttempt, error) {
+func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*pentestcommonfern.AuthAttempt, error) {
 	timestamp := time.Now()
-	attempt := &commonprotocolfern.SshAuthAttempt{
+	attempt := &pentestcommonfern.AuthAttempt{
 		Username:  username,
-		Password:  password,
+		Password:  &password,
 		Success:   false,
 		Timestamp: timestamp,
+		Message:   "",
 	}
 
 	sshConfig := &ssh.ClientConfig{
@@ -210,13 +153,4 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 	attempt.Message = fmt.Sprintf("Authentication successful for %s", username)
 
 	return attempt, nil
-}
-
-// Helper functions
-
-func getStringValue(s *string) string {
-	if s != nil {
-		return *s
-	}
-	return ""
 }

--- a/internal/pentest/telnet/auth.go
+++ b/internal/pentest/telnet/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
 	telnetfern "github.com/Method-Security/networkscan/generated/go/pentest/telnet"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -15,15 +16,15 @@ import (
 
 // PerformAuthentication performs authentication attempts against Telnet service
 // Returns both base server info and auth results
-func PerformAuthentication(target string, config *telnetfern.PentestTelnetConfig) (*telnetfern.PentestTelnetDetails, error) {
+func PerformAuthentication(target string, config *telnetfern.PentestTelnetConfig) (*telnetfern.AuthResult, error) {
 	return PerformAuthenticationWithContext(context.Background(), target, config)
 }
 
 // PerformAuthenticationWithContext performs authentication attempts against Telnet service with context
 // Returns both base server info and auth results
-func PerformAuthenticationWithContext(ctx context.Context, target string, config *telnetfern.PentestTelnetConfig) (*telnetfern.PentestTelnetDetails, error) {
+func PerformAuthenticationWithContext(ctx context.Context, target string, config *telnetfern.PentestTelnetConfig) (*telnetfern.AuthResult, error) {
 
-	details := &telnetfern.PentestTelnetDetails{
+	result := &telnetfern.AuthResult{
 		Target: target,
 	}
 
@@ -31,74 +32,35 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 	host, port := utils.ParseHostPort(target, 23)
 
-	// First, always extract base server information
-	serverInfo, err := extractBaseServerInfoWithContext(ctx, host, port, config.Timeout)
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("Failed to extract server info: %v", err))
-		details.Errors = errors
-		return details, err
+	// Only perform auth attempts if we have auth config
+	if config.AuthConfig != nil {
+		// Perform auth attempts
+		authAttempts, authErrors := performAuthAttemptsWithContext(ctx, host, port, config)
+		result.AuthAttempts = authAttempts
+		errors = append(errors, authErrors...)
 	}
-	details.ServerInfo = serverInfo
-
-	// Perform auth attempts
-	authAttempts, successfulAuths, authErrors := performAuthAttemptsWithContext(ctx, host, port, config)
-
-	details.AuthAttempts = authAttempts
-	details.SuccessfulAuths = successfulAuths
-	errors = append(errors, authErrors...)
 
 	if len(errors) > 0 {
-		details.Errors = errors
+		result.Errors = errors
 	}
 
-	return details, nil
-}
-
-// extractBaseServerInfoWithContext extracts basic server information from Telnet connection with context
-func extractBaseServerInfoWithContext(ctx context.Context, host string, port int, timeout int) (*telnetfern.TelnetServerInfo, error) {
-	targetAddr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-	timeoutDuration := time.Duration(timeout) * time.Millisecond
-
-	conn, err := net.DialTimeout("tcp", targetAddr, timeoutDuration)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer func() { _ = conn.Close() }()
-
-	serverInfo := &telnetfern.TelnetServerInfo{}
-
-	// Try to read banner/initial response
-	_ = conn.SetReadDeadline(time.Now().Add(timeoutDuration))
-	buffer := make([]byte, 1024)
-	n, err := conn.Read(buffer)
-	if err == nil && n > 0 {
-		banner := filterPrintable(buffer[:n])
-		serverInfo.Banner = &banner
-
-		// Extract common prompts from banner
-		prompts := extractPrompts(banner)
-		if len(prompts) > 0 {
-			serverInfo.Prompts = prompts
-		}
-	}
-
-	log := svc1log.FromContext(ctx)
-	log.Info("Extracted Telnet server info",
-		svc1log.SafeParam("banner", getStringValue(serverInfo.Banner)))
-
-	return serverInfo, nil
+	return result, nil
 }
 
 // performAuthAttemptsWithContext performs credential-based authentication attempts with context
 func performAuthAttemptsWithContext(ctx context.Context, host string, port int, config *telnetfern.PentestTelnetConfig) (
-	[]*telnetfern.AuthAttempt, []*telnetfern.AuthAttempt, []string) {
+	[]*pentestcommonfern.AuthAttempt, []string) {
 
-	var allAttempts []*telnetfern.AuthAttempt
-	var successfulAttempts []*telnetfern.AuthAttempt
+	var allAttempts []*pentestcommonfern.AuthAttempt
 	var errors []string
 
-	// Generate credential pairs
-	credPairs := generateCredentialPairs(config.Usernames, config.Passwords)
+	// Generate credential pairs from auth config
+	var usernames, passwords []string
+	if config.AuthConfig != nil {
+		usernames = config.AuthConfig.Usernames
+		passwords = config.AuthConfig.Passwords
+	}
+	credPairs := generateCredentialPairs(usernames, passwords)
 
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting Telnet authentication attempts", svc1log.SafeParam("credentialPairs", len(credPairs)))
@@ -112,8 +74,6 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 		allAttempts = append(allAttempts, attempt)
 
 		if attempt.Success {
-			successfulAttempts = append(successfulAttempts, attempt)
-
 			log.Info("Telnet authentication successful",
 				svc1log.SafeParam("username", cred.username),
 				svc1log.SafeParam("password", "[REDACTED]"))
@@ -124,11 +84,18 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 		}
 	}
 
-	log.Info("Telnet authentication completed",
-		svc1log.SafeParam("successful", len(successfulAttempts)),
-		svc1log.SafeParam("failed", len(credPairs)-len(successfulAttempts)))
+	successfulCount := 0
+	for _, attempt := range allAttempts {
+		if attempt.Success {
+			successfulCount++
+		}
+	}
 
-	return allAttempts, successfulAttempts, errors
+	log.Info("Telnet authentication completed",
+		svc1log.SafeParam("successful", successfulCount),
+		svc1log.SafeParam("failed", len(credPairs)-successfulCount))
+
+	return allAttempts, errors
 }
 
 // credentialPair represents a username/password combination
@@ -161,11 +128,11 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 }
 
 // attemptAuthenticationWithContext performs a single Telnet authentication attempt with context
-func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*telnetfern.AuthAttempt, error) {
+func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*pentestcommonfern.AuthAttempt, error) {
 	timestamp := time.Now()
-	attempt := &telnetfern.AuthAttempt{
+	attempt := &pentestcommonfern.AuthAttempt{
 		Username:  username,
-		Password:  password,
+		Password:  &password,
 		Success:   false,
 		Timestamp: timestamp,
 	}
@@ -244,27 +211,6 @@ func performTelnetHandshake(conn net.Conn, username, password string, timeout ti
 }
 
 // Helper functions
-
-func getStringValue(s *string) string {
-	if s != nil {
-		return *s
-	}
-	return ""
-}
-
-func extractPrompts(banner string) []string {
-	prompts := []string{}
-	commonPrompts := []string{"login:", "Password:", "#", "$", ">"}
-
-	bannerLower := strings.ToLower(banner)
-	for _, prompt := range commonPrompts {
-		if strings.Contains(bannerLower, strings.ToLower(prompt)) {
-			prompts = append(prompts, prompt)
-		}
-	}
-
-	return prompts
-}
 
 func readUntilPromptWithTimeout(conn net.Conn, prompt string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/internal/pentest/telnet/command.go
+++ b/internal/pentest/telnet/command.go
@@ -4,14 +4,19 @@ import (
 	"fmt"
 	"net"
 	"time"
-
-	telnetfern "github.com/Method-Security/networkscan/generated/go/pentest/telnet"
 )
+
+// CommandExecution represents a command execution result for Telnet
+type CommandExecution struct {
+	Command   string
+	Output    string
+	Timestamp time.Time
+}
 
 // ExecuteCommands executes commands on the remote Telnet server using valid credentials
 // This function requires successful authentication first
-func ExecuteCommands(host string, port int, username, password string, commands []string, timeout int) ([]*telnetfern.CommandExecution, error) {
-	var executions []*telnetfern.CommandExecution
+func ExecuteCommands(host string, port int, username, password string, commands []string, timeout int) ([]*CommandExecution, error) {
+	var executions []*CommandExecution
 
 	targetAddr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 	timeoutDuration := time.Duration(timeout) * time.Millisecond
@@ -31,7 +36,7 @@ func ExecuteCommands(host string, port int, username, password string, commands 
 	for _, command := range commands {
 		execution, err := executeCommand(conn, command, timeoutDuration)
 		if err != nil {
-			execution = &telnetfern.CommandExecution{
+			execution = &CommandExecution{
 				Command:   command,
 				Output:    fmt.Sprintf("Error: %v", err),
 				Timestamp: time.Now(),
@@ -44,8 +49,8 @@ func ExecuteCommands(host string, port int, username, password string, commands 
 }
 
 // executeCommand executes a single command over Telnet
-func executeCommand(conn net.Conn, command string, timeout time.Duration) (*telnetfern.CommandExecution, error) {
-	execution := &telnetfern.CommandExecution{
+func executeCommand(conn net.Conn, command string, timeout time.Duration) (*CommandExecution, error) {
+	execution := &CommandExecution{
 		Command:   command,
 		Timestamp: time.Now(),
 	}

--- a/utils/action_parser.go
+++ b/utils/action_parser.go
@@ -4,22 +4,25 @@ import (
 	"fmt"
 	"strings"
 
-	pentest "github.com/Method-Security/networkscan/generated/go/pentest"
-	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
+	ldapcommonfern "github.com/Method-Security/networkscan/generated/go/common/ldap"
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
+	smbcommonfern "github.com/Method-Security/networkscan/generated/go/common/smb"
+	sshcommonfern "github.com/Method-Security/networkscan/generated/go/common/ssh"
+	telnetcommonfern "github.com/Method-Security/networkscan/generated/go/common/telnet"
 )
 
 // ServiceActionParser defines the interface for parsing service-specific actions
 type ServiceActionParser interface {
-	ParseActions(actionStrings []string) ([]*pentest.PentestServiceAction, error)
+	ParseActions(actionStrings []string) ([]*pentestcommonfern.PentestServiceAction, error)
 	GetValidActions() []string
-	ContainsAction(actions []*pentest.PentestServiceAction, target interface{}) bool
+	ContainsAction(actions []*pentestcommonfern.PentestServiceAction, target interface{}) bool
 }
 
 // SMBActionParser handles SMB-specific action parsing
 type SMBActionParser struct{}
 
-func (p *SMBActionParser) ParseActions(actionStrings []string) ([]*pentest.PentestServiceAction, error) {
-	var actions []*pentest.PentestServiceAction
+func (p *SMBActionParser) ParseActions(actionStrings []string) ([]*pentestcommonfern.PentestServiceAction, error) {
+	var actions []*pentestcommonfern.PentestServiceAction
 
 	for _, actionStr := range actionStrings {
 		// Handle comma-separated actions in a single flag
@@ -31,11 +34,11 @@ func (p *SMBActionParser) ParseActions(actionStrings []string) ([]*pentest.Pente
 			}
 			// Convert to uppercase for enum matching
 			upperPart := strings.ToUpper(part)
-			smbAction, err := pentest.NewPentestSmbActionFromString(upperPart)
+			smbAction, err := smbcommonfern.NewPentestSmbActionFromString(upperPart)
 			if err != nil {
 				return nil, fmt.Errorf("invalid SMB action '%s': valid actions are %s", part, strings.Join(p.GetValidActions(), ","))
 			}
-			action := pentest.NewPentestServiceActionFromSmb(smbAction)
+			action := pentestcommonfern.NewPentestServiceActionFromSmb(smbAction)
 			actions = append(actions, action)
 		}
 	}
@@ -47,8 +50,8 @@ func (p *SMBActionParser) GetValidActions() []string {
 	return []string{"auth", "samdump", "lsadump"}
 }
 
-func (p *SMBActionParser) ContainsAction(actions []*pentest.PentestServiceAction, target interface{}) bool {
-	targetAction, ok := target.(pentest.PentestSmbAction)
+func (p *SMBActionParser) ContainsAction(actions []*pentestcommonfern.PentestServiceAction, target interface{}) bool {
+	targetAction, ok := target.(smbcommonfern.PentestSmbAction)
 	if !ok {
 		return false
 	}
@@ -63,8 +66,8 @@ func (p *SMBActionParser) ContainsAction(actions []*pentest.PentestServiceAction
 // SSHActionParser handles SSH-specific action parsing
 type SSHActionParser struct{}
 
-func (p *SSHActionParser) ParseActions(actionStrings []string) ([]*pentest.PentestServiceAction, error) {
-	var actions []*pentest.PentestServiceAction
+func (p *SSHActionParser) ParseActions(actionStrings []string) ([]*pentestcommonfern.PentestServiceAction, error) {
+	var actions []*pentestcommonfern.PentestServiceAction
 
 	for _, actionStr := range actionStrings {
 		// Handle comma-separated actions in a single flag
@@ -76,11 +79,11 @@ func (p *SSHActionParser) ParseActions(actionStrings []string) ([]*pentest.Pente
 			}
 			// Convert to uppercase for enum matching
 			upperPart := strings.ToUpper(part)
-			sshAction, err := pentest.NewPentestSshActionFromString(upperPart)
+			sshAction, err := sshcommonfern.NewPentestSshActionFromString(upperPart)
 			if err != nil {
 				return nil, fmt.Errorf("invalid SSH action '%s': valid actions are %s", part, strings.Join(p.GetValidActions(), ","))
 			}
-			action := pentest.NewPentestServiceActionFromSsh(sshAction)
+			action := pentestcommonfern.NewPentestServiceActionFromSsh(sshAction)
 			actions = append(actions, action)
 		}
 	}
@@ -92,8 +95,8 @@ func (p *SSHActionParser) GetValidActions() []string {
 	return []string{"auth", "command", "user_enum", "file_transfer"}
 }
 
-func (p *SSHActionParser) ContainsAction(actions []*pentest.PentestServiceAction, target interface{}) bool {
-	targetAction, ok := target.(pentest.PentestSshAction)
+func (p *SSHActionParser) ContainsAction(actions []*pentestcommonfern.PentestServiceAction, target interface{}) bool {
+	targetAction, ok := target.(sshcommonfern.PentestSshAction)
 	if !ok {
 		return false
 	}
@@ -108,8 +111,8 @@ func (p *SSHActionParser) ContainsAction(actions []*pentest.PentestServiceAction
 // TelnetActionParser handles Telnet-specific action parsing
 type TelnetActionParser struct{}
 
-func (p *TelnetActionParser) ParseActions(actionStrings []string) ([]*pentest.PentestServiceAction, error) {
-	var actions []*pentest.PentestServiceAction
+func (p *TelnetActionParser) ParseActions(actionStrings []string) ([]*pentestcommonfern.PentestServiceAction, error) {
+	var actions []*pentestcommonfern.PentestServiceAction
 
 	for _, actionStr := range actionStrings {
 		// Handle comma-separated actions in a single flag
@@ -121,11 +124,11 @@ func (p *TelnetActionParser) ParseActions(actionStrings []string) ([]*pentest.Pe
 			}
 			// Convert to uppercase for enum matching
 			upperPart := strings.ToUpper(part)
-			telnetAction, err := pentest.NewPentestTelnetActionFromString(upperPart)
+			telnetAction, err := telnetcommonfern.NewPentestTelnetActionFromString(upperPart)
 			if err != nil {
 				return nil, fmt.Errorf("invalid Telnet action '%s': valid actions are %s", part, strings.Join(p.GetValidActions(), ","))
 			}
-			action := pentest.NewPentestServiceActionFromTelnet(telnetAction)
+			action := pentestcommonfern.NewPentestServiceActionFromTelnet(telnetAction)
 			actions = append(actions, action)
 		}
 	}
@@ -137,8 +140,8 @@ func (p *TelnetActionParser) GetValidActions() []string {
 	return []string{"auth", "command"}
 }
 
-func (p *TelnetActionParser) ContainsAction(actions []*pentest.PentestServiceAction, target interface{}) bool {
-	targetAction, ok := target.(pentest.PentestTelnetAction)
+func (p *TelnetActionParser) ContainsAction(actions []*pentestcommonfern.PentestServiceAction, target interface{}) bool {
+	targetAction, ok := target.(telnetcommonfern.PentestTelnetAction)
 	if !ok {
 		return false
 	}
@@ -154,18 +157,18 @@ func (p *TelnetActionParser) ContainsAction(actions []*pentest.PentestServiceAct
 type ActionUtil struct{}
 
 // ContainsAction checks if actions contain a specific target action (generic version)
-func (au *ActionUtil) ContainsAction(actions []*pentest.PentestServiceAction, serviceType string, target interface{}) bool {
+func (au *ActionUtil) ContainsAction(actions []*pentestcommonfern.PentestServiceAction, serviceType string, target interface{}) bool {
 	switch serviceType {
 	case "smb":
-		if targetAction, ok := target.(pentest.PentestSmbAction); ok {
+		if targetAction, ok := target.(smbcommonfern.PentestSmbAction); ok {
 			return GetSMBParser().ContainsAction(actions, targetAction)
 		}
 	case "ssh":
-		if targetAction, ok := target.(pentest.PentestSshAction); ok {
+		if targetAction, ok := target.(sshcommonfern.PentestSshAction); ok {
 			return GetSSHParser().ContainsAction(actions, targetAction)
 		}
 	case "telnet":
-		if targetAction, ok := target.(pentest.PentestTelnetAction); ok {
+		if targetAction, ok := target.(telnetcommonfern.PentestTelnetAction); ok {
 			return GetTelnetParser().ContainsAction(actions, targetAction)
 		}
 	}
@@ -175,8 +178,8 @@ func (au *ActionUtil) ContainsAction(actions []*pentest.PentestServiceAction, se
 // LDAPActionParser handles LDAP-specific action parsing
 type LDAPActionParser struct{}
 
-func (p *LDAPActionParser) ParseActions(actionStrings []string) ([]ldapfern.LdapAction, error) {
-	var actions []ldapfern.LdapAction
+func (p *LDAPActionParser) ParseActions(actionStrings []string) ([]ldapcommonfern.LdapAction, error) {
+	var actions []ldapcommonfern.LdapAction
 
 	for _, actionStr := range actionStrings {
 		// Handle comma-separated actions in a single flag
@@ -188,7 +191,7 @@ func (p *LDAPActionParser) ParseActions(actionStrings []string) ([]ldapfern.Ldap
 			}
 			// Convert to uppercase for enum matching
 			upperPart := strings.ToUpper(part)
-			ldapAction, err := ldapfern.NewLdapActionFromString(upperPart)
+			ldapAction, err := ldapcommonfern.NewLdapActionFromString(upperPart)
 			if err != nil {
 				return nil, fmt.Errorf("invalid LDAP action '%s': valid actions are %s", part, strings.Join(p.GetValidActions(), ","))
 			}
@@ -203,7 +206,7 @@ func (p *LDAPActionParser) GetValidActions() []string {
 	return []string{"auth", "domaindump"}
 }
 
-func (p *LDAPActionParser) ContainsAction(actions []ldapfern.LdapAction, target ldapfern.LdapAction) bool {
+func (p *LDAPActionParser) ContainsAction(actions []ldapcommonfern.LdapAction, target ldapcommonfern.LdapAction) bool {
 	for _, action := range actions {
 		if action == target {
 			return true


### PR DESCRIPTION
# Unified Authentication Configuration for Network Scanning

This PR introduces a unified authentication configuration model across all pentest services (SMB, SSH, Telnet, LDAP). The changes include:

- Created a new `PentestAuthConfig` type that standardizes authentication parameters across all services
- Refactored service-specific action types into their respective service files
- Updated all pentest service configurations to use the unified auth config
- Improved handling of optional fields with proper null checks
- Restructured result containers to better handle different action results
- Added proper domain handling for authentication across services

These changes provide a more consistent API for authentication across different protocols while maintaining backward compatibility with existing code.