### PR TITLE
Add admin privilege detection for SMB authentication

### DIFF
--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -302,8 +302,9 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 			attempt.Message = fmt.Sprintf("Authentication successful for %s", username)
 		}
 
-		// Admin privilege checking could be implemented by accessing ADMIN$ share
-		// For now, we'll leave it as nil
+		// Check for admin privileges by testing ADMIN$ share access
+		isAdmin := checkAdminPrivileges(ctx, client)
+		attempt.IsAdmin = &isAdmin
 
 	} else {
 		attempt.Message = "Authentication failed"
@@ -379,12 +380,41 @@ func attemptHashAuthenticationWithContext(ctx context.Context, host string, port
 			attempt.Message = fmt.Sprintf("Pass-the-hash authentication successful for %s", username)
 		}
 
-		// Admin privilege checking could be implemented by accessing ADMIN$ share
-		// For now, we'll leave it as nil
+		// Check for admin privileges by testing ADMIN$ share access
+		isAdmin := checkAdminPrivileges(ctx, client)
+		attempt.IsAdmin = &isAdmin
 
 	} else {
 		attempt.Message = "Pass-the-hash authentication failed"
 	}
 
 	return attempt, nil
+}
+
+// checkAdminPrivileges tests administrative privileges by attempting to access the ADMIN$ share
+// This follows NetExec's approach but uses a simpler share-based test rather than DCERPC/SCM
+func checkAdminPrivileges(ctx context.Context, client *smbclient.Client) bool {
+	log := svc1log.FromContext(ctx)
+
+	// Get the underlying SMB session for direct operations
+	session, err := client.GetSMBSession()
+	if err != nil {
+		log.Debug("Failed to get SMB session for admin check", svc1log.SafeParam("error", err.Error()))
+		return false
+	}
+
+	// Test access to ADMIN$ share - this requires admin privileges
+	log.Debug("Testing ADMIN$ share access for admin privilege detection")
+	err = session.TreeConnect("ADMIN$")
+	if err != nil {
+		log.Debug("ADMIN$ share access denied - user is not admin", svc1log.SafeParam("error", err.Error()))
+		return false
+	}
+
+	// Successfully accessed ADMIN$ - user has admin privileges
+	// Clean up the tree connection
+	_ = session.TreeDisconnect("ADMIN$")
+
+	log.Info("ADMIN$ share accessible - user has admin privileges")
+	return true
 }


### PR DESCRIPTION
### TL;DR

Implemented admin privilege detection for SMB authentication by testing access to the ADMIN$ share.

### What changed?

- Added a new `checkAdminPrivileges` function that tests if a user has administrative privileges by attempting to connect to the ADMIN$ share
- Updated both password-based and hash-based authentication functions to check for admin privileges after successful authentication
- Set the `IsAdmin` field in authentication attempt results based on the privilege check

### How to test?

1. Attempt SMB authentication with both admin and non-admin credentials
2. Verify that the `IsAdmin` field is correctly set to `true` for accounts with administrative privileges
3. Verify that the `IsAdmin` field is set to `false` for regular user accounts
4. Check logs for "ADMIN$ share accessible - user has admin privileges" message when admin privileges are detected

### Why make this change?

This enhancement provides valuable information about the privilege level of authenticated accounts during penetration testing. Knowing whether a compromised account has administrative privileges is critical for assessing the potential impact of a security breach and for planning lateral movement strategies during security assessments.