### PR TITLE
Add Container collection method to default LDAP domain dump configuration

### DIFF
--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -1101,7 +1101,7 @@ func (l *LibraryPentestLdap) getCollectionMethods(config ldapfern.PentestLdapCon
 	if config.DomaindumpConfig != nil && config.DomaindumpConfig.CollectionMethods != nil {
 		return config.DomaindumpConfig.CollectionMethods
 	}
-	return []ldapfern.CollectionMethod{ldapfern.CollectionMethodGroup}
+	return []ldapfern.CollectionMethod{ldapfern.CollectionMethodGroup, ldapfern.CollectionMethodContainer}
 }
 
 // getMaxResults extracts max results from config


### PR DESCRIPTION
### TL;DR

Added `CollectionMethodContainer` to the default collection methods for domain dumps.

### What changed?

Modified the default collection methods in the `getCollectionMethods` function to include both `CollectionMethodGroup` and `CollectionMethodContainer` instead of just `CollectionMethodGroup`.

### How to test?

1. Run a domain dump without explicitly specifying collection methods in the configuration
2. Verify that container information is now collected by default
3. Confirm that the previous functionality (group collection) still works as expected

### Why make this change?

Including container information by default provides more comprehensive domain data during pentests without requiring explicit configuration. This enhances the default behavior of the domain dump functionality while maintaining backward compatibility.