### PR TITLE
Implement unified NTLM server info extraction for SMB and LDAP protocols

### DIFF
--- a/fern/definition/common/protocol/ldap.yml
+++ b/fern/definition/common/protocol/ldap.yml
@@ -1,3 +1,6 @@
+imports:
+  ntlmProtocol: ./ntlm.yml
+
 types:
   # LDAP Protocol Common Types
   
@@ -12,10 +15,10 @@ types:
   
   # LDAP Server Information
   LdapServerInfo:
+    extends: ntlmProtocol.NtlmServerInfo
     properties:
-      serverName: optional<string>
-      domain: optional<string>
-      baseDN: optional<string>
+      # LDAP-specific properties
+      baseDN: optional<string>               # LDAP-specific base DN
       supportsTLS: optional<boolean>
       supportsStartTLS: optional<boolean>
       supportsSASL: optional<boolean>

--- a/fern/definition/common/protocol/ntlm.yml
+++ b/fern/definition/common/protocol/ntlm.yml
@@ -1,0 +1,36 @@
+types:
+  # NTLM Target Info structure - extracted from NTLM challenge TargetInfo
+  NtlmTargetInfo:
+    properties:
+      netbiosDomainName: optional<string>      # Attribute: NetBIOS domain name (e.g., ADICORP)
+      netbiosComputerName: optional<string>    # Attribute: NetBIOS computer name (e.g., NYC-DC01)
+      dnsDomainName: optional<string>          # Attribute: DNS domain name (e.g., corp.auric-dynamics.com)
+      dnsComputerName: optional<string>        # Attribute: DNS computer name (e.g., NYC-DC01.corp.auric-dynamics.com)
+      dnsTreeName: optional<string>            # Attribute: DNS tree name (e.g., corp.auric-dynamics.com)
+      timestamp: optional<datetime>            # Attribute: Timestamp from NTLM challenge
+      length: optional<integer>                # Target Info length
+      maxLength: optional<integer>             # Target Info max length
+      offset: optional<integer>                # Target Info offset
+
+  # NTLM OS Information structure - extracted from NTLM challenge Version block
+  NtlmOsInfo:
+    properties:
+      majorVersion: optional<integer>          # Major Version (e.g., 10)
+      minorVersion: optional<integer>          # Minor Version (e.g., 0)
+      buildNumber: optional<integer>           # Build Number (e.g., 20348)
+      ntlmCurrentRevision: optional<integer>   # NTLM Current Revision (e.g., 15)
+      versionString: optional<string>          # Formatted version string (e.g., "Version 10.0 (Build 20348)")
+      rawVersionData: optional<string>         # Raw version data from NTLM
+
+  # Common NTLM Server Information extracted from NTLM challenge
+  NtlmServerInfo:
+    properties:
+      # Parsed OS version (derived from OsInfo)
+      parsedOsVersion: optional<string>        # Parsed OS version (e.g., "Windows Server 2022")
+      
+      # Protocol-specific fields
+      signingRequired: optional<boolean>       # Whether SMB signing is required
+      
+      # Detailed NTLM structures
+      targetInfo: optional<NtlmTargetInfo>     # Detailed TargetInfo from NTLM challenge
+      osInfo: optional<NtlmOsInfo>             # Detailed OS/Version info from NTLM challenge

--- a/fern/definition/common/protocol/ntlm.yml
+++ b/fern/definition/common/protocol/ntlm.yml
@@ -2,35 +2,32 @@ types:
   # NTLM Target Info structure - extracted from NTLM challenge TargetInfo
   NtlmTargetInfo:
     properties:
-      netbiosDomainName: optional<string>      # Attribute: NetBIOS domain name (e.g., ADICORP)
-      netbiosComputerName: optional<string>    # Attribute: NetBIOS computer name (e.g., NYC-DC01)
-      dnsDomainName: optional<string>          # Attribute: DNS domain name (e.g., corp.auric-dynamics.com)
-      dnsComputerName: optional<string>        # Attribute: DNS computer name (e.g., NYC-DC01.corp.auric-dynamics.com)
-      dnsTreeName: optional<string>            # Attribute: DNS tree name (e.g., corp.auric-dynamics.com)
-      timestamp: optional<datetime>            # Attribute: Timestamp from NTLM challenge
-      length: optional<integer>                # Target Info length
-      maxLength: optional<integer>             # Target Info max length
-      offset: optional<integer>                # Target Info offset
+      netbiosDomainName: optional<string> # Attribute: NetBIOS domain name (e.g., ADICORP)
+      netbiosComputerName: optional<string> # Attribute: NetBIOS computer name (e.g., NYC-DC01)
+      dnsDomainName: optional<string> # Attribute: DNS domain name (e.g., corp.auric-dynamics.com)
+      dnsComputerName: optional<string> # Attribute: DNS computer name (e.g., NYC-DC01.corp.auric-dynamics.com)
+      dnsTreeName: optional<string> # Attribute: DNS tree name (e.g., corp.auric-dynamics.com)
+      timestamp: optional<datetime> # Attribute: Timestamp from NTLM challenge
 
   # NTLM OS Information structure - extracted from NTLM challenge Version block
   NtlmOsInfo:
     properties:
-      majorVersion: optional<integer>          # Major Version (e.g., 10)
-      minorVersion: optional<integer>          # Minor Version (e.g., 0)
-      buildNumber: optional<integer>           # Build Number (e.g., 20348)
-      ntlmCurrentRevision: optional<integer>   # NTLM Current Revision (e.g., 15)
-      versionString: optional<string>          # Formatted version string (e.g., "Version 10.0 (Build 20348)")
-      rawVersionData: optional<string>         # Raw version data from NTLM
+      majorVersion: optional<integer> # Major Version (e.g., 10)
+      minorVersion: optional<integer> # Minor Version (e.g., 0)
+      buildNumber: optional<integer> # Build Number (e.g., 20348)
+      ntlmCurrentRevision: optional<integer> # NTLM Current Revision (e.g., 15)
+      versionString: optional<string> # Formatted version string (e.g., "Version 10.0 (Build 20348)")
+      rawVersionData: optional<string> # Raw version data from NTLM
 
   # Common NTLM Server Information extracted from NTLM challenge
   NtlmServerInfo:
     properties:
       # Parsed OS version (derived from OsInfo)
-      parsedOsVersion: optional<string>        # Parsed OS version (e.g., "Windows Server 2022")
-      
+      parsedOsVersion: optional<string> # Parsed OS version (e.g., "Windows Server 2022")
+
       # Protocol-specific fields
-      signingRequired: optional<boolean>       # Whether SMB signing is required
-      
+      signingRequired: optional<boolean> # Whether SMB signing is required
+
       # Detailed NTLM structures
-      targetInfo: optional<NtlmTargetInfo>     # Detailed TargetInfo from NTLM challenge
-      osInfo: optional<NtlmOsInfo>             # Detailed OS/Version info from NTLM challenge
+      targetInfo: optional<NtlmTargetInfo> # Detailed TargetInfo from NTLM challenge
+      osInfo: optional<NtlmOsInfo> # Detailed OS/Version info from NTLM challenge

--- a/fern/definition/common/protocol/smb.yml
+++ b/fern/definition/common/protocol/smb.yml
@@ -1,3 +1,6 @@
+imports:
+  ntlmProtocol: ./ntlm.yml
+
 types:
   # SMB Protocol ENUMs
   SmbVersion:
@@ -31,30 +34,19 @@ types:
 
   # Core SMB Protocol Objects
   SmbServerInfo:
+    extends: ntlmProtocol.NtlmServerInfo
     properties:
-      # Basic server identification
-      serverName: optional<string>
-      domain: optional<string>
-      netBIOSDomainName: optional<string>
-      workgroup: optional<string>
-      
-      # Version information
-      osVersion: optional<string>          # Parsed/human-readable version (e.g., "Windows Server 2019")
-      rawOsVersion: optional<string>       # Raw version from NTLM challenge (e.g., "Windows Server 2019 Build 17763")
-      lanManagerVersion: optional<string>  # LAN Manager version if available
-      
-      # SMB protocol details
+      # SMB-specific protocol details
       smbVersion: optional<SmbVersion>             # Primary SMB version in use
       supportedSmbVersions: optional<list<SmbVersion>>  # All supported SMB versions
       
-      # Security capabilities
-      signingRequired: optional<boolean>
+      # SMB-specific security capabilities
       signingEnabled: optional<boolean>
       encryptionSupported: optional<boolean>
       encryptionRequired: optional<boolean>
       
-      # Additional capabilities
-      capabilities: optional<list<string>>
+      # SMB-specific version information
+      lanManagerVersion: optional<string>         # LAN Manager version if available
 
   SmbShare:
     properties:

--- a/fern/definition/enumerate/ldap/ldap.yml
+++ b/fern/definition/enumerate/ldap/ldap.yml
@@ -6,6 +6,7 @@ types:
   EnumerateLdapDetails:
     properties:
       target: string
+      serverInfo: optional<ldapProtocol.LdapServerInfo>  # Server information extracted from NTLM challenge
       anonymousBindAllowed: optional<boolean>
       nullBindAllowed: optional<boolean>
       authMethods: optional<list<ldapProtocol.LdapAuthMethod>>

--- a/fern/definition/pentest/auth.yml
+++ b/fern/definition/pentest/auth.yml
@@ -44,5 +44,4 @@ types:
     properties:
       target: string                     # Target host:port
       authAttempts: optional<list<AuthAttempt>>  # All authentication attempts made
-      serverInfo: optional<smbProtocol.SmbServerInfo>  # Server information extracted from NTLM challenge or other means
       errors: optional<list<string>>     # General errors not tied to specific attempts

--- a/fern/definition/pentest/ldap/ldap.yml
+++ b/fern/definition/pentest/ldap/ldap.yml
@@ -1,6 +1,7 @@
 imports:
   common: ../common.yml
   ldapProtocol: ../../common/protocol/ldap.yml
+  probe: ./probe.yml
   domaindump: ./domaindump.yml
   auth: ../auth.yml
 
@@ -8,6 +9,7 @@ types:
   # LDAP Actions
   LdapAction:
     enum:
+      - PROBE # Server information gathering via LDAP connection (no credentials)
       - AUTH
       - DOMAINDUMP
 
@@ -27,13 +29,14 @@ types:
   # LDAP Result Types
   PentestLdapResult:
     union:
+      ProbeResult: probe.ProbeResult
       AuthResult: auth.AuthResult
       DomainDumpResult: domaindump.DomainDumpResult
 
-  # Container for optional LDAP result
+  # Container for list of incremental LDAP results from phased approach
   PentestLdapResultContainer:
     properties:
-      result: optional<PentestLdapResult>
+      results: optional<list<PentestLdapResult>>  # List of results from PROBE -> AUTH -> ACTION phases
 
   # LDAP Report Types
   PentestLdapReport:

--- a/fern/definition/pentest/ldap/probe.yml
+++ b/fern/definition/pentest/ldap/probe.yml
@@ -1,0 +1,10 @@
+imports:
+  ldapProtocol: ../../common/protocol/ldap.yml
+
+types:
+  # Probe result for LDAP server information gathering
+  ProbeResult:
+    properties:
+      target: string
+      serverInfo: optional<ldapProtocol.LdapServerInfo>  # Server information extracted from LDAP connection
+      errors: optional<list<string>>  # Any errors during probe

--- a/fern/definition/pentest/smb/probe.yml
+++ b/fern/definition/pentest/smb/probe.yml
@@ -1,0 +1,10 @@
+imports:
+  smbProtocol: ../../common/protocol/smb.yml
+
+types:
+  # Probe result for server information gathering
+  ProbeResult:
+    properties:
+      target: string
+      serverInfo: optional<smbProtocol.SmbServerInfo>  # Server information extracted from NTLM challenge
+      errors: optional<list<string>>  # Any errors during probe

--- a/fern/definition/pentest/smb/smb.yml
+++ b/fern/definition/pentest/smb/smb.yml
@@ -1,6 +1,7 @@
 imports:
   common: ../common.yml
   smbProtocol: ../../common/protocol/smb.yml
+  probe: ./probe.yml
   auth: ./auth.yml
   samdump: ./samdump.yml
   lsadump: ./lsadump.yml
@@ -10,6 +11,7 @@ types:
   # SMB Actions
   PentestSMBAction:
     enum:
+      - PROBE # Server information gathering via NTLM challenge (no credentials)
       - AUTH # Authentication/credential testing (bruteforce)
       - SAMDUMP # Extract SAM hashes from Windows registry
       - LSADUMP # Extract LSA secrets from Windows registry
@@ -18,15 +20,16 @@ types:
   # SMB Result Types - union of all action results
   PentestSmbResult:
     union:
+      ProbeResult: probe.ProbeResult
       AuthResult: auth.AuthResult
       SamdumpResult: samdump.SamdumpResult
       LsadumpResult: lsadump.LsadumpResult
       SharesResult: shares.SharesResult
 
-  # Container for optional SMB result
+  # Container for list of incremental SMB results from phased approach
   PentestSmbResultContainer:
     properties:
-      result: optional<PentestSmbResult>
+      results: optional<list<PentestSmbResult>>  # List of results from PROBE -> AUTH -> ACTION phases
 
   # Config for SMB pentest operations - extends general config
   PentestSmbConfig:

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 
 require (
 	aead.dev/minisign v0.2.0 // indirect
-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057 // indirect
 	github.com/Mzack9999/go-http-digest-auth-client v0.6.1-0.20220414142836-eb8883508809 // indirect
@@ -112,6 +112,7 @@ require (
 	github.com/projectdiscovery/utils v0.0.92 // indirect
 	github.com/projectdiscovery/wappalyzergo v0.0.77 // indirect
 	github.com/quic-go/quic-go v0.48.2 // indirect
+	github.com/rbetts/go-ntlm v0.0.0-20130522135510-f22198915663
 	github.com/refraction-networking/utls v1.5.4 // indirect
 	github.com/remeh/sizedwaitgroup v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,8 @@ github.com/projectdiscovery/wappalyzergo v0.0.77 h1:PjWTwa4T8AoR+QpxLVY/4agQba+l
 github.com/projectdiscovery/wappalyzergo v0.0.77/go.mod h1:HvYuW0Be4JCjVds/+XAEaMSqRG9yrI97UmZq0TPk6A0=
 github.com/quic-go/quic-go v0.48.2 h1:wsKXZPeGWpMpCGSWqOcqpW2wZYic/8T3aqiOID0/KWE=
 github.com/quic-go/quic-go v0.48.2/go.mod h1:yBgs3rWBOADpga7F+jJsb6Ybg1LSYiQvwWlLX+/6HMs=
+github.com/rbetts/go-ntlm v0.0.0-20130522135510-f22198915663 h1:7W7RFMsP0Q1nHOGFLaFDfIDOKhJcTRsk9uO7VgHJAzA=
+github.com/rbetts/go-ntlm v0.0.0-20130522135510-f22198915663/go.mod h1:HN+0xrMIX5WaoEv6aOjKJWPgH9Oe5ur1c31WWv+XBB8=
 github.com/refraction-networking/utls v1.5.4 h1:9k6EO2b8TaOGsQ7Pl7p9w6PUhx18/ZCeT0WNTZ7Uw4o=
 github.com/refraction-networking/utls v1.5.4/go.mod h1:SPuDbBmgLGp8s+HLNc83FuavwZCFoMmExj+ltUHiHUw=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=

--- a/internal/common/ntlm/hash.go
+++ b/internal/common/ntlm/hash.go
@@ -1,4 +1,4 @@
-package common
+package ntlm
 
 import (
 	"encoding/hex"
@@ -12,16 +12,16 @@ const StandardLMHash = "aad3b435b51404eeaad3b435b51404ee"
 // EmptyNTHash is the empty NT hash (for empty password)
 const EmptyNTHash = "31D6CFE0D16AE931B73C59D7E0C089C0"
 
-// NTLMHashProcessor provides utilities for processing NTLM hashes
-type NTLMHashProcessor struct{}
+// HashProcessor provides utilities for processing NTLM hashes
+type HashProcessor struct{}
 
-// NewNTLMHashProcessor creates a new NTLM hash processor
-func NewNTLMHashProcessor() *NTLMHashProcessor {
-	return &NTLMHashProcessor{}
+// NewHashProcessor creates a new NTLM hash processor
+func NewHashProcessor() *HashProcessor {
+	return &HashProcessor{}
 }
 
 // ProcessHashForSMB processes an NTLM hash for SMB authentication (returns only NT portion as bytes)
-func (p *NTLMHashProcessor) ProcessHashForSMB(ntlmHash string) ([]byte, error) {
+func (p *HashProcessor) ProcessHashForSMB(ntlmHash string) ([]byte, error) {
 	if len(ntlmHash) == 32 {
 		// Only NT hash provided (32 hex chars), use directly
 		return hex.DecodeString(ntlmHash)
@@ -34,7 +34,7 @@ func (p *NTLMHashProcessor) ProcessHashForSMB(ntlmHash string) ([]byte, error) {
 }
 
 // ProcessHashForLDAP processes an NTLM hash for LDAP authentication (returns LM:NT format)
-func (p *NTLMHashProcessor) ProcessHashForLDAP(ntlmHash string) string {
+func (p *HashProcessor) ProcessHashForLDAP(ntlmHash string) string {
 	if len(ntlmHash) == 32 {
 		// Only NT hash provided (32 hex chars), prepend standard LM hash
 		return StandardLMHash + ":" + ntlmHash
@@ -44,11 +44,11 @@ func (p *NTLMHashProcessor) ProcessHashForLDAP(ntlmHash string) string {
 }
 
 // IsValidNTHash checks if a hash looks like a valid NT hash
-func (p *NTLMHashProcessor) IsValidNTHash(hash string) bool {
+func (p *HashProcessor) IsValidNTHash(hash string) bool {
 	return len(hash) == 32 && strings.ToUpper(hash) != EmptyNTHash
 }
 
 // IsEmptyNTHash checks if the hash represents an empty password
-func (p *NTLMHashProcessor) IsEmptyNTHash(hash string) bool {
+func (p *HashProcessor) IsEmptyNTHash(hash string) bool {
 	return strings.ToUpper(hash) == EmptyNTHash
 }

--- a/internal/common/ntlm/serverinfo.go
+++ b/internal/common/ntlm/serverinfo.go
@@ -1,7 +1,6 @@
 package ntlm
 
 import (
-	"encoding/binary"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -100,81 +99,6 @@ func ExtractServerInfoFromChallenge(challengeMessage []byte, log svc1log.Logger)
 		svc1log.SafeParam("dnsDomain", dnsDomain),
 		svc1log.SafeParam("dnsComputer", dnsComputer),
 		svc1log.SafeParam("flags", fmt.Sprintf("0x%08x", c.NegotiateFlags)))
-
-	return result, nil
-}
-
-// GoSMBTargetInfo represents the TargetInfo struct from go-smb library
-// This is defined here to avoid importing the go-smb library directly
-type GoSMBTargetInfo struct {
-	DNSComputerName  string
-	DNSDomainName    string
-	NBComputerName   string
-	NBDomainName     string
-	OS               uint64
-	GuessedOSVersion string
-}
-
-// ExtractServerInfoFromGoSMBTargetInfo extracts unified server information from go-smb TargetInfo
-// This provides a centralized way for SMB client to convert go-smb TargetInfo to unified NtlmServerInfo
-func ExtractServerInfoFromGoSMBTargetInfo(targetInfo *GoSMBTargetInfo, log svc1log.Logger) (*commonprotocolfern.NtlmServerInfo, error) {
-	if targetInfo == nil {
-		return nil, fmt.Errorf("go-smb target info is nil")
-	}
-
-	result := &commonprotocolfern.NtlmServerInfo{}
-
-	// Create and populate the NtlmTargetInfo structure with exact fields from NTLM challenge
-	ntlmTargetInfo := &commonprotocolfern.NtlmTargetInfo{
-		NetbiosDomainName:   stringToPtr(targetInfo.NBDomainName),
-		NetbiosComputerName: stringToPtr(targetInfo.NBComputerName),
-		DnsDomainName:       stringToPtr(targetInfo.DNSDomainName),
-		DnsComputerName:     stringToPtr(targetInfo.DNSComputerName),
-		DnsTreeName:         stringToPtr(targetInfo.DNSDomainName), // Usually same as DNS domain
-	}
-	result.TargetInfo = ntlmTargetInfo
-
-	// Create and populate the NtlmOsInfo structure with version details
-	var ntlmOsInfo *commonprotocolfern.NtlmOsInfo
-	if targetInfo.OS != 0 {
-		// Parse the version information exactly as go-smb does
-		versionBuf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(versionBuf, targetInfo.OS)
-		majorVersion := int(versionBuf[0])
-		minorVersion := int(versionBuf[1])
-		buildNumber := int(binary.LittleEndian.Uint16(versionBuf[2:4]))
-		// Extract NTLM revision from byte 7
-		ntlmRevision := int(versionBuf[7])
-
-		// Create formatted version string matching the NTLM challenge format
-		versionString := fmt.Sprintf("Version %d.%d (Build %d); NTLM Current Revision %d",
-			majorVersion, minorVersion, buildNumber, ntlmRevision)
-
-		ntlmOsInfo = &commonprotocolfern.NtlmOsInfo{
-			MajorVersion:        &majorVersion,
-			MinorVersion:        &minorVersion,
-			BuildNumber:         &buildNumber,
-			NtlmCurrentRevision: &ntlmRevision,
-			VersionString:       &versionString,
-			RawVersionData: stringToPtr(fmt.Sprintf("%02x%02x%02x%02x%02x%02x%02x%02x",
-				versionBuf[0], versionBuf[1], versionBuf[2], versionBuf[3],
-				versionBuf[4], versionBuf[5], versionBuf[6], versionBuf[7])),
-		}
-	}
-	result.OsInfo = ntlmOsInfo
-
-	// Parse and enhance the OS version
-	if targetInfo.GuessedOSVersion != "" {
-		osVersion := ParseWindowsVersion(targetInfo.GuessedOSVersion)
-		result.ParsedOsVersion = &osVersion
-	}
-
-	// Log detailed extraction info
-	log.Info("Extracted unified server info from go-smb TargetInfo",
-		svc1log.SafeParam("nbDomain", targetInfo.NBDomainName),
-		svc1log.SafeParam("nbComputer", targetInfo.NBComputerName),
-		svc1log.SafeParam("dnsDomain", targetInfo.DNSDomainName),
-		svc1log.SafeParam("dnsComputer", targetInfo.DNSComputerName))
 
 	return result, nil
 }

--- a/internal/common/ntlm/serverinfo.go
+++ b/internal/common/ntlm/serverinfo.go
@@ -224,6 +224,190 @@ func stringToPtr(s string) *string {
 	return &s
 }
 
+// GetServerName extracts server name from server info, preferring DNS computer name
+func GetServerName(serverInfo *commonprotocolfern.NtlmServerInfo) string {
+	if serverInfo != nil && serverInfo.TargetInfo != nil {
+		if serverInfo.TargetInfo.DnsComputerName != nil && *serverInfo.TargetInfo.DnsComputerName != "" {
+			return *serverInfo.TargetInfo.DnsComputerName
+		}
+		if serverInfo.TargetInfo.NetbiosComputerName != nil && *serverInfo.TargetInfo.NetbiosComputerName != "" {
+			return *serverInfo.TargetInfo.NetbiosComputerName
+		}
+	}
+	return ""
+}
+
+// GetDomainName extracts domain name from server info, preferring DNS domain name
+func GetDomainName(serverInfo *commonprotocolfern.NtlmServerInfo) string {
+	if serverInfo != nil && serverInfo.TargetInfo != nil {
+		if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
+			return *serverInfo.TargetInfo.DnsDomainName
+		}
+		if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
+			return *serverInfo.TargetInfo.NetbiosDomainName
+		}
+	}
+	return ""
+}
+
+// GetOSVersion extracts parsed OS version from server info
+func GetOSVersion(serverInfo *commonprotocolfern.NtlmServerInfo) string {
+	if serverInfo != nil && serverInfo.ParsedOsVersion != nil {
+		return *serverInfo.ParsedOsVersion
+	}
+	return ""
+}
+
+// GetSigningRequired extracts signing requirement from server info
+func GetSigningRequired(serverInfo *commonprotocolfern.NtlmServerInfo) bool {
+	if serverInfo != nil && serverInfo.SigningRequired != nil {
+		return *serverInfo.SigningRequired
+	}
+	return false
+}
+
+// LogServerInfoDetails logs detailed server info with all available fields
+func LogServerInfoDetails(serverInfo *commonprotocolfern.NtlmServerInfo, target string, log svc1log.Logger) {
+	if serverInfo == nil {
+		log.Debug("No server info available for logging", svc1log.SafeParam("target", target))
+		return
+	}
+
+	// Extract main fields
+	serverName := GetServerName(serverInfo)
+	domain := GetDomainName(serverInfo)
+	osVersion := GetOSVersion(serverInfo)
+	signingRequired := GetSigningRequired(serverInfo)
+
+	// Extract detailed TargetInfo fields
+	var netbiosDomain, dnsDomain, dnsComputer, netbiosComputer string
+	if serverInfo.TargetInfo != nil {
+		if serverInfo.TargetInfo.NetbiosDomainName != nil {
+			netbiosDomain = *serverInfo.TargetInfo.NetbiosDomainName
+		}
+		if serverInfo.TargetInfo.DnsDomainName != nil {
+			dnsDomain = *serverInfo.TargetInfo.DnsDomainName
+		}
+		if serverInfo.TargetInfo.DnsComputerName != nil {
+			dnsComputer = *serverInfo.TargetInfo.DnsComputerName
+		}
+		if serverInfo.TargetInfo.NetbiosComputerName != nil {
+			netbiosComputer = *serverInfo.TargetInfo.NetbiosComputerName
+		}
+	}
+
+	// Extract detailed OsInfo fields
+	var majorVersion, minorVersion, buildNumber, ntlmRevision int
+	var versionString string
+	if serverInfo.OsInfo != nil {
+		if serverInfo.OsInfo.MajorVersion != nil {
+			majorVersion = *serverInfo.OsInfo.MajorVersion
+		}
+		if serverInfo.OsInfo.MinorVersion != nil {
+			minorVersion = *serverInfo.OsInfo.MinorVersion
+		}
+		if serverInfo.OsInfo.BuildNumber != nil {
+			buildNumber = *serverInfo.OsInfo.BuildNumber
+		}
+		if serverInfo.OsInfo.NtlmCurrentRevision != nil {
+			ntlmRevision = *serverInfo.OsInfo.NtlmCurrentRevision
+		}
+		if serverInfo.OsInfo.VersionString != nil {
+			versionString = *serverInfo.OsInfo.VersionString
+		}
+	}
+
+	log.Info("Extracted detailed server info",
+		svc1log.SafeParam("target", target),
+		svc1log.SafeParam("serverName", serverName),
+		svc1log.SafeParam("domain", domain),
+		svc1log.SafeParam("osVersion", osVersion),
+		svc1log.SafeParam("signingRequired", signingRequired),
+		// TargetInfo details
+		svc1log.SafeParam("netbiosDomain", netbiosDomain),
+		svc1log.SafeParam("dnsDomain", dnsDomain),
+		svc1log.SafeParam("dnsComputer", dnsComputer),
+		svc1log.SafeParam("netbiosComputer", netbiosComputer),
+		// OsInfo details
+		svc1log.SafeParam("osMajorVersion", majorVersion),
+		svc1log.SafeParam("osMinorVersion", minorVersion),
+		svc1log.SafeParam("osBuildNumber", buildNumber),
+		svc1log.SafeParam("ntlmRevision", ntlmRevision),
+		svc1log.SafeParam("osVersionString", versionString))
+}
+
+// GetSMBServerName extracts server name from SMB server info, preferring DNS computer name
+func GetSMBServerName(serverInfo *commonprotocolfern.SmbServerInfo) string {
+	if serverInfo != nil && serverInfo.TargetInfo != nil {
+		if serverInfo.TargetInfo.DnsComputerName != nil && *serverInfo.TargetInfo.DnsComputerName != "" {
+			return *serverInfo.TargetInfo.DnsComputerName
+		}
+		if serverInfo.TargetInfo.NetbiosComputerName != nil && *serverInfo.TargetInfo.NetbiosComputerName != "" {
+			return *serverInfo.TargetInfo.NetbiosComputerName
+		}
+	}
+	return ""
+}
+
+func GetSMBDomainName(serverInfo *commonprotocolfern.SmbServerInfo) string {
+	if serverInfo != nil && serverInfo.TargetInfo != nil {
+		if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
+			return *serverInfo.TargetInfo.DnsDomainName
+		}
+		if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
+			return *serverInfo.TargetInfo.NetbiosDomainName
+		}
+	}
+	return ""
+}
+
+func GetSMBOSVersion(serverInfo *commonprotocolfern.SmbServerInfo) string {
+	if serverInfo != nil && serverInfo.ParsedOsVersion != nil {
+		return *serverInfo.ParsedOsVersion
+	}
+	return ""
+}
+
+func GetSMBSigningRequired(serverInfo *commonprotocolfern.SmbServerInfo) bool {
+	if serverInfo != nil && serverInfo.SigningRequired != nil {
+		return *serverInfo.SigningRequired
+	}
+	return false
+}
+
+// GetLDAPServerName extracts server name from LDAP server info, preferring DNS computer name
+func GetLDAPServerName(serverInfo *commonprotocolfern.LdapServerInfo) string {
+	if serverInfo != nil && serverInfo.TargetInfo != nil {
+		if serverInfo.TargetInfo.DnsComputerName != nil && *serverInfo.TargetInfo.DnsComputerName != "" {
+			return *serverInfo.TargetInfo.DnsComputerName
+		}
+		if serverInfo.TargetInfo.NetbiosComputerName != nil && *serverInfo.TargetInfo.NetbiosComputerName != "" {
+			return *serverInfo.TargetInfo.NetbiosComputerName
+		}
+	}
+	return ""
+}
+
+func GetLDAPDomainName(serverInfo *commonprotocolfern.LdapServerInfo) string {
+	if serverInfo != nil && serverInfo.TargetInfo != nil {
+		if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
+			return *serverInfo.TargetInfo.DnsDomainName
+		}
+		if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
+			return *serverInfo.TargetInfo.NetbiosDomainName
+		}
+	}
+	return ""
+}
+
+// GetSMBNetbiosDomain extracts NetBIOS domain name from SMB server info
+func GetSMBNetbiosDomain(serverInfo *commonprotocolfern.SmbServerInfo) string {
+	if serverInfo != nil && serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil {
+		return *serverInfo.TargetInfo.NetbiosDomainName
+	}
+	return ""
+}
+
 // WindowsBuildMapping maps Windows build numbers to human-readable versions
 var WindowsBuildMapping = map[string]string{
 	// Windows Server builds (prioritized for server environments)

--- a/internal/common/ntlm/serverinfo.go
+++ b/internal/common/ntlm/serverinfo.go
@@ -1,0 +1,337 @@
+package ntlm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/rbetts/go-ntlm/ntlm/messages"
+)
+
+// ExtractServerInfoFromChallenge extracts server information from NTLM Type 2 challenge message
+func ExtractServerInfoFromChallenge(challengeMessage []byte, log svc1log.Logger) (*commonprotocolfern.NtlmServerInfo, error) {
+	// Parse the NTLM Type 2 challenge message
+	c, err := messages.ParseChallengeMessage(challengeMessage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse NTLM challenge message: %v", err)
+	}
+
+	if c.TargetInfo == nil {
+		return nil, fmt.Errorf("no target info in NTLM challenge message")
+	}
+
+	ti := c.TargetInfo
+	result := &commonprotocolfern.NtlmServerInfo{}
+
+	// Extract target info fields
+	var nbDomain, nbComputer, dnsDomain, dnsComputer string
+	if nb := ti.StringValue(messages.MsvAvNbDomainName); nb != "" {
+		nbDomain = nb
+	}
+
+	if nb := ti.StringValue(messages.MsvAvNbComputerName); nb != "" {
+		nbComputer = nb
+	}
+
+	if dns := ti.StringValue(messages.MsvAvDnsDomainName); dns != "" {
+		dnsDomain = dns
+	}
+
+	if dns := ti.StringValue(messages.MsvAvDnsComputerName); dns != "" {
+		dnsComputer = dns
+	}
+
+	// Create and populate the NtlmTargetInfo structure
+	ntlmTargetInfo := &commonprotocolfern.NtlmTargetInfo{
+		NetbiosDomainName:   stringToPtr(nbDomain),
+		NetbiosComputerName: stringToPtr(nbComputer),
+		DnsDomainName:       stringToPtr(dnsDomain),
+		DnsComputerName:     stringToPtr(dnsComputer),
+		DnsTreeName:         stringToPtr(dnsDomain), // Usually same as DNS domain
+	}
+	result.TargetInfo = ntlmTargetInfo
+
+	// Extract OS version information from NTLM Version struct if available
+	var rawOSVersion, osVersion string
+	var ntlmOsInfo *commonprotocolfern.NtlmOsInfo
+	if c.Version != nil {
+		// Build raw OS version string from version struct
+		rawOSVersion = fmt.Sprintf("Windows NT %d.%d Build %d",
+			c.Version.ProductMajorVersion,
+			c.Version.ProductMinorVersion,
+			c.Version.ProductBuild)
+
+		// Parse to human-readable version
+		osVersion = ParseWindowsVersion(rawOSVersion)
+
+		// Create formatted version string matching the NTLM challenge format
+		majorVersion := int(c.Version.ProductMajorVersion)
+		minorVersion := int(c.Version.ProductMinorVersion)
+		buildNumber := int(c.Version.ProductBuild)
+		ntlmRevision := int(c.Version.NTLMRevisionCurrent)
+		versionString := fmt.Sprintf("Version %d.%d (Build %d); NTLM Current Revision %d",
+			majorVersion, minorVersion, buildNumber, ntlmRevision)
+
+		ntlmOsInfo = &commonprotocolfern.NtlmOsInfo{
+			MajorVersion:        &majorVersion,
+			MinorVersion:        &minorVersion,
+			BuildNumber:         &buildNumber,
+			NtlmCurrentRevision: &ntlmRevision,
+			VersionString:       &versionString,
+			RawVersionData:      &rawOSVersion,
+		}
+
+		result.ParsedOsVersion = &osVersion
+	}
+	result.OsInfo = ntlmOsInfo
+
+	// Set signing requirement based on NTLM flags
+	signingRequired := (c.NegotiateFlags & 0x00040000) != 0 // NTLMSSP_NEGOTIATE_SIGN
+	result.SigningRequired = &signingRequired
+
+	// Log detailed extraction info
+	log.Info("Extracted unified server info from NTLM challenge",
+		svc1log.SafeParam("nbDomain", nbDomain),
+		svc1log.SafeParam("nbComputer", nbComputer),
+		svc1log.SafeParam("dnsDomain", dnsDomain),
+		svc1log.SafeParam("dnsComputer", dnsComputer),
+		svc1log.SafeParam("flags", fmt.Sprintf("0x%08x", c.NegotiateFlags)))
+
+	return result, nil
+}
+
+// GoSMBTargetInfo represents the TargetInfo struct from go-smb library
+// This is defined here to avoid importing the go-smb library directly
+type GoSMBTargetInfo struct {
+	DNSComputerName  string
+	DNSDomainName    string
+	NBComputerName   string
+	NBDomainName     string
+	OS               uint64
+	GuessedOSVersion string
+}
+
+// ExtractServerInfoFromGoSMBTargetInfo extracts unified server information from go-smb TargetInfo
+// This provides a centralized way for SMB client to convert go-smb TargetInfo to unified NtlmServerInfo
+func ExtractServerInfoFromGoSMBTargetInfo(targetInfo *GoSMBTargetInfo, log svc1log.Logger) (*commonprotocolfern.NtlmServerInfo, error) {
+	if targetInfo == nil {
+		return nil, fmt.Errorf("go-smb target info is nil")
+	}
+
+	result := &commonprotocolfern.NtlmServerInfo{}
+
+	// Create and populate the NtlmTargetInfo structure with exact fields from NTLM challenge
+	ntlmTargetInfo := &commonprotocolfern.NtlmTargetInfo{
+		NetbiosDomainName:   stringToPtr(targetInfo.NBDomainName),
+		NetbiosComputerName: stringToPtr(targetInfo.NBComputerName),
+		DnsDomainName:       stringToPtr(targetInfo.DNSDomainName),
+		DnsComputerName:     stringToPtr(targetInfo.DNSComputerName),
+		DnsTreeName:         stringToPtr(targetInfo.DNSDomainName), // Usually same as DNS domain
+	}
+	result.TargetInfo = ntlmTargetInfo
+
+	// Create and populate the NtlmOsInfo structure with version details
+	var ntlmOsInfo *commonprotocolfern.NtlmOsInfo
+	if targetInfo.OS != 0 {
+		// Parse the version information exactly as go-smb does
+		versionBuf := make([]byte, 8)
+		binary.LittleEndian.PutUint64(versionBuf, targetInfo.OS)
+		majorVersion := int(versionBuf[0])
+		minorVersion := int(versionBuf[1])
+		buildNumber := int(binary.LittleEndian.Uint16(versionBuf[2:4]))
+		// Extract NTLM revision from byte 7
+		ntlmRevision := int(versionBuf[7])
+
+		// Create formatted version string matching the NTLM challenge format
+		versionString := fmt.Sprintf("Version %d.%d (Build %d); NTLM Current Revision %d",
+			majorVersion, minorVersion, buildNumber, ntlmRevision)
+
+		ntlmOsInfo = &commonprotocolfern.NtlmOsInfo{
+			MajorVersion:        &majorVersion,
+			MinorVersion:        &minorVersion,
+			BuildNumber:         &buildNumber,
+			NtlmCurrentRevision: &ntlmRevision,
+			VersionString:       &versionString,
+			RawVersionData: stringToPtr(fmt.Sprintf("%02x%02x%02x%02x%02x%02x%02x%02x",
+				versionBuf[0], versionBuf[1], versionBuf[2], versionBuf[3],
+				versionBuf[4], versionBuf[5], versionBuf[6], versionBuf[7])),
+		}
+	}
+	result.OsInfo = ntlmOsInfo
+
+	// Parse and enhance the OS version
+	if targetInfo.GuessedOSVersion != "" {
+		osVersion := ParseWindowsVersion(targetInfo.GuessedOSVersion)
+		result.ParsedOsVersion = &osVersion
+	}
+
+	// Log detailed extraction info
+	log.Info("Extracted unified server info from go-smb TargetInfo",
+		svc1log.SafeParam("nbDomain", targetInfo.NBDomainName),
+		svc1log.SafeParam("nbComputer", targetInfo.NBComputerName),
+		svc1log.SafeParam("dnsDomain", targetInfo.DNSDomainName),
+		svc1log.SafeParam("dnsComputer", targetInfo.DNSComputerName))
+
+	return result, nil
+}
+
+// ConvertToLDAPServerInfo converts common NTLM server info to LDAP-specific format
+func ConvertToLDAPServerInfo(ntlmInfo *commonprotocolfern.NtlmServerInfo) *commonprotocolfern.LdapServerInfo {
+	result := &commonprotocolfern.LdapServerInfo{}
+
+	// Copy core fields that exist in cleaned structure
+	if ntlmInfo.ParsedOsVersion != nil {
+		result.ParsedOsVersion = ntlmInfo.ParsedOsVersion
+	}
+	if ntlmInfo.SigningRequired != nil {
+		result.SigningRequired = ntlmInfo.SigningRequired
+	}
+
+	// Copy nested structures
+	if ntlmInfo.TargetInfo != nil {
+		result.TargetInfo = ntlmInfo.TargetInfo
+	}
+	if ntlmInfo.OsInfo != nil {
+		result.OsInfo = ntlmInfo.OsInfo
+	}
+
+	// Generate LDAP-specific base DN from nested TargetInfo
+	if ntlmInfo.TargetInfo != nil {
+		if ntlmInfo.TargetInfo.DnsDomainName != nil && *ntlmInfo.TargetInfo.DnsDomainName != "" {
+			baseDN := convertDNSDomainToBaseDN(*ntlmInfo.TargetInfo.DnsDomainName)
+			result.BaseDn = &baseDN
+		} else if ntlmInfo.TargetInfo.NetbiosDomainName != nil && *ntlmInfo.TargetInfo.NetbiosDomainName != "" {
+			baseDN := fmt.Sprintf("DC=%s", *ntlmInfo.TargetInfo.NetbiosDomainName)
+			result.BaseDn = &baseDN
+		}
+	}
+
+	// Set LDAP-specific capabilities
+	supportsTLS := false          // Default - would need more sophisticated detection
+	supportsStartTLS := true      // Most modern servers support StartTLS
+	supportsSASL := true          // NTLM is a SASL mechanism
+	anonymousBindAllowed := false // Default for AD
+
+	result.SupportsTls = &supportsTLS
+	result.SupportsStartTls = &supportsStartTLS
+	result.SupportsSasl = &supportsSASL
+	result.AnonymousBindAllowed = &anonymousBindAllowed
+
+	return result
+}
+
+// convertDNSDomainToBaseDN converts a DNS domain name to LDAP base DN format
+// e.g., corp.auric-dynamics.com -> DC=corp,DC=auric-dynamics,DC=com
+func convertDNSDomainToBaseDN(dnsDomain string) string {
+	if dnsDomain == "" {
+		return ""
+	}
+
+	parts := strings.Split(dnsDomain, ".")
+	dcParts := make([]string, len(parts))
+	for i, part := range parts {
+		dcParts[i] = "DC=" + part
+	}
+	return strings.Join(dcParts, ",")
+}
+
+// ParseWindowsVersion extracts and enhances Windows version information
+func ParseWindowsVersion(rawOSVersion string) string {
+	if rawOSVersion == "" {
+		return ""
+	}
+
+	// Extract build number using regex
+	buildRegex := regexp.MustCompile(`Build (\d+)`)
+	matches := buildRegex.FindStringSubmatch(rawOSVersion)
+
+	if len(matches) > 1 {
+		buildNumber := matches[1]
+
+		// Look up human-readable version
+		if readableVersion, exists := WindowsBuildMapping[buildNumber]; exists {
+			return readableVersion
+		}
+
+		// If not found, try to classify by build number ranges
+		return classifyWindowsByBuildNumber(buildNumber, rawOSVersion)
+	}
+
+	// Fallback to original version if no build number found
+	return rawOSVersion
+}
+
+// classifyWindowsByBuildNumber classifies Windows versions by build number ranges
+func classifyWindowsByBuildNumber(buildNumber, rawVersion string) string {
+	build, err := strconv.Atoi(buildNumber)
+	if err != nil {
+		return rawVersion
+	}
+
+	switch {
+	case build >= 22000:
+		return fmt.Sprintf("Windows 11 (Build %s)", buildNumber)
+	case build >= 19000:
+		return fmt.Sprintf("Windows 10 (Build %s)", buildNumber)
+	case build >= 10000:
+		return fmt.Sprintf("Windows 10 (Build %s)", buildNumber)
+	case build >= 9600:
+		return fmt.Sprintf("Windows 8.1 (Build %s)", buildNumber)
+	case build >= 9200:
+		return fmt.Sprintf("Windows 8 (Build %s)", buildNumber)
+	case build >= 7600:
+		return fmt.Sprintf("Windows 7 (Build %s)", buildNumber)
+	case build >= 6000:
+		return fmt.Sprintf("Windows Vista (Build %s)", buildNumber)
+	default:
+		return fmt.Sprintf("Windows (Build %s)", buildNumber)
+	}
+}
+
+// stringToPtr converts a string to a pointer, returning nil for empty strings
+func stringToPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// WindowsBuildMapping maps Windows build numbers to human-readable versions
+var WindowsBuildMapping = map[string]string{
+	// Windows Server builds (prioritized for server environments)
+	"20348": "Windows Server 2022",
+	"17763": "Windows Server 2019",
+	"14393": "Windows Server 2016",
+	"9600":  "Windows Server 2012 R2",
+	"9200":  "Windows Server 2012",
+	"7601":  "Windows Server 2008 R2 SP1",
+	"6002":  "Windows Server 2008 SP2",
+	"6001":  "Windows Server 2008 SP1",
+	"6000":  "Windows Server 2008",
+
+	// Windows 11 builds
+	"22631": "Windows 11 23H2",
+	"22621": "Windows 11 22H2",
+	"22000": "Windows 11 21H2",
+
+	// Windows 10 builds (client builds that don't conflict with server)
+	"19045": "Windows 10 22H2",
+	"19044": "Windows 10 21H2",
+	"19043": "Windows 10 21H1",
+	"19042": "Windows 10 20H2",
+	"19041": "Windows 10 2004",
+	"18363": "Windows 10 1909",
+	"18362": "Windows 10 1903",
+	"17134": "Windows 10 1803",
+	"16299": "Windows 10 1709",
+	"15063": "Windows 10 1703",
+	"10586": "Windows 10 1511",
+	"10240": "Windows 10 1507",
+
+	// Older Windows versions
+	"7600": "Windows 7",
+}

--- a/internal/discover/domain.go
+++ b/internal/discover/domain.go
@@ -9,6 +9,7 @@ import (
 
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	ldappentest "github.com/Method-Security/networkscan/internal/pentest/ldap"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
 	"github.com/Method-Security/networkscan/utils"
@@ -124,13 +125,13 @@ func discoverViaSMB(ctx context.Context, host string) *basicDomainInfo {
 	// Extract domain names from server info
 
 	// Set DNS domain name
-	if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
-		info.dnsDomainName = *serverInfo.TargetInfo.DnsDomainName
+	if domain := ntlm.GetSMBDomainName(serverInfo); domain != "" {
+		info.dnsDomainName = domain
 	}
 
 	// Set NetBIOS domain name from the TargetInfo structure
-	if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
-		info.netbiosDomainName = *serverInfo.TargetInfo.NetbiosDomainName
+	if netbiosDomain := ntlm.GetSMBNetbiosDomain(serverInfo); netbiosDomain != "" {
+		info.netbiosDomainName = netbiosDomain
 	}
 
 	// Close the client

--- a/internal/discover/domain.go
+++ b/internal/discover/domain.go
@@ -124,8 +124,8 @@ func discoverViaSMB(ctx context.Context, host string) *basicDomainInfo {
 	// Extract domain names from server info
 
 	// Set DNS domain name
-	if serverInfo.Domain != nil && *serverInfo.Domain != "" {
-		info.dnsDomainName = *serverInfo.Domain
+	if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
+		info.dnsDomainName = *serverInfo.TargetInfo.DnsDomainName
 	}
 
 	// Set NetBIOS domain name from the TargetInfo structure
@@ -324,8 +324,8 @@ func enumerateDomainControllers(ctx context.Context, host string, domainName str
 
 			domainControllers = append(domainControllers, dcInfo)
 			var serverVersion string
-			if dcInfo.SmbServerInfo != nil && dcInfo.SmbServerInfo.OsVersion != nil {
-				serverVersion = *dcInfo.SmbServerInfo.OsVersion
+			if dcInfo.SmbServerInfo != nil && dcInfo.SmbServerInfo.ParsedOsVersion != nil {
+				serverVersion = *dcInfo.SmbServerInfo.ParsedOsVersion
 			}
 			log.Debug("Found domain controller",
 				svc1log.SafeParam("hostname", hostname),
@@ -397,8 +397,8 @@ func gatherDomainControllerDetails(ctx context.Context, hostname, ipAddress stri
 		_ = client.Close()
 
 		var osVersion string
-		if serverInfo.OsVersion != nil {
-			osVersion = *serverInfo.OsVersion
+		if serverInfo.ParsedOsVersion != nil {
+			osVersion = *serverInfo.ParsedOsVersion
 		}
 		log.Debug("Successfully gathered DC details",
 			svc1log.SafeParam("target", target),

--- a/internal/discover/domain.go
+++ b/internal/discover/domain.go
@@ -124,13 +124,13 @@ func discoverViaSMB(ctx context.Context, host string) *basicDomainInfo {
 	// Extract domain names from server info
 
 	// Set DNS domain name
-	if serverInfo.Domain != "" {
-		info.dnsDomainName = serverInfo.Domain
+	if serverInfo.Domain != nil && *serverInfo.Domain != "" {
+		info.dnsDomainName = *serverInfo.Domain
 	}
 
-	// Set NetBIOS domain name from the dedicated field
-	if serverInfo.NetBIOSDomainName != "" {
-		info.netbiosDomainName = serverInfo.NetBIOSDomainName
+	// Set NetBIOS domain name from the TargetInfo structure
+	if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
+		info.netbiosDomainName = *serverInfo.TargetInfo.NetbiosDomainName
 	}
 
 	// Close the client
@@ -387,11 +387,9 @@ func gatherDomainControllerDetails(ctx context.Context, hostname, ipAddress stri
 			continue // Try next target
 		}
 
-		// Convert the internal server info to the common protocol structure
-		smbServerInfo := convertToSmbServerInfo(serverInfo)
-
+		// Use the unified server info directly
 		details := &domainControllerDetails{
-			smbServerInfo: smbServerInfo,
+			smbServerInfo: serverInfo,
 			ipAddress:     target, // Store the target we used to connect
 		}
 
@@ -399,8 +397,8 @@ func gatherDomainControllerDetails(ctx context.Context, hostname, ipAddress stri
 		_ = client.Close()
 
 		var osVersion string
-		if smbServerInfo.OsVersion != nil {
-			osVersion = *smbServerInfo.OsVersion
+		if serverInfo.OsVersion != nil {
+			osVersion = *serverInfo.OsVersion
 		}
 		log.Debug("Successfully gathered DC details",
 			svc1log.SafeParam("target", target),
@@ -413,30 +411,6 @@ func gatherDomainControllerDetails(ctx context.Context, hostname, ipAddress stri
 		svc1log.SafeParam("hostname", hostname),
 		svc1log.SafeParam("ipAddress", ipAddress))
 	return nil
-}
-
-// convertToSmbServerInfo converts protocol library ServerInfo to common SMB ServerInfo
-func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocolfern.SmbServerInfo {
-	if serverInfo == nil {
-		return nil
-	}
-
-	result := &commonprotocolfern.SmbServerInfo{
-		ServerName:        &serverInfo.ServerName,
-		Domain:            &serverInfo.Domain,
-		NetBiosDomainName: &serverInfo.NetBIOSDomainName,
-		Workgroup:         &serverInfo.Domain, // Use domain as workgroup fallback
-		OsVersion:         &serverInfo.OSVersion,
-		Capabilities:      serverInfo.Capabilities,
-		SigningRequired:   &serverInfo.SigningRequired,
-	}
-
-	// Include raw OS version if available
-	if serverInfo.RawOSVersion != "" {
-		result.RawOsVersion = &serverInfo.RawOSVersion
-	}
-
-	return result
 }
 
 // Helper functions

--- a/internal/enumerate/ldap/ldap.go
+++ b/internal/enumerate/ldap/ldap.go
@@ -60,9 +60,9 @@ func (l *LibraryEnumerateLDAP) extractServerInfoFromNTLMChallenge(ctx context.Co
 
 	// Attempt NTLM bind to trigger challenge/response and extract server info
 	req := &ldap.NTLMBindRequest{
-		Domain:     "",          // Let the server provide domain info
-		Username:   "enumerate", // Dummy username for enumeration
-		Password:   "enumerate", // Dummy password for enumeration
+		Domain:     "", // Let the server provide domain info
+		Username:   "", // Empty username for enumeration
+		Password:   "", // Empty password for enumeration
 		Negotiator: negotiator,
 	}
 
@@ -74,27 +74,8 @@ func (l *LibraryEnumerateLDAP) extractServerInfoFromNTLMChallenge(ctx context.Co
 		// Convert unified server info to LDAP-specific format
 		ldapServerInfo := ntlm.ConvertToLDAPServerInfo(negotiator.serverInfo)
 		log.Debug("Successfully extracted server info from NTLM challenge during enumeration",
-			svc1log.SafeParam("dnsDomain", func() string {
-				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.DnsDomainName != nil {
-					return *ldapServerInfo.TargetInfo.DnsDomainName
-				}
-				return ""
-			}()),
-			svc1log.SafeParam("netbiosDomain", func() string {
-				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.NetbiosDomainName != nil {
-					return *ldapServerInfo.TargetInfo.NetbiosDomainName
-				}
-				return ""
-			}()),
-			svc1log.SafeParam("serverName", func() string {
-				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.DnsComputerName != nil {
-					return *ldapServerInfo.TargetInfo.DnsComputerName
-				}
-				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.NetbiosComputerName != nil {
-					return *ldapServerInfo.TargetInfo.NetbiosComputerName
-				}
-				return ""
-			}()))
+			svc1log.SafeParam("domain", ntlm.GetLDAPDomainName(ldapServerInfo)),
+			svc1log.SafeParam("serverName", ntlm.GetLDAPServerName(ldapServerInfo)))
 		return ldapServerInfo
 	}
 

--- a/internal/enumerate/ldap/ldap.go
+++ b/internal/enumerate/ldap/ldap.go
@@ -60,9 +60,9 @@ func (l *LibraryEnumerateLDAP) extractServerInfoFromNTLMChallenge(ctx context.Co
 
 	// Attempt NTLM bind to trigger challenge/response and extract server info
 	req := &ldap.NTLMBindRequest{
-		Domain:     "", // Let the server provide domain info
-		Username:   "", // Empty username for enumeration
-		Password:   "", // Empty password for enumeration
+		Domain:     "",      // Let the server provide domain info
+		Username:   "probe", // Dummy username for enumeration (same as probe)
+		Password:   "probe", // Dummy password for enumeration (same as probe)
 		Negotiator: negotiator,
 	}
 

--- a/internal/enumerate/ldap/ldap.go
+++ b/internal/enumerate/ldap/ldap.go
@@ -86,7 +86,15 @@ func (l *LibraryEnumerateLDAP) extractServerInfoFromNTLMChallenge(ctx context.Co
 				}
 				return ""
 			}()),
-			svc1log.SafeParam("serverName", ldapServerInfo.ServerName))
+			svc1log.SafeParam("serverName", func() string {
+				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.DnsComputerName != nil {
+					return *ldapServerInfo.TargetInfo.DnsComputerName
+				}
+				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.NetbiosComputerName != nil {
+					return *ldapServerInfo.TargetInfo.NetbiosComputerName
+				}
+				return ""
+			}()))
 		return ldapServerInfo
 	}
 

--- a/internal/enumerate/ldap/ldap.go
+++ b/internal/enumerate/ldap/ldap.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/go-ntlmssp"
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	ldapfern "github.com/Method-Security/networkscan/generated/go/enumerate/ldap"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	"github.com/Method-Security/networkscan/utils"
 	ldap "github.com/go-ldap/ldap/v3"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -15,12 +17,90 @@ import (
 // LibraryEnumerateLDAP implements NetworkApplicationLibrary for LDAP enumeration.
 type LibraryEnumerateLDAP struct{}
 
+// enumerateNegotiator implements NTLM negotiation for server info extraction during enumeration
+type enumerateNegotiator struct {
+	serverInfo *commonprotocolfern.NtlmServerInfo
+	log        svc1log.Logger
+}
+
+func (en *enumerateNegotiator) Negotiate(domain, workstation string) ([]byte, error) {
+	return ntlmssp.NewNegotiateMessage(domain, workstation)
+}
+
+func (en *enumerateNegotiator) ChallengeResponse(chal []byte, user, hash string) ([]byte, error) {
+	// Use unified NTLM extractor
+	serverInfo, err := ntlm.ExtractServerInfoFromChallenge(chal, en.log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract server info from NTLM challenge: %v", err)
+	}
+
+	en.serverInfo = serverInfo
+
+	// We don't actually want to complete the authentication, just extract server info
+	// Return an empty response to avoid actually authenticating
+	return []byte{}, fmt.Errorf("enumeration server info extraction completed, authentication not required")
+}
+
+// extractServerInfoFromNTLMChallenge extracts server information via NTLM challenge during enumeration
+func (l *LibraryEnumerateLDAP) extractServerInfoFromNTLMChallenge(ctx context.Context, host string, port int, target string) *commonprotocolfern.LdapServerInfo {
+	log := svc1log.FromContext(ctx)
+	log.Debug("Extracting LDAP server info via NTLM challenge for enumeration", svc1log.SafeParam("target", target))
+
+	conn, err := ldap.DialURL(fmt.Sprintf("ldap://%s:%d", host, port))
+	if err != nil {
+		log.Debug("Failed to connect to LDAP server for server info extraction", svc1log.SafeParam("error", err.Error()))
+		return nil
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Create enumeration negotiator to capture server info
+	negotiator := &enumerateNegotiator{
+		log: log,
+	}
+
+	// Attempt NTLM bind to trigger challenge/response and extract server info
+	req := &ldap.NTLMBindRequest{
+		Domain:     "",          // Let the server provide domain info
+		Username:   "enumerate", // Dummy username for enumeration
+		Password:   "enumerate", // Dummy password for enumeration
+		Negotiator: negotiator,
+	}
+
+	// We expect this to fail, but we should capture the server info from the challenge
+	_, err = conn.NTLMChallengeBind(req)
+
+	// Check if we successfully extracted server info even if bind failed
+	if negotiator.serverInfo != nil {
+		// Convert unified server info to LDAP-specific format
+		ldapServerInfo := ntlm.ConvertToLDAPServerInfo(negotiator.serverInfo)
+		log.Debug("Successfully extracted server info from NTLM challenge during enumeration",
+			svc1log.SafeParam("dnsDomain", func() string {
+				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.DnsDomainName != nil {
+					return *ldapServerInfo.TargetInfo.DnsDomainName
+				}
+				return ""
+			}()),
+			svc1log.SafeParam("netbiosDomain", func() string {
+				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.NetbiosDomainName != nil {
+					return *ldapServerInfo.TargetInfo.NetbiosDomainName
+				}
+				return ""
+			}()),
+			svc1log.SafeParam("serverName", ldapServerInfo.ServerName))
+		return ldapServerInfo
+	}
+
+	log.Debug("Could not extract server info from NTLM challenge during enumeration")
+	return nil
+}
+
 // authTestResult holds the result of an authentication test
 type authTestResult struct {
 	success       bool
 	conn          *ldap.Conn
 	allowedMethod bool
 	authMethod    commonprotocolfern.LdapAuthMethod
+	serverInfo    *commonprotocolfern.LdapServerInfo
 }
 
 // authenticationState holds the overall state of authentication testing
@@ -30,6 +110,7 @@ type authenticationState struct {
 	anonymousAllowed     bool
 	nullBindAllowed      bool
 	supportedMethods     []commonprotocolfern.LdapAuthMethod
+	serverInfo           *commonprotocolfern.LdapServerInfo
 }
 
 // testNullBind tests null bind (no credentials)
@@ -128,6 +209,9 @@ func (l *LibraryEnumerateLDAP) performAuthentication(ctx context.Context, host s
 		connectionSuccessful: false,
 		supportedMethods:     []commonprotocolfern.LdapAuthMethod{},
 	}
+
+	// Extract server info first using NTLM challenge
+	state.serverInfo = l.extractServerInfoFromNTLMChallenge(ctx, host, port, target)
 
 	// Test null bind
 	nullResult := l.testNullBind(ctx, host, port, target)
@@ -228,6 +312,11 @@ func (l *LibraryEnumerateLDAP) extractLdapInfo(ctx context.Context, conn *ldap.C
 
 // assembleResponse assembles the final response
 func (l *LibraryEnumerateLDAP) assembleResponse(details *ldapfern.EnumerateLdapDetails, state authenticationState) {
+	// Set server info
+	if state.serverInfo != nil {
+		details.ServerInfo = state.serverInfo
+	}
+
 	// Set authentication results
 	details.NullBindAllowed = &state.nullBindAllowed
 	details.AnonymousBindAllowed = &state.anonymousAllowed

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -8,6 +8,7 @@ import (
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	smb "github.com/Method-Security/networkscan/generated/go/enumerate/smb"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -173,80 +174,16 @@ func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *commonprotocolfern.S
 	if serverInfo != nil {
 		smbServerInfo := convertToSmbServerInfo(serverInfo)
 		details.ServerInfo = smbServerInfo
-		var serverName, domain, osVersion string
-		var signingRequired bool
-		if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsComputerName != nil {
-			serverName = *serverInfo.TargetInfo.DnsComputerName
-		} else if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosComputerName != nil {
-			serverName = *serverInfo.TargetInfo.NetbiosComputerName
-		}
-		if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsDomainName != nil {
-			domain = *serverInfo.TargetInfo.DnsDomainName
-		} else if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil {
-			domain = *serverInfo.TargetInfo.NetbiosDomainName
-		}
-		if serverInfo.ParsedOsVersion != nil {
-			osVersion = *serverInfo.ParsedOsVersion
-		}
-		if serverInfo.SigningRequired != nil {
-			signingRequired = *serverInfo.SigningRequired
-		}
 
-		// Log detailed TargetInfo structure
-		var netbiosDomain, dnsDomain, dnsComputer, netbiosComputer string
-		if serverInfo.TargetInfo != nil {
-			if serverInfo.TargetInfo.NetbiosDomainName != nil {
-				netbiosDomain = *serverInfo.TargetInfo.NetbiosDomainName
-			}
-			if serverInfo.TargetInfo.DnsDomainName != nil {
-				dnsDomain = *serverInfo.TargetInfo.DnsDomainName
-			}
-			if serverInfo.TargetInfo.DnsComputerName != nil {
-				dnsComputer = *serverInfo.TargetInfo.DnsComputerName
-			}
-			if serverInfo.TargetInfo.NetbiosComputerName != nil {
-				netbiosComputer = *serverInfo.TargetInfo.NetbiosComputerName
-			}
+		// Use centralized logging function
+		// Convert to base NtlmServerInfo for logging
+		ntlmServerInfo := &commonprotocolfern.NtlmServerInfo{
+			TargetInfo:      serverInfo.TargetInfo,
+			OsInfo:          serverInfo.OsInfo,
+			ParsedOsVersion: serverInfo.ParsedOsVersion,
+			SigningRequired: serverInfo.SigningRequired,
 		}
-
-		// Log detailed OsInfo structure
-		var majorVersion, minorVersion, buildNumber, ntlmRevision int
-		var versionString string
-		if serverInfo.OsInfo != nil {
-			if serverInfo.OsInfo.MajorVersion != nil {
-				majorVersion = *serverInfo.OsInfo.MajorVersion
-			}
-			if serverInfo.OsInfo.MinorVersion != nil {
-				minorVersion = *serverInfo.OsInfo.MinorVersion
-			}
-			if serverInfo.OsInfo.BuildNumber != nil {
-				buildNumber = *serverInfo.OsInfo.BuildNumber
-			}
-			if serverInfo.OsInfo.NtlmCurrentRevision != nil {
-				ntlmRevision = *serverInfo.OsInfo.NtlmCurrentRevision
-			}
-			if serverInfo.OsInfo.VersionString != nil {
-				versionString = *serverInfo.OsInfo.VersionString
-			}
-		}
-
-		log.Info("Extracted detailed server info",
-			svc1log.SafeParam("target", target),
-			svc1log.SafeParam("server", serverName),
-			svc1log.SafeParam("domain", domain),
-			svc1log.SafeParam("os", osVersion),
-			svc1log.SafeParam("signingRequired", signingRequired),
-			// TargetInfo details
-			svc1log.SafeParam("netbiosDomain", netbiosDomain),
-			svc1log.SafeParam("dnsDomain", dnsDomain),
-			svc1log.SafeParam("dnsComputer", dnsComputer),
-			svc1log.SafeParam("netbiosComputer", netbiosComputer),
-			// OsInfo details
-			svc1log.SafeParam("osMajorVersion", majorVersion),
-			svc1log.SafeParam("osMinorVersion", minorVersion),
-			svc1log.SafeParam("osBuildNumber", buildNumber),
-			svc1log.SafeParam("ntlmRevision", ntlmRevision),
-			svc1log.SafeParam("osVersionString", versionString))
+		ntlm.LogServerInfoDetails(ntlmServerInfo, target, log)
 
 		// Set supported versions from server capabilities if available
 		if len(serverInfo.SupportedSmbVersions) > 0 {

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -20,7 +20,7 @@ type LibraryEnumerateSMB struct{}
 type authTestResult struct {
 	success       bool
 	client        *smbclient.Client
-	serverInfo    *smbclient.ServerInfo
+	serverInfo    *commonprotocolfern.SmbServerInfo
 	authAttempt   *commonprotocolfern.SmbAuthAttempt
 	allowedMethod bool
 }
@@ -89,7 +89,7 @@ func (s *LibraryEnumerateSMB) testGuestAuthentication(ctx context.Context, host 
 
 // authenticationState holds the collective results of all authentication tests
 type authenticationState struct {
-	serverInfo           *smbclient.ServerInfo
+	serverInfo           *commonprotocolfern.SmbServerInfo
 	authAttempts         []*commonprotocolfern.SmbAuthAttempt
 	nullSessionAllowed   bool
 	anonymousAllowed     bool
@@ -169,29 +169,87 @@ func (s *LibraryEnumerateSMB) performAuthentication(ctx context.Context, host st
 }
 
 // processServerInfo sets up server info and SMB version details in the response
-func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *smbclient.ServerInfo, details *smb.EnumerateSmbDetails, target string, log svc1log.Logger) {
+func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *commonprotocolfern.SmbServerInfo, details *smb.EnumerateSmbDetails, target string, log svc1log.Logger) {
 	if serverInfo != nil {
 		smbServerInfo := convertToSmbServerInfo(serverInfo)
 		details.ServerInfo = smbServerInfo
-		log.Info("Extracted server info",
+		var serverName, domain, osVersion string
+		var signingRequired bool
+		if serverInfo.ServerName != nil {
+			serverName = *serverInfo.ServerName
+		}
+		if serverInfo.Domain != nil {
+			domain = *serverInfo.Domain
+		}
+		if serverInfo.OsVersion != nil {
+			osVersion = *serverInfo.OsVersion
+		}
+		if serverInfo.SigningRequired != nil {
+			signingRequired = *serverInfo.SigningRequired
+		}
+
+		// Log detailed TargetInfo structure
+		var netbiosDomain, dnsDomain, dnsComputer, netbiosComputer string
+		if serverInfo.TargetInfo != nil {
+			if serverInfo.TargetInfo.NetbiosDomainName != nil {
+				netbiosDomain = *serverInfo.TargetInfo.NetbiosDomainName
+			}
+			if serverInfo.TargetInfo.DnsDomainName != nil {
+				dnsDomain = *serverInfo.TargetInfo.DnsDomainName
+			}
+			if serverInfo.TargetInfo.DnsComputerName != nil {
+				dnsComputer = *serverInfo.TargetInfo.DnsComputerName
+			}
+			if serverInfo.TargetInfo.NetbiosComputerName != nil {
+				netbiosComputer = *serverInfo.TargetInfo.NetbiosComputerName
+			}
+		}
+
+		// Log detailed OsInfo structure
+		var majorVersion, minorVersion, buildNumber, ntlmRevision int
+		var versionString string
+		if serverInfo.OsInfo != nil {
+			if serverInfo.OsInfo.MajorVersion != nil {
+				majorVersion = *serverInfo.OsInfo.MajorVersion
+			}
+			if serverInfo.OsInfo.MinorVersion != nil {
+				minorVersion = *serverInfo.OsInfo.MinorVersion
+			}
+			if serverInfo.OsInfo.BuildNumber != nil {
+				buildNumber = *serverInfo.OsInfo.BuildNumber
+			}
+			if serverInfo.OsInfo.NtlmCurrentRevision != nil {
+				ntlmRevision = *serverInfo.OsInfo.NtlmCurrentRevision
+			}
+			if serverInfo.OsInfo.VersionString != nil {
+				versionString = *serverInfo.OsInfo.VersionString
+			}
+		}
+
+		log.Info("Extracted detailed server info",
 			svc1log.SafeParam("target", target),
-			svc1log.SafeParam("server", serverInfo.ServerName),
-			svc1log.SafeParam("domain", serverInfo.Domain),
-			svc1log.SafeParam("os", serverInfo.OSVersion),
-			svc1log.SafeParam("signingRequired", serverInfo.SigningRequired))
+			svc1log.SafeParam("server", serverName),
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("os", osVersion),
+			svc1log.SafeParam("signingRequired", signingRequired),
+			// TargetInfo details
+			svc1log.SafeParam("netbiosDomain", netbiosDomain),
+			svc1log.SafeParam("dnsDomain", dnsDomain),
+			svc1log.SafeParam("dnsComputer", dnsComputer),
+			svc1log.SafeParam("netbiosComputer", netbiosComputer),
+			// OsInfo details
+			svc1log.SafeParam("osMajorVersion", majorVersion),
+			svc1log.SafeParam("osMinorVersion", minorVersion),
+			svc1log.SafeParam("osBuildNumber", buildNumber),
+			svc1log.SafeParam("ntlmRevision", ntlmRevision),
+			svc1log.SafeParam("osVersionString", versionString))
 
 		// Set supported versions from server capabilities if available
-		if len(serverInfo.SupportedVersions) > 0 {
-			var smbVersions []commonprotocolfern.SmbVersion
-			for _, version := range serverInfo.SupportedVersions {
-				if smbVersion, ok := smbclient.MapProtocolVersionToEnum(version); ok {
-					smbVersions = append(smbVersions, smbVersion)
-				}
-			}
-			if len(smbVersions) > 0 {
-				details.SupportedVersions = smbVersions
-				// Use the first (highest) supported version as the primary version
-				details.Version = &smbVersions[0]
+		if len(serverInfo.SupportedSmbVersions) > 0 {
+			details.SupportedVersions = serverInfo.SupportedSmbVersions
+			// Use the first (highest) supported version as the primary version
+			if len(serverInfo.SupportedSmbVersions) > 0 {
+				details.Version = &serverInfo.SupportedSmbVersions[0]
 			}
 		}
 	}
@@ -235,7 +293,7 @@ func (s *LibraryEnumerateSMB) enumerateShares(ctx context.Context, client *smbcl
 }
 
 // assembleResponse builds the final enumeration response
-func (s *LibraryEnumerateSMB) assembleResponse(details *smb.EnumerateSmbDetails, state authenticationState, serverInfo *smbclient.ServerInfo) {
+func (s *LibraryEnumerateSMB) assembleResponse(details *smb.EnumerateSmbDetails, state authenticationState, serverInfo *commonprotocolfern.SmbServerInfo) {
 	// Set authentication method information
 	authMethods := []commonprotocolfern.AuthMethod{commonprotocolfern.AuthMethodNtlm}
 	details.AuthMethods = authMethods
@@ -249,13 +307,16 @@ func (s *LibraryEnumerateSMB) assembleResponse(details *smb.EnumerateSmbDetails,
 	details.AuthAttempts = state.authAttempts
 
 	// Set security settings from server info
-	if serverInfo != nil {
-		details.SigningRequired = &serverInfo.SigningRequired
+	if serverInfo != nil && serverInfo.SigningRequired != nil {
+		details.SigningRequired = serverInfo.SigningRequired
 	}
 
 	// Set raw response information
-	rawResponse := fmt.Sprintf("SMB2 Connection - Signing: %v",
-		serverInfo != nil && serverInfo.SigningRequired)
+	var signing bool
+	if serverInfo != nil && serverInfo.SigningRequired != nil {
+		signing = *serverInfo.SigningRequired
+	}
+	rawResponse := fmt.Sprintf("SMB2 Connection - Signing: %v", signing)
 	details.RawResponse = &rawResponse
 }
 
@@ -305,79 +366,17 @@ func (s *LibraryEnumerateSMB) EnumerateTarget(ctx context.Context, target string
 }
 
 // convertToSmbServerInfo converts protocol library ServerInfo to common SMB ServerInfo
-func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocolfern.SmbServerInfo {
+func convertToSmbServerInfo(serverInfo *commonprotocolfern.SmbServerInfo) *commonprotocolfern.SmbServerInfo {
 	if serverInfo == nil {
 		return nil
 	}
 
-	result := &commonprotocolfern.SmbServerInfo{
-		ServerName:        &serverInfo.ServerName,
-		Domain:            &serverInfo.Domain,
-		NetBiosDomainName: &serverInfo.NetBIOSDomainName,
-		Workgroup:         &serverInfo.Domain, // Use domain as workgroup fallback
-		OsVersion:         &serverInfo.OSVersion,
-		Capabilities:      serverInfo.Capabilities,
-		SigningRequired:   &serverInfo.SigningRequired,
-	}
-
-	// Include raw OS version if available
-	if serverInfo.RawOSVersion != "" {
-		result.RawOsVersion = &serverInfo.RawOSVersion
-	}
-
-	return result
+	// Since both input and output are already the same type, just return the input
+	return serverInfo
 }
 
 // convertToSmbShares converts protocol library ShareInfo to common SMB Share
-func convertToSmbShares(shares []*smbclient.ShareInfo) []*commonprotocolfern.SmbShare {
-	var smbShares []*commonprotocolfern.SmbShare
-
-	for _, share := range shares {
-		shareType := convertShareType(share.Type)
-		shareAccess := convertShareAccess(share.Access)
-
-		smbShare := &commonprotocolfern.SmbShare{
-			Name:            share.Name,
-			Type:            shareType,
-			Accessible:      &share.Accessible,
-			Access:          &shareAccess,
-			AnonymousAccess: &share.AnonymousAccess,
-			GuestAccess:     &share.GuestAccess,
-			Hidden:          &share.Hidden,
-		}
-
-		if share.Comment != "" {
-			smbShare.Comment = &share.Comment
-		}
-
-		smbShares = append(smbShares, smbShare)
-	}
-
-	return smbShares
-}
-
-// convertShareType converts string share type to common ShareType
-func convertShareType(shareType string) commonprotocolfern.ShareType {
-	switch shareType {
-	case "IPC":
-		return commonprotocolfern.ShareTypeIpc
-	case "Print":
-		return commonprotocolfern.ShareTypePrint
-	case "Disk":
-		return commonprotocolfern.ShareTypeDisk
-	default:
-		return commonprotocolfern.ShareTypeDisk
-	}
-}
-
-// convertShareAccess converts string share access to common ShareAccess
-func convertShareAccess(access string) commonprotocolfern.ShareAccess {
-	switch access {
-	case "Read":
-		return commonprotocolfern.ShareAccessReadOnly
-	case "Write", "Full":
-		return commonprotocolfern.ShareAccessReadWrite
-	default:
-		return commonprotocolfern.ShareAccessNoAccess
-	}
+func convertToSmbShares(shares []*commonprotocolfern.SmbShare) []*commonprotocolfern.SmbShare {
+	// Since both input and output are already the same type, just return the input
+	return shares
 }

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -175,14 +175,18 @@ func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *commonprotocolfern.S
 		details.ServerInfo = smbServerInfo
 		var serverName, domain, osVersion string
 		var signingRequired bool
-		if serverInfo.ServerName != nil {
-			serverName = *serverInfo.ServerName
+		if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsComputerName != nil {
+			serverName = *serverInfo.TargetInfo.DnsComputerName
+		} else if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosComputerName != nil {
+			serverName = *serverInfo.TargetInfo.NetbiosComputerName
 		}
-		if serverInfo.Domain != nil {
-			domain = *serverInfo.Domain
+		if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsDomainName != nil {
+			domain = *serverInfo.TargetInfo.DnsDomainName
+		} else if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil {
+			domain = *serverInfo.TargetInfo.NetbiosDomainName
 		}
-		if serverInfo.OsVersion != nil {
-			osVersion = *serverInfo.OsVersion
+		if serverInfo.ParsedOsVersion != nil {
+			osVersion = *serverInfo.ParsedOsVersion
 		}
 		if serverInfo.SigningRequired != nil {
 			signingRequired = *serverInfo.SigningRequired

--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -3,9 +3,9 @@ package pentest
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
+	ldapcommonfern "github.com/Method-Security/networkscan/generated/go/common/ldap"
 	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
 	smbcommonfern "github.com/Method-Security/networkscan/generated/go/common/smb"
 	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
@@ -32,9 +32,8 @@ func NewEngine() *Engine {
 	return &Engine{}
 }
 
-// RunSMBPentest performs SMB pentest operations
+// RunSMBPentest performs SMB pentest operations using 3-stage phased approach
 func (e *Engine) RunSMBPentest(ctx context.Context, config *smbfern.PentestSmbConfig) (*smbfern.PentestSmbReport, error) {
-	// Create single consolidated report with list of results
 	var allResults []*smbfern.PentestSmbResult
 	var allErrors []string
 
@@ -42,30 +41,18 @@ func (e *Engine) RunSMBPentest(ctx context.Context, config *smbfern.PentestSmbCo
 	for _, target := range config.Targets {
 		// Create a copy of the config for each target to avoid modifications affecting other targets
 		configCopy := *config
-		report, err := e.runSMBPentestForTarget(ctx, target, &configCopy)
-		if err != nil {
-			// Add error and continue with other targets
-			allErrors = append(allErrors, fmt.Sprintf("SMB pentest failed for %s: %v", target, err))
-			continue
-		}
+		targetResults, targetErrors := e.runSMBPentestForTargetPhased(ctx, target, &configCopy)
 
-		// Accumulate results
-		if report.Result != nil && report.Result.Result != nil {
-			allResults = append(allResults, report.Result.Result)
-		}
-
-		// Accumulate errors
-		if report.Errors != nil {
-			allErrors = append(allErrors, report.Errors...)
-		}
+		// Accumulate results and errors from all phases
+		allResults = append(allResults, targetResults...)
+		allErrors = append(allErrors, targetErrors...)
 	}
 
-	// Return single consolidated report with result container
+	// Return consolidated report with list of phased results
 	var resultContainer *smbfern.PentestSmbResultContainer
 	if len(allResults) > 0 {
-		// For now, return the first result - this could be enhanced to merge results
 		resultContainer = &smbfern.PentestSmbResultContainer{
-			Result: allResults[0],
+			Results: allResults,
 		}
 	}
 
@@ -76,21 +63,116 @@ func (e *Engine) RunSMBPentest(ctx context.Context, config *smbfern.PentestSmbCo
 	}, nil
 }
 
-// runSMBPentestForTarget performs SMB pentest operations for a single target
-func (e *Engine) runSMBPentestForTarget(ctx context.Context, target string, config *smbfern.PentestSmbConfig) (*smbfern.PentestSmbReport, error) {
-	// Perform authentication (includes base server info extraction)
-	authResult, err := smbpentest.PerformAuthenticationWithContext(ctx, target, config)
-	if err != nil {
-		return &smbfern.PentestSmbReport{
-			Config: config,
-			Result: &smbfern.PentestSmbResultContainer{
-				Result: smbfern.NewPentestSmbResultFromAuthResult(authResult),
-			},
-			Errors: []string{err.Error()},
-		}, err
+// runSMBPentestForTargetPhased performs 3-stage phased SMB pentest operations for a single target
+func (e *Engine) runSMBPentestForTargetPhased(ctx context.Context, target string, config *smbfern.PentestSmbConfig) ([]*smbfern.PentestSmbResult, []string) {
+	var results []*smbfern.PentestSmbResult
+	var errors []string
+
+	log := svc1log.FromContext(ctx)
+
+	// Determine the execution phases based on requested actions
+	var needsProbe, needsAuth, needsOtherAction bool
+	var otherActions []smbcommonfern.PentestSmbAction
+
+	for _, action := range config.Actions {
+		switch action.GetSmb() {
+		case smbcommonfern.PentestSmbActionProbe:
+			needsProbe = true
+		case smbcommonfern.PentestSmbActionAuth:
+			needsAuth = true
+		default:
+			needsOtherAction = true
+			otherActions = append(otherActions, action.GetSmb())
+		}
 	}
 
-	// Find successful auth attempts
+	// If user requests non-PROBE actions, automatically include PROBE phase
+	// If user requests AUTH or other actions, automatically include PROBE phase
+	if needsAuth || needsOtherAction {
+		needsProbe = true
+	}
+
+	// If user requests non-PROBE/AUTH actions, automatically include AUTH phase
+	if needsOtherAction {
+		needsAuth = true
+	}
+
+	// STAGE 1: PROBE - Server info gathering via NTLM challenge (no credentials)
+	if needsProbe {
+		log.Info("Stage 1: PROBE - Gathering server information", svc1log.SafeParam("target", target))
+		probeResult, err := smbpentest.PerformProbe(ctx, target, config)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("PROBE stage failed: %v", err))
+			return results, errors // Fail fast - don't continue to AUTH/ACTION stages
+		}
+
+		// Check if probe result indicates failure
+		if probeResult.Errors != nil && len(probeResult.Errors) > 0 {
+			results = append(results, smbfern.NewPentestSmbResultFromProbeResult(probeResult))
+			errors = append(errors, "PROBE stage failed - cannot continue to AUTH/ACTION stages")
+			return results, errors // Fail fast - probe failed
+		}
+
+		results = append(results, smbfern.NewPentestSmbResultFromProbeResult(probeResult))
+
+		// If only PROBE was requested, return early
+		if !needsAuth && !needsOtherAction {
+			return results, errors
+		}
+	}
+
+	// STAGE 2: AUTH - Authentication testing with credentials
+	if needsAuth || needsOtherAction {
+		log.Info("Stage 2: AUTH - Authentication testing", svc1log.SafeParam("target", target))
+		authResult, err := smbpentest.PerformAuthenticationWithContext(ctx, target, config)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("AUTH stage failed: %v", err))
+			return results, errors // Fail fast - don't continue to ACTION stage
+		}
+
+		// Check if auth result indicates failure (no successful auth attempts)
+		successfulAuths := make([]*pentestcommonfern.AuthAttempt, 0)
+		if authResult.AuthAttempts != nil {
+			for _, attempt := range authResult.AuthAttempts {
+				if attempt.Success {
+					successfulAuths = append(successfulAuths, attempt)
+				}
+			}
+		}
+
+		results = append(results, smbfern.NewPentestSmbResultFromAuthResult(authResult))
+
+		// If no successful authentication and ACTION is needed, fail fast
+		if needsOtherAction && len(successfulAuths) == 0 {
+			errors = append(errors, "AUTH stage failed - no successful authentication for ACTION stage")
+			return results, errors // Fail fast - auth failed, can't do actions
+		}
+
+		// If only AUTH was requested, return early
+		if !needsOtherAction {
+			return results, errors
+		}
+
+		// STAGE 3: ACTION - Execute specific actions with authenticated context
+		if needsOtherAction {
+			actionResults, actionErrors := e.executeSMBActionsWithAuth(ctx, target, config, authResult, otherActions)
+			results = append(results, actionResults...)
+			errors = append(errors, actionErrors...)
+		}
+	}
+
+	return results, errors
+}
+
+// executeSMBActionsWithAuth executes specific SMB actions using authenticated context
+func (e *Engine) executeSMBActionsWithAuth(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authResult *smbfern.AuthResult, actions []smbcommonfern.PentestSmbAction) ([]*smbfern.PentestSmbResult, []string) {
+	var results []*smbfern.PentestSmbResult
+	var errors []string
+
+	log := svc1log.FromContext(ctx)
+	log.Info("Stage 3: ACTION - Executing specific actions with authenticated context", svc1log.SafeParam("target", target))
+
+	// Find successful auth attempts (we already validated there's at least one)
 	successfulAuths := make([]*pentestcommonfern.AuthAttempt, 0)
 	for _, attempt := range authResult.AuthAttempts {
 		if attempt.Success {
@@ -98,141 +180,90 @@ func (e *Engine) runSMBPentestForTarget(ctx context.Context, target string, conf
 		}
 	}
 
-	// If samdump/lsadump/shares is requested and we have successful auth, perform operations
-	if (utils.GetSMBParser().ContainsAction(config.Actions, smbcommonfern.PentestSmbActionSamdump) ||
-		utils.GetSMBParser().ContainsAction(config.Actions, smbcommonfern.PentestSmbActionLsadump) ||
-		utils.GetSMBParser().ContainsAction(config.Actions, smbcommonfern.PentestSmbActionShares)) &&
-		len(successfulAuths) > 0 {
+	// Create authenticated session for action execution
+	authenticatedSession, tempClient, sessionErr := e.createAuthenticatedSMBSession(ctx, target, config, successfulAuths[0])
+	if sessionErr != nil {
+		errors = append(errors, fmt.Sprintf("Failed to create authenticated session: %v", sessionErr))
+		return results, errors
+	}
+	defer func() {
+		if tempClient != nil {
+			// Don't explicitly close to avoid panic - let GC handle it
+		}
+	}()
 
-		log := svc1log.FromContext(ctx)
+	// Execute each requested action
+	for _, action := range actions {
+		switch action {
+		case smbcommonfern.PentestSmbActionSamdump:
+			log.Debug("Performing " + string(smbcommonfern.PentestSmbActionSamdump))
+			samdumpResult, err := smbpentest.PerformSamdump(ctx, target, config, authenticatedSession)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbcommonfern.PentestSmbActionSamdump), err))
+			} else {
+				results = append(results, smbfern.NewPentestSmbResultFromSamdumpResult(samdumpResult))
+			}
 
-		// Log the operations we're about to perform
-		actionNames := []string{}
-		for _, action := range config.Actions {
-			switch action.GetSmb() {
-			case smbcommonfern.PentestSmbActionSamdump:
-				actionNames = append(actionNames, string(smbcommonfern.PentestSmbActionSamdump))
-			case smbcommonfern.PentestSmbActionLsadump:
-				actionNames = append(actionNames, string(smbcommonfern.PentestSmbActionLsadump))
-			case smbcommonfern.PentestSmbActionShares:
-				actionNames = append(actionNames, string(smbcommonfern.PentestSmbActionShares))
+		case smbcommonfern.PentestSmbActionLsadump:
+			log.Debug("Performing " + string(smbcommonfern.PentestSmbActionLsadump))
+			lsadumpResult, err := smbpentest.PerformLsadump(ctx, target, config, authenticatedSession)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbcommonfern.PentestSmbActionLsadump), err))
+			} else {
+				results = append(results, smbfern.NewPentestSmbResultFromLsadumpResult(lsadumpResult))
+			}
+
+		case smbcommonfern.PentestSmbActionShares:
+			log.Debug("Performing " + string(smbcommonfern.PentestSmbActionShares))
+			sharesResult, err := smbpentest.PerformShares(ctx, target, config, authenticatedSession)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbcommonfern.PentestSmbActionShares), err))
+			} else {
+				results = append(results, smbfern.NewPentestSmbResultFromSharesResult(sharesResult))
 			}
 		}
-		if len(actionNames) > 0 {
-			log.Info("Starting dump operations", svc1log.SafeParam("actions", strings.Join(actionNames, ", ")))
-		}
-
-		// Try to get authenticated session from the previous authentication
-		var authenticatedSession *gosmb.Connection = nil
-
-		// Create a temporary client to get the authenticated session
-		successfulAuth := successfulAuths[0]
-		host, port := utils.ParseHostPort(target, 445)
-
-		// Create SMB client and authenticate to get session
-		tempClient := smbclient.NewClient(host, port)
-		tempClient.Timeout = time.Duration(config.Timeout) * time.Millisecond
-
-		// Handle domain pointer properly
-		authDomain := ""
-		if successfulAuth.Domain != nil {
-			authDomain = *successfulAuth.Domain
-		}
-
-		// Check if we should use hash or password authentication
-		if config.AuthConfig != nil && config.AuthConfig.Ntlmv2Hash != nil && *config.AuthConfig.Ntlmv2Hash != "" {
-			// Use pass-the-hash authentication
-			ntlmHash := *config.AuthConfig.Ntlmv2Hash
-			tempClient.SetCredentialsWithHash(successfulAuth.Username, ntlmHash, authDomain)
-		} else {
-			// Use password authentication
-			var password string
-			if successfulAuth.Password != nil {
-				password = *successfulAuth.Password
-			}
-			tempClient.SetCredentials(successfulAuth.Username, password, authDomain)
-		}
-
-		err = tempClient.ConnectWithContext(ctx)
-		if err == nil {
-			authenticatedSession, _ = tempClient.GetSMBSession()
-			// Don't close the client yet - we'll close it after all actions complete
-		}
-
-		// Execute each requested action - return separate results for each
-		for _, action := range config.Actions {
-			switch action.GetSmb() {
-			case smbcommonfern.PentestSmbActionSamdump:
-				log.Debug("Performing " + string(smbcommonfern.PentestSmbActionSamdump))
-				samdumpDetails, err := smbpentest.PerformSamdump(ctx, target, config, authenticatedSession)
-				if err != nil {
-					if authResult.Errors == nil {
-						authResult.Errors = []string{}
-					}
-					authResult.Errors = append(authResult.Errors, fmt.Sprintf("%s failed: %v", string(smbcommonfern.PentestSmbActionSamdump), err))
-				} else {
-					// Return samdump result
-					return &smbfern.PentestSmbReport{
-						Config: config,
-						Result: &smbfern.PentestSmbResultContainer{
-							Result: smbfern.NewPentestSmbResultFromSamdumpResult(samdumpDetails),
-						},
-						Errors: authResult.Errors,
-					}, nil
-				}
-
-			case smbcommonfern.PentestSmbActionLsadump:
-				log.Debug("Performing " + string(smbcommonfern.PentestSmbActionLsadump))
-				lsadumpDetails, err := smbpentest.PerformLsadump(ctx, target, config, authenticatedSession)
-				if err != nil {
-					if authResult.Errors == nil {
-						authResult.Errors = []string{}
-					}
-					authResult.Errors = append(authResult.Errors, fmt.Sprintf("%s failed: %v", string(smbcommonfern.PentestSmbActionLsadump), err))
-				} else {
-					// Return lsadump result
-					return &smbfern.PentestSmbReport{
-						Config: config,
-						Result: &smbfern.PentestSmbResultContainer{
-							Result: smbfern.NewPentestSmbResultFromLsadumpResult(lsadumpDetails),
-						},
-						Errors: authResult.Errors,
-					}, nil
-				}
-
-			case smbcommonfern.PentestSmbActionShares:
-				log.Debug("Performing " + string(smbcommonfern.PentestSmbActionShares))
-				sharesDetails, err := smbpentest.PerformShares(ctx, target, config, authenticatedSession)
-				if err != nil {
-					if authResult.Errors == nil {
-						authResult.Errors = []string{}
-					}
-					authResult.Errors = append(authResult.Errors, fmt.Sprintf("%s failed: %v", string(smbcommonfern.PentestSmbActionShares), err))
-				} else {
-					// Return shares result
-					return &smbfern.PentestSmbReport{
-						Config: config,
-						Result: &smbfern.PentestSmbResultContainer{
-							Result: smbfern.NewPentestSmbResultFromSharesResult(sharesDetails),
-						},
-						Errors: authResult.Errors,
-					}, nil
-				}
-			}
-		}
-
-		// Note: Not explicitly closing tempClient to avoid "close of closed channel" panic
-		// The connection will be cleaned up by Go's garbage collector
 	}
 
-	// If no dump operations were requested or they failed, return auth result
-	return &smbfern.PentestSmbReport{
-		Config: config,
-		Result: &smbfern.PentestSmbResultContainer{
-			Result: smbfern.NewPentestSmbResultFromAuthResult(authResult),
-		},
-		Errors: authResult.Errors,
-	}, nil
+	return results, errors
+}
+
+// createAuthenticatedSMBSession creates an authenticated SMB session for action execution
+func (e *Engine) createAuthenticatedSMBSession(ctx context.Context, target string, config *smbfern.PentestSmbConfig, successfulAuth *pentestcommonfern.AuthAttempt) (*gosmb.Connection, *smbclient.Client, error) {
+	host, port := utils.ParseHostPort(target, 445)
+
+	// Create SMB client and authenticate to get session
+	tempClient := smbclient.NewClient(host, port)
+	tempClient.Timeout = time.Duration(config.Timeout) * time.Millisecond
+	// Skip server info extraction since it's done in PROBE stage
+	tempClient.SkipServerInfoExtraction(true)
+
+	// Handle domain pointer properly
+	authDomain := ""
+	if successfulAuth.Domain != nil {
+		authDomain = *successfulAuth.Domain
+	}
+
+	// Check if we should use hash or password authentication
+	if config.AuthConfig != nil && config.AuthConfig.Ntlmv2Hash != nil && *config.AuthConfig.Ntlmv2Hash != "" {
+		// Use pass-the-hash authentication
+		ntlmHash := *config.AuthConfig.Ntlmv2Hash
+		tempClient.SetCredentialsWithHash(successfulAuth.Username, ntlmHash, authDomain)
+	} else {
+		// Use password authentication
+		var password string
+		if successfulAuth.Password != nil {
+			password = *successfulAuth.Password
+		}
+		tempClient.SetCredentials(successfulAuth.Username, password, authDomain)
+	}
+
+	err := tempClient.ConnectWithContext(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	authenticatedSession, err := tempClient.GetSMBSession()
+	return authenticatedSession, tempClient, err
 }
 
 // RunSSHPentest performs SSH pentest operations for multiple targets
@@ -422,18 +453,16 @@ func (e *Engine) runTelnetPentestForTarget(ctx context.Context, target string, c
 	}, nil
 }
 
-// RunLDAPPentest performs LDAP pentest operations
+// RunLDAPPentest performs LDAP pentest operations using 3-stage phased approach
 func (e *Engine) RunLDAPPentest(ctx context.Context, config *ldapfern.PentestLdapConfig) (*ldapfern.PentestLdapReport, error) {
 	// LDAP pentest for single target (config.Target, not config.Targets)
-	library := &ldappentest.LibraryPentestLdap{}
+	results, errors := e.runLDAPPentestForTargetPhased(ctx, config.Target, config)
 
-	result, errors := library.PentestLdap(ctx, *config)
-
-	// Wrap result in container
+	// Return consolidated report with list of phased results
 	var resultContainer *ldapfern.PentestLdapResultContainer
-	if result != nil {
+	if len(results) > 0 {
 		resultContainer = &ldapfern.PentestLdapResultContainer{
-			Result: result,
+			Results: results,
 		}
 	}
 
@@ -442,6 +471,142 @@ func (e *Engine) RunLDAPPentest(ctx context.Context, config *ldapfern.PentestLda
 		Result: resultContainer,
 		Errors: errors,
 	}, nil
+}
+
+// runLDAPPentestForTargetPhased performs 3-stage phased LDAP pentest operations for a single target
+func (e *Engine) runLDAPPentestForTargetPhased(ctx context.Context, target string, config *ldapfern.PentestLdapConfig) ([]*ldapfern.PentestLdapResult, []string) {
+	var results []*ldapfern.PentestLdapResult
+	var errors []string
+
+	log := svc1log.FromContext(ctx)
+
+	// Determine the execution phases based on requested actions
+	var needsProbe, needsAuth, needsOtherAction bool
+	var otherActions []ldapcommonfern.LdapAction
+
+	for _, action := range config.Actions {
+		switch action {
+		case ldapcommonfern.LdapActionProbe:
+			needsProbe = true
+		case ldapcommonfern.LdapActionAuth:
+			needsAuth = true
+		default:
+			needsOtherAction = true
+			otherActions = append(otherActions, action)
+		}
+	}
+
+	// If user requests non-PROBE actions, automatically include PROBE phase
+	// If user requests AUTH or other actions, automatically include PROBE phase
+	if needsAuth || needsOtherAction {
+		needsProbe = true
+	}
+
+	// If user requests non-PROBE/AUTH actions, automatically include AUTH phase
+	if needsOtherAction {
+		needsAuth = true
+	}
+
+	// STAGE 1: PROBE - Server info gathering via anonymous LDAP connection (no credentials)
+	if needsProbe {
+		log.Info("Stage 1: PROBE - Gathering server information", svc1log.SafeParam("target", target))
+		probeResult, err := ldappentest.PerformProbe(ctx, target, config)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("PROBE stage failed: %v", err))
+			return results, errors // Fail fast - don't continue to AUTH/ACTION stages
+		}
+
+		// Check if probe result indicates failure
+		if probeResult.Errors != nil && len(probeResult.Errors) > 0 {
+			results = append(results, ldapfern.NewPentestLdapResultFromProbeResult(probeResult))
+			errors = append(errors, "PROBE stage failed - cannot continue to AUTH/ACTION stages")
+			return results, errors // Fail fast - probe failed
+		}
+
+		results = append(results, ldapfern.NewPentestLdapResultFromProbeResult(probeResult))
+
+		// If only PROBE was requested, return early
+		if !needsAuth && !needsOtherAction {
+			return results, errors
+		}
+	}
+
+	// STAGE 2: AUTH - Authentication testing with credentials
+	if needsAuth || needsOtherAction {
+		log.Info("Stage 2: AUTH - Authentication testing", svc1log.SafeParam("target", target))
+		authResult, err := ldappentest.PerformAuthenticationWithContext(ctx, target, config)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("AUTH stage failed: %v", err))
+			return results, errors // Fail fast - don't continue to ACTION stage
+		}
+
+		// Check if auth result indicates failure (no successful auth attempts)
+		successfulAuths := make([]*pentestcommonfern.AuthAttempt, 0)
+		if authResult.AuthAttempts != nil {
+			for _, attempt := range authResult.AuthAttempts {
+				if attempt.Success {
+					successfulAuths = append(successfulAuths, attempt)
+				}
+			}
+		}
+
+		results = append(results, ldapfern.NewPentestLdapResultFromAuthResult(authResult))
+
+		// If no successful authentication and ACTION is needed, fail fast
+		if needsOtherAction && len(successfulAuths) == 0 {
+			errors = append(errors, "AUTH stage failed - no successful authentication for ACTION stage")
+			return results, errors // Fail fast - auth failed, can't do actions
+		}
+
+		// If only AUTH was requested, return early
+		if !needsOtherAction {
+			return results, errors
+		}
+
+		// STAGE 3: ACTION - Execute specific actions with authenticated context
+		if needsOtherAction {
+			actionResults, actionErrors := e.executeLDAPActionsWithAuth(ctx, target, config, authResult, otherActions)
+			results = append(results, actionResults...)
+			errors = append(errors, actionErrors...)
+		}
+	}
+
+	return results, errors
+}
+
+// executeLDAPActionsWithAuth executes specific LDAP actions using authenticated context
+func (e *Engine) executeLDAPActionsWithAuth(ctx context.Context, target string, config *ldapfern.PentestLdapConfig, authResult *pentestcommonfern.AuthResult, actions []ldapcommonfern.LdapAction) ([]*ldapfern.PentestLdapResult, []string) {
+	var results []*ldapfern.PentestLdapResult
+	var errors []string
+
+	log := svc1log.FromContext(ctx)
+	log.Info("Stage 3: ACTION - Executing specific actions with authenticated context", svc1log.SafeParam("target", target))
+
+	// Find successful auth attempts (we already validated there's at least one)
+	successfulAuths := make([]*pentestcommonfern.AuthAttempt, 0)
+	for _, attempt := range authResult.AuthAttempts {
+		if attempt.Success {
+			successfulAuths = append(successfulAuths, attempt)
+		}
+	}
+
+	// Execute each requested action
+	for _, action := range actions {
+		switch action {
+		case ldapcommonfern.LdapActionDomaindump:
+			log.Debug("Performing " + string(ldapcommonfern.LdapActionDomaindump))
+			// Use the existing library for domain dump with authenticated context
+			library := &ldappentest.LibraryPentestLdap{}
+			domainDumpResult, err := library.DomainDump(ctx, *config)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(ldapcommonfern.LdapActionDomaindump), err))
+			} else if domainDumpResult != nil {
+				results = append(results, domainDumpResult)
+			}
+		}
+	}
+
+	return results, errors
 }
 
 // Helper functions have been moved to utils package

--- a/internal/pentest/ldap/auth.go
+++ b/internal/pentest/ldap/auth.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Method-Security/networkscan/internal/common"
+	pentestcommonfern "github.com/Method-Security/networkscan/generated/go/common/pentest"
+	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	"github.com/Method-Security/networkscan/utils"
 	"github.com/go-ldap/ldap/v3"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -133,7 +135,7 @@ func AuthenticateUserWithHash(ctx context.Context, target *Target, username, ntl
 	log.Debug("Attempting NTLM hash authentication", svc1log.SafeParam("username", username))
 
 	// Prepare NTLM hash for LDAP (requires LM:NT format)
-	processor := common.NewNTLMHashProcessor()
+	processor := ntlm.NewHashProcessor()
 	fullHash := processor.ProcessHashForLDAP(ntlmHash)
 
 	// Use NTLM bind with hash
@@ -383,6 +385,163 @@ func createLDAPConnection(target *Target, timeout int) (*ldap.Conn, error) {
 	}
 
 	return conn, nil
+}
+
+// PerformAuthenticationWithContext performs LDAP authentication attempts with context
+func PerformAuthenticationWithContext(ctx context.Context, target string, config *ldapfern.PentestLdapConfig) (*pentestcommonfern.AuthResult, error) {
+	log := svc1log.FromContext(ctx)
+	log.Info("Starting LDAP authentication testing", svc1log.SafeParam("target", target))
+
+	result := &pentestcommonfern.AuthResult{
+		Target: target,
+	}
+
+	var errors []string
+
+	// Parse the target
+	ldapTarget, err := ParseTarget(target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse target: %v", err)
+	}
+
+	// Check if auth should be performed based on credentials or explicit actions
+	shouldPerformAuth := false
+	if config.AuthConfig != nil {
+		hasCredentials := len(config.AuthConfig.Usernames) > 0 && (len(config.AuthConfig.Passwords) > 0 ||
+			(config.AuthConfig.Ntlmv2Hash != nil && *config.AuthConfig.Ntlmv2Hash != ""))
+		shouldPerformAuth = hasCredentials
+	}
+
+	// If credentials are provided, perform authentication
+	if shouldPerformAuth {
+		authAttempts, authErrors := performLDAPAuthAttemptsWithContext(ctx, ldapTarget, config)
+		result.AuthAttempts = authAttempts
+		errors = append(errors, authErrors...)
+	}
+
+	if len(errors) > 0 {
+		result.Errors = errors
+	}
+
+	return result, nil
+}
+
+// performLDAPAuthAttemptsWithContext performs credential-based authentication attempts with context
+func performLDAPAuthAttemptsWithContext(ctx context.Context, target *Target, config *ldapfern.PentestLdapConfig) ([]*pentestcommonfern.AuthAttempt, []string) {
+	var allAttempts []*pentestcommonfern.AuthAttempt
+	var errors []string
+
+	// Generate credential pairs - check if AuthConfig exists
+	if config.AuthConfig == nil {
+		return nil, []string{"no auth config provided"}
+	}
+
+	log := svc1log.FromContext(ctx)
+
+	// Check if we should use hash-based authentication
+	if config.AuthConfig.Ntlmv2Hash != nil && *config.AuthConfig.Ntlmv2Hash != "" {
+		// Use pass-the-hash authentication
+		ntlmHash := *config.AuthConfig.Ntlmv2Hash
+		log.Info("Using pass-the-hash authentication", svc1log.SafeParam("hash", "[REDACTED]"))
+
+		for _, username := range config.AuthConfig.Usernames {
+			attempt, err := attemptLDAPHashAuthenticationWithContext(ctx, target, username, ntlmHash, config.Timeout)
+			if err != nil {
+				errors = append(errors, err.Error())
+			}
+
+			allAttempts = append(allAttempts, attempt)
+
+			if attempt.Success {
+				log.Info("Pass-the-hash authentication successful",
+					svc1log.SafeParam("username", username),
+					svc1log.SafeParam("hash", "[REDACTED]"))
+
+				// Stop on first success for pass-the-hash
+				break
+			}
+		}
+	} else {
+		// Use traditional password authentication
+		for _, username := range config.AuthConfig.Usernames {
+			for _, password := range config.AuthConfig.Passwords {
+				attempt, err := attemptLDAPAuthenticationWithContext(ctx, target, username, password, config.Timeout)
+				if err != nil {
+					errors = append(errors, err.Error())
+				}
+
+				allAttempts = append(allAttempts, attempt)
+
+				if attempt.Success {
+					log.Info("Authentication successful",
+						svc1log.SafeParam("username", username),
+						svc1log.SafeParam("password", "[REDACTED]"))
+
+					// Continue with next password for traditional auth
+				}
+			}
+		}
+	}
+
+	// Count successful attempts
+	successfulCount := 0
+	for _, attempt := range allAttempts {
+		if attempt.Success {
+			successfulCount++
+		}
+	}
+
+	log.Info("LDAP Authentication completed",
+		svc1log.SafeParam("successful", successfulCount),
+		svc1log.SafeParam("failed", len(allAttempts)-successfulCount))
+
+	return allAttempts, errors
+}
+
+// attemptLDAPAuthenticationWithContext performs a single LDAP authentication attempt with context
+func attemptLDAPAuthenticationWithContext(ctx context.Context, target *Target, username, password string, timeout int) (*pentestcommonfern.AuthAttempt, error) {
+	timestamp := time.Now()
+	attempt := &pentestcommonfern.AuthAttempt{
+		Username:  username,
+		Password:  &password,
+		Domain:    &target.Domain,
+		Success:   false,
+		Timestamp: timestamp,
+	}
+
+	success, message, err := AuthenticateUser(ctx, target, username, password, timeout)
+	if err != nil {
+		attempt.Message = err.Error()
+		return attempt, nil // Don't return error here, it's expected for failed auth
+	}
+
+	attempt.Success = success
+	attempt.Message = message
+
+	return attempt, nil
+}
+
+// attemptLDAPHashAuthenticationWithContext performs a single LDAP pass-the-hash authentication attempt with context
+func attemptLDAPHashAuthenticationWithContext(ctx context.Context, target *Target, username, ntlmHash string, timeout int) (*pentestcommonfern.AuthAttempt, error) {
+	timestamp := time.Now()
+	attempt := &pentestcommonfern.AuthAttempt{
+		Username:  username,
+		Password:  nil, // No password for hash auth
+		Domain:    &target.Domain,
+		Success:   false,
+		Timestamp: timestamp,
+	}
+
+	success, message, err := AuthenticateUserWithHash(ctx, target, username, ntlmHash, timeout)
+	if err != nil {
+		attempt.Message = err.Error()
+		return attempt, nil // Don't return error here, it's expected for failed auth
+	}
+
+	attempt.Success = success
+	attempt.Message = message
+
+	return attempt, nil
 }
 
 // generateBindDNS generates possible bind DN formats for a username

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -14,7 +14,7 @@ import (
 	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
 
 	// Internal
-	"github.com/Method-Security/networkscan/internal/common"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	// External
 	"github.com/go-ldap/ldap/v3"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -155,7 +155,7 @@ func (l *LibraryPentestLdap) authenticateConnection(ctx context.Context, conn *l
 		}
 
 		// Process hash for LDAP (requires LM:NT format)
-		processor := common.NewNTLMHashProcessor()
+		processor := ntlm.NewHashProcessor()
 		fullHash := processor.ProcessHashForLDAP(ntlmHash)
 
 		// Use NTLM bind with hash directly on the provided connection

--- a/internal/pentest/ldap/probe.go
+++ b/internal/pentest/ldap/probe.go
@@ -1,0 +1,147 @@
+package ldap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/go-ntlmssp"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	"github.com/go-ldap/ldap/v3"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// PerformProbe performs LDAP server information gathering without authentication
+func PerformProbe(ctx context.Context, target string, config *ldapfern.PentestLdapConfig) (*ldapfern.ProbeResult, error) {
+	log := svc1log.FromContext(ctx)
+	log.Info("Starting LDAP probe operation", svc1log.SafeParam("target", target))
+
+	result := &ldapfern.ProbeResult{
+		Target: target,
+	}
+
+	// Parse the target
+	ldapTarget, err := ParseTarget(target)
+	if err != nil {
+		errorMsg := "Failed to parse target: " + err.Error()
+		result.Errors = []string{errorMsg}
+		log.Debug("LDAP probe failed - target parse error", svc1log.SafeParam("error", err))
+		return result, nil // Return result with error, don't fail the whole operation
+	}
+
+	// Create LDAP connection for probing
+	conn, err := createLDAPConnection(ldapTarget, config.Timeout)
+	if err != nil {
+		errorMsg := "Failed to connect to LDAP server: " + err.Error()
+		result.Errors = []string{errorMsg}
+		log.Debug("LDAP probe failed - connection error", svc1log.SafeParam("error", err))
+		return result, nil // Return result with error, don't fail the whole operation
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Warn("Failed to close LDAP connection during probe", svc1log.SafeParam("error", closeErr))
+		}
+	}()
+
+	// Extract server information via NTLM challenge using unified extractor
+	serverInfo, err := extractServerInfoFromNTLMChallenge(ctx, conn, ldapTarget)
+	if err != nil {
+		errorMsg := "Failed to extract server info from NTLM challenge: " + err.Error()
+		result.Errors = []string{errorMsg}
+		log.Debug("LDAP NTLM challenge extraction failed", svc1log.SafeParam("error", err))
+		return result, nil // Return result with error, don't fail the whole operation
+	}
+
+	result.ServerInfo = serverInfo
+	log.Info("LDAP probe completed successfully",
+		svc1log.SafeParam("target", target),
+		svc1log.SafeParam("dnsDomain", func() string {
+			if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsDomainName != nil {
+				return *serverInfo.TargetInfo.DnsDomainName
+			}
+			return ""
+		}()),
+		svc1log.SafeParam("netbiosDomain", func() string {
+			if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil {
+				return *serverInfo.TargetInfo.NetbiosDomainName
+			}
+			return ""
+		}()),
+		svc1log.SafeParam("serverName", serverInfo.ServerName))
+
+	return result, nil
+}
+
+// probeNegotiator implements NTLM negotiation for server info extraction using unified extractor
+type probeNegotiator struct {
+	serverInfo *commonprotocolfern.NtlmServerInfo
+	log        svc1log.Logger
+}
+
+func (pn *probeNegotiator) Negotiate(domain, workstation string) ([]byte, error) {
+	return ntlmssp.NewNegotiateMessage(domain, workstation)
+}
+
+func (pn *probeNegotiator) ChallengeResponse(chal []byte, user, hash string) ([]byte, error) {
+	// Use unified NTLM extractor
+	serverInfo, err := ntlm.ExtractServerInfoFromChallenge(chal, pn.log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract server info from NTLM challenge: %v", err)
+	}
+
+	pn.serverInfo = serverInfo
+
+	// We don't actually want to complete the authentication, just extract server info
+	// Return an empty response to avoid actually authenticating
+	return []byte{}, fmt.Errorf("probe completed, authentication not required")
+}
+
+// extractServerInfoFromNTLMChallenge extracts server information via NTLM challenge using unified extractor
+func extractServerInfoFromNTLMChallenge(ctx context.Context, conn *ldap.Conn, target *Target) (*commonprotocolfern.LdapServerInfo, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Create probe negotiator to capture server info
+	negotiator := &probeNegotiator{
+		log: log,
+	}
+
+	// Attempt NTLM bind to trigger challenge/response and extract server info
+	req := &ldap.NTLMBindRequest{
+		Domain:     "",      // Let the server provide domain info
+		Username:   "probe", // Dummy username for probing
+		Password:   "probe", // Dummy password for probing
+		Negotiator: negotiator,
+	}
+
+	// We expect this to fail, but we should capture the server info from the challenge
+	_, err := conn.NTLMChallengeBind(req)
+
+	// Check if we successfully extracted server info even if bind failed
+	if negotiator.serverInfo != nil {
+		// Convert unified server info to LDAP-specific format
+		ldapServerInfo := ntlm.ConvertToLDAPServerInfo(negotiator.serverInfo)
+		log.Debug("Successfully extracted server info from NTLM challenge",
+			svc1log.SafeParam("dnsDomain", func() string {
+				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.DnsDomainName != nil {
+					return *ldapServerInfo.TargetInfo.DnsDomainName
+				}
+				return ""
+			}()),
+			svc1log.SafeParam("netbiosDomain", func() string {
+				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.NetbiosDomainName != nil {
+					return *ldapServerInfo.TargetInfo.NetbiosDomainName
+				}
+				return ""
+			}()),
+			svc1log.SafeParam("serverName", ldapServerInfo.ServerName))
+		return ldapServerInfo, nil
+	}
+
+	// If we got here, we couldn't extract server info
+	if err != nil {
+		return nil, fmt.Errorf("NTLM challenge bind failed and no server info extracted: %v", err)
+	}
+
+	return nil, fmt.Errorf("no server info extracted from NTLM challenge")
+}

--- a/internal/pentest/ldap/probe.go
+++ b/internal/pentest/ldap/probe.go
@@ -68,7 +68,15 @@ func PerformProbe(ctx context.Context, target string, config *ldapfern.PentestLd
 			}
 			return ""
 		}()),
-		svc1log.SafeParam("serverName", serverInfo.ServerName))
+		svc1log.SafeParam("serverName", func() string {
+			if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsComputerName != nil {
+				return *serverInfo.TargetInfo.DnsComputerName
+			}
+			if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosComputerName != nil {
+				return *serverInfo.TargetInfo.NetbiosComputerName
+			}
+			return ""
+		}()))
 
 	return result, nil
 }
@@ -134,7 +142,15 @@ func extractServerInfoFromNTLMChallenge(ctx context.Context, conn *ldap.Conn, ta
 				}
 				return ""
 			}()),
-			svc1log.SafeParam("serverName", ldapServerInfo.ServerName))
+			svc1log.SafeParam("serverName", func() string {
+				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.DnsComputerName != nil {
+					return *ldapServerInfo.TargetInfo.DnsComputerName
+				}
+				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.NetbiosComputerName != nil {
+					return *ldapServerInfo.TargetInfo.NetbiosComputerName
+				}
+				return ""
+			}()))
 		return ldapServerInfo, nil
 	}
 

--- a/internal/pentest/ldap/probe.go
+++ b/internal/pentest/ldap/probe.go
@@ -56,27 +56,8 @@ func PerformProbe(ctx context.Context, target string, config *ldapfern.PentestLd
 	result.ServerInfo = serverInfo
 	log.Info("LDAP probe completed successfully",
 		svc1log.SafeParam("target", target),
-		svc1log.SafeParam("dnsDomain", func() string {
-			if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsDomainName != nil {
-				return *serverInfo.TargetInfo.DnsDomainName
-			}
-			return ""
-		}()),
-		svc1log.SafeParam("netbiosDomain", func() string {
-			if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil {
-				return *serverInfo.TargetInfo.NetbiosDomainName
-			}
-			return ""
-		}()),
-		svc1log.SafeParam("serverName", func() string {
-			if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsComputerName != nil {
-				return *serverInfo.TargetInfo.DnsComputerName
-			}
-			if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosComputerName != nil {
-				return *serverInfo.TargetInfo.NetbiosComputerName
-			}
-			return ""
-		}()))
+		svc1log.SafeParam("domain", ntlm.GetLDAPDomainName(serverInfo)),
+		svc1log.SafeParam("serverName", ntlm.GetLDAPServerName(serverInfo)))
 
 	return result, nil
 }
@@ -130,27 +111,8 @@ func extractServerInfoFromNTLMChallenge(ctx context.Context, conn *ldap.Conn, ta
 		// Convert unified server info to LDAP-specific format
 		ldapServerInfo := ntlm.ConvertToLDAPServerInfo(negotiator.serverInfo)
 		log.Debug("Successfully extracted server info from NTLM challenge",
-			svc1log.SafeParam("dnsDomain", func() string {
-				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.DnsDomainName != nil {
-					return *ldapServerInfo.TargetInfo.DnsDomainName
-				}
-				return ""
-			}()),
-			svc1log.SafeParam("netbiosDomain", func() string {
-				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.NetbiosDomainName != nil {
-					return *ldapServerInfo.TargetInfo.NetbiosDomainName
-				}
-				return ""
-			}()),
-			svc1log.SafeParam("serverName", func() string {
-				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.DnsComputerName != nil {
-					return *ldapServerInfo.TargetInfo.DnsComputerName
-				}
-				if ldapServerInfo.TargetInfo != nil && ldapServerInfo.TargetInfo.NetbiosComputerName != nil {
-					return *ldapServerInfo.TargetInfo.NetbiosComputerName
-				}
-				return ""
-			}()))
+			svc1log.SafeParam("domain", ntlm.GetLDAPDomainName(ldapServerInfo)),
+			svc1log.SafeParam("serverName", ntlm.GetLDAPServerName(ldapServerInfo)))
 		return ldapServerInfo, nil
 	}
 

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -260,8 +260,12 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 		// Extract actual domain from SMB server info after successful authentication
 		serverInfo := client.GetServerInfo()
 		actualDomain := domain // Use provided domain as fallback
-		if serverInfo != nil && serverInfo.Domain != nil && *serverInfo.Domain != "" {
-			actualDomain = *serverInfo.Domain
+		if serverInfo != nil && serverInfo.TargetInfo != nil {
+			if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
+				actualDomain = *serverInfo.TargetInfo.DnsDomainName
+			} else if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
+				actualDomain = *serverInfo.TargetInfo.NetbiosDomainName
+			}
 		}
 
 		// Update the attempt with the actual domain
@@ -301,9 +305,14 @@ func discoverDomainFromServerChallenge(ctx context.Context, host string, port, t
 		return ""
 	}
 
-	if serverInfo != nil && serverInfo.Domain != nil && *serverInfo.Domain != "" {
-		log.Debug("Successfully discovered domain from NTLM challenge", svc1log.SafeParam("domain", *serverInfo.Domain))
-		return *serverInfo.Domain
+	if serverInfo != nil && serverInfo.TargetInfo != nil {
+		if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
+			log.Debug("Successfully discovered DNS domain from NTLM challenge", svc1log.SafeParam("domain", *serverInfo.TargetInfo.DnsDomainName))
+			return *serverInfo.TargetInfo.DnsDomainName
+		} else if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
+			log.Debug("Successfully discovered NetBIOS domain from NTLM challenge", svc1log.SafeParam("domain", *serverInfo.TargetInfo.NetbiosDomainName))
+			return *serverInfo.TargetInfo.NetbiosDomainName
+		}
 	}
 
 	log.Debug("No domain information available from NTLM challenge")
@@ -342,8 +351,12 @@ func attemptHashAuthenticationWithContext(ctx context.Context, host string, port
 		// Extract actual domain from SMB server info after successful authentication
 		serverInfo := client.GetServerInfo()
 		actualDomain := domain // Use provided domain as fallback
-		if serverInfo != nil && serverInfo.Domain != nil && *serverInfo.Domain != "" {
-			actualDomain = *serverInfo.Domain
+		if serverInfo != nil && serverInfo.TargetInfo != nil {
+			if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
+				actualDomain = *serverInfo.TargetInfo.DnsDomainName
+			} else if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
+				actualDomain = *serverInfo.TargetInfo.NetbiosDomainName
+			}
 		}
 
 		// Update the attempt with the actual domain

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -9,6 +9,7 @@ import (
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	smbcommonfern "github.com/Method-Security/networkscan/generated/go/common/smb"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -260,12 +261,8 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 		// Extract actual domain from SMB server info after successful authentication
 		serverInfo := client.GetServerInfo()
 		actualDomain := domain // Use provided domain as fallback
-		if serverInfo != nil && serverInfo.TargetInfo != nil {
-			if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
-				actualDomain = *serverInfo.TargetInfo.DnsDomainName
-			} else if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
-				actualDomain = *serverInfo.TargetInfo.NetbiosDomainName
-			}
+		if actualDomainFromServer := ntlm.GetSMBDomainName(serverInfo); actualDomainFromServer != "" {
+			actualDomain = actualDomainFromServer
 		}
 
 		// Update the attempt with the actual domain
@@ -305,14 +302,9 @@ func discoverDomainFromServerChallenge(ctx context.Context, host string, port, t
 		return ""
 	}
 
-	if serverInfo != nil && serverInfo.TargetInfo != nil {
-		if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
-			log.Debug("Successfully discovered DNS domain from NTLM challenge", svc1log.SafeParam("domain", *serverInfo.TargetInfo.DnsDomainName))
-			return *serverInfo.TargetInfo.DnsDomainName
-		} else if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
-			log.Debug("Successfully discovered NetBIOS domain from NTLM challenge", svc1log.SafeParam("domain", *serverInfo.TargetInfo.NetbiosDomainName))
-			return *serverInfo.TargetInfo.NetbiosDomainName
-		}
+	if domain := ntlm.GetSMBDomainName(serverInfo); domain != "" {
+		log.Debug("Successfully discovered domain from NTLM challenge", svc1log.SafeParam("domain", domain))
+		return domain
 	}
 
 	log.Debug("No domain information available from NTLM challenge")
@@ -351,12 +343,8 @@ func attemptHashAuthenticationWithContext(ctx context.Context, host string, port
 		// Extract actual domain from SMB server info after successful authentication
 		serverInfo := client.GetServerInfo()
 		actualDomain := domain // Use provided domain as fallback
-		if serverInfo != nil && serverInfo.TargetInfo != nil {
-			if serverInfo.TargetInfo.DnsDomainName != nil && *serverInfo.TargetInfo.DnsDomainName != "" {
-				actualDomain = *serverInfo.TargetInfo.DnsDomainName
-			} else if serverInfo.TargetInfo.NetbiosDomainName != nil && *serverInfo.TargetInfo.NetbiosDomainName != "" {
-				actualDomain = *serverInfo.TargetInfo.NetbiosDomainName
-			}
+		if actualDomainFromServer := ntlm.GetSMBDomainName(serverInfo); actualDomainFromServer != "" {
+			actualDomain = actualDomainFromServer
 		}
 
 		// Update the attempt with the actual domain

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -15,35 +15,13 @@ import (
 )
 
 // convertToSmbServerInfo converts internal ServerInfo to fern SmbServerInfo
-func convertToSmbServerInfo(serverInfo *smbclient.ServerInfo) *commonprotocolfern.SmbServerInfo {
+func convertToSmbServerInfo(serverInfo *commonprotocolfern.SmbServerInfo) *commonprotocolfern.SmbServerInfo {
 	if serverInfo == nil {
 		return nil
 	}
 
-	// Convert capabilities
-	var capabilities []string
-	if serverInfo.Capabilities != nil {
-		capabilities = serverInfo.Capabilities
-	}
-
-	// Convert supported versions (note: slice of values, not pointers)
-	var supportedVersions []commonprotocolfern.SmbVersion
-	for _, version := range serverInfo.SupportedVersions {
-		if smbVersion, err := commonprotocolfern.NewSmbVersionFromString(version); err == nil {
-			supportedVersions = append(supportedVersions, smbVersion)
-		}
-	}
-
-	return &commonprotocolfern.SmbServerInfo{
-		ServerName:           &serverInfo.ServerName,
-		Domain:               &serverInfo.Domain,
-		NetBiosDomainName:    &serverInfo.NetBIOSDomainName,
-		OsVersion:            &serverInfo.OSVersion,
-		RawOsVersion:         &serverInfo.RawOSVersion,
-		SigningRequired:      &serverInfo.SigningRequired,
-		SupportedSmbVersions: supportedVersions,
-		Capabilities:         capabilities,
-	}
+	// Since both input and output are already the same type, just return the input
+	return serverInfo
 }
 
 // PerformAuthentication performs authentication attempts against SMB service
@@ -74,16 +52,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(config.Timeout) * time.Millisecond
 
-	serverInfo, err := client.ExtractServerInfoFromChallenge(ctx)
-	if err != nil {
-		log.Debug("Failed to extract server info from NTLM challenge", svc1log.SafeParam("error", err.Error()))
-		errors = append(errors, fmt.Sprintf("Failed to extract server info: %v", err))
-	} else {
-		log.Debug("Successfully extracted server info",
-			svc1log.SafeParam("serverName", serverInfo.ServerName),
-			svc1log.SafeParam("domain", serverInfo.Domain))
-		result.ServerInfo = convertToSmbServerInfo(serverInfo)
-	}
+	// Server info is now extracted in the PROBE stage, so we don't need to extract it again here
 
 	// Check if auth should be performed based on credentials or explicit actions
 	shouldPerformAuth := false
@@ -263,6 +232,8 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*pentestcommonfern.AuthAttempt, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
+	// Skip server info extraction since it's done in PROBE stage
+	client.SkipServerInfoExtraction(true)
 
 	// Use provided domain or empty string for local authentication
 	client.SetCredentials(username, password, domain)
@@ -289,8 +260,8 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 		// Extract actual domain from SMB server info after successful authentication
 		serverInfo := client.GetServerInfo()
 		actualDomain := domain // Use provided domain as fallback
-		if serverInfo != nil && serverInfo.Domain != "" {
-			actualDomain = serverInfo.Domain
+		if serverInfo != nil && serverInfo.Domain != nil && *serverInfo.Domain != "" {
+			actualDomain = *serverInfo.Domain
 		}
 
 		// Update the attempt with the actual domain
@@ -320,6 +291,8 @@ func discoverDomainFromServerChallenge(ctx context.Context, host string, port, t
 	// Create a temporary SMB client just to extract server info from NTLM challenge
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
+	// Skip server info extraction in Connect - we'll extract just domain info manually
+	client.SkipServerInfoExtraction(true)
 
 	// Use our new ExtractServerInfoFromChallenge method
 	serverInfo, err := client.ExtractServerInfoFromChallenge(ctx)
@@ -328,9 +301,9 @@ func discoverDomainFromServerChallenge(ctx context.Context, host string, port, t
 		return ""
 	}
 
-	if serverInfo != nil && serverInfo.Domain != "" {
-		log.Debug("Successfully discovered domain from NTLM challenge", svc1log.SafeParam("domain", serverInfo.Domain))
-		return serverInfo.Domain
+	if serverInfo != nil && serverInfo.Domain != nil && *serverInfo.Domain != "" {
+		log.Debug("Successfully discovered domain from NTLM challenge", svc1log.SafeParam("domain", *serverInfo.Domain))
+		return *serverInfo.Domain
 	}
 
 	log.Debug("No domain information available from NTLM challenge")
@@ -341,6 +314,8 @@ func discoverDomainFromServerChallenge(ctx context.Context, host string, port, t
 func attemptHashAuthenticationWithContext(ctx context.Context, host string, port int, username, ntlmHash, domain string, timeout int) (*pentestcommonfern.AuthAttempt, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
+	// Skip server info extraction since it's done in PROBE stage
+	client.SkipServerInfoExtraction(true)
 
 	// Use NTLM hash for authentication
 	client.SetCredentialsWithHash(username, ntlmHash, domain)
@@ -367,8 +342,8 @@ func attemptHashAuthenticationWithContext(ctx context.Context, host string, port
 		// Extract actual domain from SMB server info after successful authentication
 		serverInfo := client.GetServerInfo()
 		actualDomain := domain // Use provided domain as fallback
-		if serverInfo != nil && serverInfo.Domain != "" {
-			actualDomain = serverInfo.Domain
+		if serverInfo != nil && serverInfo.Domain != nil && *serverInfo.Domain != "" {
+			actualDomain = *serverInfo.Domain
 		}
 
 		// Update the attempt with the actual domain

--- a/internal/pentest/smb/probe.go
+++ b/internal/pentest/smb/probe.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
 	"github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -40,24 +41,8 @@ func PerformProbe(ctx context.Context, target string, config *smbfern.PentestSmb
 		result.ServerInfo = convertToSmbServerInfo(serverInfo)
 		log.Info("SMB probe completed successfully",
 			svc1log.SafeParam("target", target),
-			svc1log.SafeParam("serverName", func() string {
-				if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsComputerName != nil {
-					return *serverInfo.TargetInfo.DnsComputerName
-				}
-				if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosComputerName != nil {
-					return *serverInfo.TargetInfo.NetbiosComputerName
-				}
-				return ""
-			}()),
-			svc1log.SafeParam("domain", func() string {
-				if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsDomainName != nil {
-					return *serverInfo.TargetInfo.DnsDomainName
-				}
-				if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil {
-					return *serverInfo.TargetInfo.NetbiosDomainName
-				}
-				return ""
-			}()))
+			svc1log.SafeParam("serverName", ntlm.GetSMBServerName(serverInfo)),
+			svc1log.SafeParam("domain", ntlm.GetSMBDomainName(serverInfo)))
 	} else {
 		errorMsg := "Failed to extract server info from connection"
 		result.Errors = []string{errorMsg}

--- a/internal/pentest/smb/probe.go
+++ b/internal/pentest/smb/probe.go
@@ -40,8 +40,24 @@ func PerformProbe(ctx context.Context, target string, config *smbfern.PentestSmb
 		result.ServerInfo = convertToSmbServerInfo(serverInfo)
 		log.Info("SMB probe completed successfully",
 			svc1log.SafeParam("target", target),
-			svc1log.SafeParam("serverName", serverInfo.ServerName),
-			svc1log.SafeParam("domain", serverInfo.Domain))
+			svc1log.SafeParam("serverName", func() string {
+				if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsComputerName != nil {
+					return *serverInfo.TargetInfo.DnsComputerName
+				}
+				if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosComputerName != nil {
+					return *serverInfo.TargetInfo.NetbiosComputerName
+				}
+				return ""
+			}()),
+			svc1log.SafeParam("domain", func() string {
+				if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.DnsDomainName != nil {
+					return *serverInfo.TargetInfo.DnsDomainName
+				}
+				if serverInfo.TargetInfo != nil && serverInfo.TargetInfo.NetbiosDomainName != nil {
+					return *serverInfo.TargetInfo.NetbiosDomainName
+				}
+				return ""
+			}()))
 	} else {
 		errorMsg := "Failed to extract server info from connection"
 		result.Errors = []string{errorMsg}

--- a/internal/pentest/smb/probe.go
+++ b/internal/pentest/smb/probe.go
@@ -1,0 +1,55 @@
+package smb
+
+import (
+	"context"
+	"time"
+
+	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
+	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
+	"github.com/Method-Security/networkscan/utils"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// PerformProbe performs server information gathering via NTLM challenge without authentication
+func PerformProbe(ctx context.Context, target string, config *smbfern.PentestSmbConfig) (*smbfern.ProbeResult, error) {
+	log := svc1log.FromContext(ctx)
+	log.Info("Starting SMB probe operation", svc1log.SafeParam("target", target))
+
+	result := &smbfern.ProbeResult{
+		Target: target,
+	}
+
+	host, port := utils.ParseHostPort(target, 445)
+
+	// Create SMB client for probing (no authentication)
+	client := smbclient.NewClient(host, port)
+	client.Timeout = time.Duration(config.Timeout) * time.Millisecond
+
+	// Perform connection and extract server info from NTLM challenge
+	err := client.ConnectWithContext(ctx)
+	if err != nil {
+		errorMsg := "Failed to connect to SMB server: " + err.Error()
+		result.Errors = []string{errorMsg}
+		log.Debug("SMB probe failed", svc1log.SafeParam("error", err))
+		return result, nil // Return result with error, don't fail the whole operation
+	}
+
+	// Extract server information
+	serverInfo := client.GetServerInfo()
+	if serverInfo != nil {
+		result.ServerInfo = convertToSmbServerInfo(serverInfo)
+		log.Info("SMB probe completed successfully",
+			svc1log.SafeParam("target", target),
+			svc1log.SafeParam("serverName", serverInfo.ServerName),
+			svc1log.SafeParam("domain", serverInfo.Domain))
+	} else {
+		errorMsg := "Failed to extract server info from connection"
+		result.Errors = []string{errorMsg}
+		log.Debug("Server info extraction failed - no server info available")
+	}
+
+	// Close the probe connection
+	_ = client.Close()
+
+	return result, nil
+}

--- a/internal/pentest/smb/shares.go
+++ b/internal/pentest/smb/shares.go
@@ -8,7 +8,6 @@ import (
 
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
-	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
 	"github.com/Method-Security/networkscan/utils"
 	gosmb "github.com/jfjallid/go-smb/smb"
 	"github.com/jfjallid/go-smb/smb/dcerpc"
@@ -52,44 +51,13 @@ func PerformShares(ctx context.Context, target string, config *smbfern.PentestSm
 }
 
 // convertToSmbShares converts protocol library ShareInfo to common SMB Share (reused from enumerate)
-func convertToSmbShares(shares []*smbclient.ShareInfo) []*commonprotocolfern.SmbShare {
-	var smbShares []*commonprotocolfern.SmbShare
-
-	for _, share := range shares {
-		shareType := convertShareType(share.Type)
-		shareAccess := convertShareAccess(share.Access)
-
-		smbShare := &commonprotocolfern.SmbShare{
-			Name: share.Name,
-			Type: shareType,
-		}
-
-		// Only set accessible field when we've actually tested accessibility
-		// (which we do in pentest context)
-		smbShare.Accessible = &share.Accessible
-
-		// Always set the access field since we've tested permissions
-		smbShare.Access = &shareAccess
-
-		// Only set anonymous/guest access if we actually tested for it
-		// (which we don't in pentest context with authenticated sessions)
-
-		if share.Hidden {
-			smbShare.Hidden = &share.Hidden
-		}
-
-		if share.Comment != "" {
-			smbShare.Comment = &share.Comment
-		}
-
-		smbShares = append(smbShares, smbShare)
-	}
-
-	return smbShares
+func convertToSmbShares(shares []*commonprotocolfern.SmbShare) []*commonprotocolfern.SmbShare {
+	// Since both input and output are already the same type, just return the input
+	return shares
 }
 
-// convertShareType converts string share type to common ShareType (reused from enumerate)
-func convertShareType(shareType string) commonprotocolfern.ShareType {
+// convertShareTypeEnum converts string share type to enum
+func convertShareTypeEnum(shareType string) commonprotocolfern.ShareType {
 	switch shareType {
 	case "IPC":
 		return commonprotocolfern.ShareTypeIpc
@@ -97,13 +65,15 @@ func convertShareType(shareType string) commonprotocolfern.ShareType {
 		return commonprotocolfern.ShareTypePrint
 	case "Disk":
 		return commonprotocolfern.ShareTypeDisk
+	case "Device":
+		return commonprotocolfern.ShareTypeDevice
 	default:
 		return commonprotocolfern.ShareTypeDisk
 	}
 }
 
-// convertShareAccess converts string share access to common ShareAccess (reused from enumerate)
-func convertShareAccess(access string) commonprotocolfern.ShareAccess {
+// convertShareAccessFromString converts string share access to enum
+func convertShareAccessFromString(access string) commonprotocolfern.ShareAccess {
 	switch {
 	case strings.Contains(access, "Read") && strings.Contains(access, "Write"):
 		return commonprotocolfern.ShareAccessReadWrite
@@ -111,13 +81,15 @@ func convertShareAccess(access string) commonprotocolfern.ShareAccess {
 		return commonprotocolfern.ShareAccessReadOnly
 	case strings.Contains(access, "Write"):
 		return commonprotocolfern.ShareAccessReadWrite
+	case strings.Contains(access, "No Access"):
+		return commonprotocolfern.ShareAccessNoAccess
 	default:
 		return commonprotocolfern.ShareAccessNoAccess
 	}
 }
 
 // enumerateSharesWithGoSmbConnection enumerates shares using NetShareEnumAll via mssrvs module
-func enumerateSharesWithGoSmbConnection(ctx context.Context, conn *gosmb.Connection) ([]*smbclient.ShareInfo, error) {
+func enumerateSharesWithGoSmbConnection(ctx context.Context, conn *gosmb.Connection) ([]*commonprotocolfern.SmbShare, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Enumerate shares using NetShareEnumAll
@@ -134,7 +106,7 @@ func enumerateSharesWithGoSmbConnection(ctx context.Context, conn *gosmb.Connect
 }
 
 // enumerateSharesViaNetShareEnum uses DCERPC NetShareEnumAll for proper share enumeration
-func enumerateSharesViaNetShareEnum(ctx context.Context, conn *gosmb.Connection) ([]*smbclient.ShareInfo, error) {
+func enumerateSharesViaNetShareEnum(ctx context.Context, conn *gosmb.Connection) ([]*commonprotocolfern.SmbShare, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Open the srvsvc named pipe directly (like samdump does with winreg)
@@ -161,20 +133,26 @@ func enumerateSharesViaNetShareEnum(ctx context.Context, conn *gosmb.Connection)
 	}
 
 	// Convert NetShare to ShareInfo and test permissions
-	var shares []*smbclient.ShareInfo
+	var shares []*commonprotocolfern.SmbShare
 	log.Info("Testing permissions for discovered shares",
 		svc1log.SafeParam("shareCount", len(netShares)))
 
 	for _, netShare := range netShares {
-		shareInfo := &smbclient.ShareInfo{
+		shareType := convertShareTypeEnum(convertNetShareType(netShare.TypeId))
+		hidden := netShare.Hidden
+		comment := netShare.Comment
+		shareInfo := &commonprotocolfern.SmbShare{
 			Name:    netShare.Name,
-			Type:    convertNetShareType(netShare.TypeId),
-			Hidden:  netShare.Hidden,
-			Comment: netShare.Comment,
+			Type:    shareType,
+			Hidden:  &hidden,
+			Comment: &comment,
 		}
 
 		// Test share permissions using NetExec's approach
-		shareInfo.Accessible, shareInfo.Access = testSharePermissions(ctx, conn, netShare.Name, log)
+		accessible, access := testSharePermissions(ctx, conn, netShare.Name, log)
+		shareInfo.Accessible = &accessible
+		accessType := convertShareAccessFromString(access)
+		shareInfo.Access = &accessType
 
 		// Note: AnonymousAccess and GuestAccess are not set since we don't test for those
 		// in this pentest context - we're using authenticated sessions
@@ -209,6 +187,14 @@ func testSharePermissions(ctx context.Context, conn *gosmb.Connection, shareName
 	accessible := false
 	permissions := []string{}
 
+	// Check context timeout first
+	select {
+	case <-ctx.Done():
+		log.Debug("Context timeout during share permission test", svc1log.SafeParam("share", shareName))
+		return false, "Timeout"
+	default:
+	}
+
 	// Test READ access by attempting to list share contents
 	err := conn.TreeConnect(shareName)
 	if err != nil {
@@ -223,8 +209,20 @@ func testSharePermissions(ctx context.Context, conn *gosmb.Connection, shareName
 
 	accessible = true
 
-	// Test READ permission - attempt to list directory contents
-	_, err = conn.ListDirectory(shareName, "", "*")
+	// Test READ permission - attempt to list directory contents with timeout
+	done := make(chan error, 1)
+	go func() {
+		_, err := conn.ListDirectory(shareName, "", "*")
+		done <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Debug("Context timeout during directory listing", svc1log.SafeParam("share", shareName))
+		return accessible, "Timeout"
+	case err = <-done:
+		// Continue with normal processing
+	}
 	if err == nil {
 		permissions = append(permissions, "Read")
 		log.Debug("READ access confirmed",
@@ -235,9 +233,24 @@ func testSharePermissions(ctx context.Context, conn *gosmb.Connection, shareName
 			svc1log.SafeParam("error", err.Error()))
 	}
 
-	// Test WRITE permission by attempting to create a temporary directory
+	// Test WRITE permission by attempting to create a temporary directory with timeout
 	tempDir := fmt.Sprintf("temp_%d_%s", time.Now().UnixNano(), utils.GenerateRandomString(8))
-	err = conn.Mkdir(shareName, tempDir)
+	writeDone := make(chan error, 1)
+	go func() {
+		err := conn.Mkdir(shareName, tempDir)
+		writeDone <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Debug("Context timeout during write permission test", svc1log.SafeParam("share", shareName))
+		if len(permissions) > 0 {
+			return accessible, strings.Join(permissions, " ")
+		}
+		return accessible, "Timeout"
+	case err = <-writeDone:
+		// Continue with normal processing
+	}
 	if err == nil {
 		permissions = append(permissions, "Write")
 		log.Debug("WRITE access confirmed via directory creation",

--- a/internal/protocol/smb/client.go
+++ b/internal/protocol/smb/client.go
@@ -27,14 +27,27 @@ func (c *CapturingNTLM) InitSecContext(inputToken []byte) ([]byte, error) {
 	// When the server replies to our first token, inputToken contains a SPNEGO NegTokenResp
 	// whose ResponseToken is the NTLM Type 2 CHALLENGE.
 	if len(inputToken) > 0 {
+		// Try to parse as SPNEGO first
 		var resp gss.NegTokenResp
 		var meta encoder.Metadata
 		if err := resp.UnmarshalBinary(inputToken, &meta); err == nil && len(resp.ResponseToken) > 0 {
 			// Store the raw challenge data for unified processing
 			c.LastChallengeData = resp.ResponseToken
+		} else {
+			// If SPNEGO parsing fails, check if this is a direct NTLM challenge
+			// NTLM Type 2 messages start with "NTLMSSP\x00" (signature) followed by type 02
+			if len(inputToken) >= 12 && string(inputToken[:8]) == "NTLMSSP\x00" {
+				// Check for Type 2 message (challenge)
+				if inputToken[8] == 0x02 && inputToken[9] == 0x00 && inputToken[10] == 0x00 && inputToken[11] == 0x00 {
+					c.LastChallengeData = inputToken
+				}
+			}
+		}
 
+		// Try to parse the challenge for validation
+		if len(c.LastChallengeData) > 0 {
 			ch := ntlmssp.NewChallenge()
-			if err := encoder.Unmarshal(resp.ResponseToken, ch); err == nil {
+			if err := encoder.Unmarshal(c.LastChallengeData, &ch); err == nil {
 				c.LastChallenge = &ch
 			}
 		}
@@ -122,26 +135,7 @@ func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*commonpro
 	log := svc1log.FromContext(ctx)
 	log.Debug("Starting ExtractServerInfoFromChallenge using unified NTLM challenge parser", svc1log.SafeParam("host", c.Host), svc1log.SafeParam("port", c.Port))
 
-	// If we don't have captured NTLM challenge, try to establish connection to get it
-	if c.capturingNTLM == nil || c.capturingNTLM.LastChallengeData == nil {
-		// Set up null session temporarily to capture NTLM challenge
-		originalNullSession := c.UseNullSession
-		c.UseNullSession = true
-
-		err := c.ConnectWithContext(ctx)
-		if err != nil {
-			log.Debug("Failed to establish null session for server info extraction", svc1log.SafeParam("error", err.Error()))
-			// Even if connection failed, check if we captured challenge data
-			if c.capturingNTLM == nil || c.capturingNTLM.LastChallengeData == nil {
-				return nil, fmt.Errorf("failed to capture NTLM challenge for server info extraction: %v", err)
-			}
-		}
-
-		// Restore original null session setting
-		c.UseNullSession = originalNullSession
-	}
-
-	// Check if we have captured challenge data
+	// Check if we have captured challenge data from a previous connection attempt
 	if c.capturingNTLM == nil || c.capturingNTLM.LastChallengeData == nil {
 		return nil, fmt.Errorf("no NTLM challenge data available for server info extraction")
 	}
@@ -435,46 +429,31 @@ func (c *Client) extractServerInfo() error {
 
 // extractServerInfoWithContext extracts server information from the SMB session with context
 func (c *Client) extractServerInfoWithContext(ctx context.Context) error {
-	if c.session == nil {
-		return fmt.Errorf("no active session")
-	}
-
-	signingRequired := c.session.IsSigningRequired()
-
-	// If we already have server info with nested structures (from ExtractServerInfoFromChallenge),
-	// preserve them and only add/update the connection-specific details
-	if c.serverInfo == nil {
-		c.serverInfo = &commonprotocolfern.SmbServerInfo{}
-	}
-
-	// Update connection-specific fields
-	c.serverInfo.SigningRequired = &signingRequired
-	c.serverInfo.SupportedSmbVersions = []commonprotocolfern.SmbVersion{
-		commonprotocolfern.SmbVersionSmb302,
-		commonprotocolfern.SmbVersionSmb30,
-		commonprotocolfern.SmbVersionSmb21,
-		commonprotocolfern.SmbVersionSmb20,
-	}
-
-	// Extract detailed information from NTLM target info using centralized parsing
-	targetInfo := c.session.GetTargetInfo()
-	if targetInfo != nil {
-		log := svc1log.FromContext(ctx)
-		log.Debug("TargetInfo available from go-smb session",
-			svc1log.SafeParam("dnsComputer", targetInfo.DnsComputerName),
-			svc1log.SafeParam("dnsDomain", targetInfo.DnsDomainName),
-			svc1log.SafeParam("nbComputer", targetInfo.NBComputerName),
-			svc1log.SafeParam("nbDomain", targetInfo.NBDomainName))
-		// Note: Detailed server info extraction is now handled by ExtractServerInfoFromChallenge
-	} else {
-		log := svc1log.FromContext(ctx)
-		log.Warn("NTLM target info not available")
-	}
-
 	log := svc1log.FromContext(ctx)
-	log.Info("Extracted server info",
-		svc1log.SafeParam("parsedOsVersion", c.serverInfo.ParsedOsVersion))
 
+	// Use the unified challenge-based extraction method
+	serverInfo, err := c.ExtractServerInfoFromChallenge(ctx)
+	if err != nil {
+		// If unified extraction fails, create minimal server info from session
+		log.Debug("Unified server info extraction failed, creating minimal server info", svc1log.SafeParam("error", err))
+		
+		if c.session != nil {
+			c.serverInfo = &commonprotocolfern.SmbServerInfo{
+				SupportedSmbVersions: []commonprotocolfern.SmbVersion{
+					commonprotocolfern.SmbVersionSmb302,
+					commonprotocolfern.SmbVersionSmb30,
+					commonprotocolfern.SmbVersionSmb21,
+					commonprotocolfern.SmbVersionSmb20,
+				},
+			}
+			signingRequired := c.session.IsSigningRequired()
+			c.serverInfo.SigningRequired = &signingRequired
+		}
+		return nil
+	}
+	
+	// Store the extracted server info
+	c.serverInfo = serverInfo
 	return nil
 }
 

--- a/internal/protocol/smb/client.go
+++ b/internal/protocol/smb/client.go
@@ -8,10 +8,39 @@ import (
 
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	"github.com/jfjallid/go-smb/gss"
+	"github.com/jfjallid/go-smb/ntlmssp"
 	gosmb "github.com/jfjallid/go-smb/smb"
+	"github.com/jfjallid/go-smb/smb/encoder"
 	"github.com/jfjallid/go-smb/spnego"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
+
+// CapturingNTLM wraps the built-in NTLM initiator and captures the server's challenge
+type CapturingNTLM struct {
+	*spnego.NTLMInitiator
+	LastChallenge     *ntlmssp.Challenge
+	LastChallengeData []byte
+}
+
+func (c *CapturingNTLM) InitSecContext(inputToken []byte) ([]byte, error) {
+	// When the server replies to our first token, inputToken contains a SPNEGO NegTokenResp
+	// whose ResponseToken is the NTLM Type 2 CHALLENGE.
+	if len(inputToken) > 0 {
+		var resp gss.NegTokenResp
+		var meta encoder.Metadata
+		if err := resp.UnmarshalBinary(inputToken, &meta); err == nil && len(resp.ResponseToken) > 0 {
+			// Store the raw challenge data for unified processing
+			c.LastChallengeData = resp.ResponseToken
+
+			ch := ntlmssp.NewChallenge()
+			if err := encoder.Unmarshal(resp.ResponseToken, ch); err == nil {
+				c.LastChallenge = &ch
+			}
+		}
+	}
+	return c.NTLMInitiator.InitSecContext(inputToken)
+}
 
 // Client represents a unified SMB client that provides base functionality
 // for both enumeration and pentest operations
@@ -28,6 +57,7 @@ type Client struct {
 	session         *gosmb.Connection
 	isConnected     bool
 	isAuthenticated bool
+	capturingNTLM   *CapturingNTLM
 	serverInfo      *commonprotocolfern.SmbServerInfo
 	skipServerInfo  bool // If true, skip automatic server info extraction on connect
 }
@@ -90,20 +120,20 @@ func (c *Client) Connect() error {
 // This works even when authentication fails, as the challenge contains server metadata
 func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*commonprotocolfern.SmbServerInfo, error) {
 	log := svc1log.FromContext(ctx)
-	log.Debug("Starting ExtractServerInfoFromChallenge using go-smb NTLM challenge", svc1log.SafeParam("host", c.Host), svc1log.SafeParam("port", c.Port))
+	log.Debug("Starting ExtractServerInfoFromChallenge using unified NTLM challenge parser", svc1log.SafeParam("host", c.Host), svc1log.SafeParam("port", c.Port))
 
-	// If we don't have an existing session, try to establish one with null session
-	if c.session == nil {
-		// Set up null session temporarily
+	// If we don't have captured NTLM challenge, try to establish connection to get it
+	if c.capturingNTLM == nil || c.capturingNTLM.LastChallengeData == nil {
+		// Set up null session temporarily to capture NTLM challenge
 		originalNullSession := c.UseNullSession
 		c.UseNullSession = true
 
 		err := c.ConnectWithContext(ctx)
 		if err != nil {
 			log.Debug("Failed to establish null session for server info extraction", svc1log.SafeParam("error", err.Error()))
-			// Even if connection failed, check if we got a session with target info
-			if c.session == nil {
-				return nil, fmt.Errorf("failed to establish session for server info extraction: %v", err)
+			// Even if connection failed, check if we captured challenge data
+			if c.capturingNTLM == nil || c.capturingNTLM.LastChallengeData == nil {
+				return nil, fmt.Errorf("failed to capture NTLM challenge for server info extraction: %v", err)
 			}
 		}
 
@@ -111,49 +141,31 @@ func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*commonpro
 		c.UseNullSession = originalNullSession
 	}
 
-	// Extract target info from the NTLM challenge in current session
-	targetInfo := c.session.GetTargetInfo()
-	if targetInfo == nil {
-		log.Debug("No target info available from NTLM challenge")
-		return nil, fmt.Errorf("no target info available from NTLM challenge")
+	// Check if we have captured challenge data
+	if c.capturingNTLM == nil || c.capturingNTLM.LastChallengeData == nil {
+		return nil, fmt.Errorf("no NTLM challenge data available for server info extraction")
 	}
 
-	log.Debug("Successfully retrieved target info from NTLM challenge",
-		svc1log.SafeParam("dnsComputer", targetInfo.DnsComputerName),
-		svc1log.SafeParam("dnsDomain", targetInfo.DnsDomainName),
-		svc1log.SafeParam("nbComputer", targetInfo.NBComputerName),
-		svc1log.SafeParam("nbDomain", targetInfo.NBDomainName),
-		svc1log.SafeParam("osValue", fmt.Sprintf("0x%016x", targetInfo.OS)),
-		svc1log.SafeParam("guessedOS", targetInfo.GuessedOSVersion))
-
-	// Use centralized NTLM parsing to convert go-smb TargetInfo to unified server info
-	goSMBTargetInfo := &ntlm.GoSMBTargetInfo{
-		DNSComputerName:  targetInfo.DnsComputerName,
-		DNSDomainName:    targetInfo.DnsDomainName,
-		NBComputerName:   targetInfo.NBComputerName,
-		NBDomainName:     targetInfo.NBDomainName,
-		OS:               targetInfo.OS,
-		GuessedOSVersion: targetInfo.GuessedOSVersion,
-	}
-
-	// Use centralized NTLM parsing to get base server info
-	ntlmInfo, err := ntlm.ExtractServerInfoFromGoSMBTargetInfo(goSMBTargetInfo, log)
+	// Use unified NTLM challenge parser
+	ntlmInfo, err := ntlm.ExtractServerInfoFromChallenge(c.capturingNTLM.LastChallengeData, log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract server info from go-smb target info: %v", err)
+		return nil, fmt.Errorf("failed to extract server info from NTLM challenge: %v", err)
 	}
 
 	// Convert to SMB-specific server info with additional fields
 	smbInfo := convertNtlmToSmbServerInfo(ntlmInfo)
 
-	// Set signing requirement based on actual session state
-	signingRequired := c.session.IsSigningRequired()
-	smbInfo.SigningRequired = &signingRequired
+	// Set signing requirement based on actual session state if available
+	if c.session != nil {
+		signingRequired := c.session.IsSigningRequired()
+		smbInfo.SigningRequired = &signingRequired
+	}
 
 	// SMB version detection - would need actual negotiation data
 	smbInfo.SmbVersion = nil                                         // Set when we have negotiation info
 	smbInfo.SupportedSmbVersions = []commonprotocolfern.SmbVersion{} // Set when we have negotiation info
 
-	log.Debug("Successfully extracted server info from NTLM challenge",
+	log.Debug("Successfully extracted server info from unified NTLM challenge parser",
 		svc1log.SafeParam("parsedOsVersion", smbInfo.ParsedOsVersion))
 
 	return smbInfo, nil
@@ -162,11 +174,14 @@ func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*commonpro
 // GetDomainFromServerInfo extracts domain information from server info for authentication
 func (c *Client) GetDomainFromServerInfo(ctx context.Context) string {
 	serverInfo, err := c.ExtractServerInfoFromChallenge(ctx)
-	if err != nil || serverInfo == nil {
+	if err != nil || serverInfo == nil || serverInfo.TargetInfo == nil {
 		return ""
 	}
-	if serverInfo.Domain != nil {
-		return *serverInfo.Domain
+	if serverInfo.TargetInfo.DnsDomainName != nil {
+		return *serverInfo.TargetInfo.DnsDomainName
+	}
+	if serverInfo.TargetInfo.NetbiosDomainName != nil {
+		return *serverInfo.TargetInfo.NetbiosDomainName
 	}
 	return ""
 }
@@ -187,18 +202,20 @@ func (c *Client) ConnectWithContext(ctx context.Context) error {
 	}
 
 	// Set up authentication based on configuration
+	var ntlmInitiator *spnego.NTLMInitiator
+
 	if c.UseNullSession {
-		options.Initiator = &spnego.NTLMInitiator{
+		ntlmInitiator = &spnego.NTLMInitiator{
 			NullSession: true,
 		}
 	} else if c.UseAnonymous {
-		options.Initiator = &spnego.NTLMInitiator{
+		ntlmInitiator = &spnego.NTLMInitiator{
 			User:     "",
 			Password: "",
 		}
 	} else if c.Username != "" || c.Password != "" || c.NTLMHash != "" {
 		// Set up NTLM authentication with password or hash
-		ntlmInitiator := &spnego.NTLMInitiator{
+		ntlmInitiator = &spnego.NTLMInitiator{
 			User:      c.Username,
 			Domain:    c.Domain,
 			LocalUser: false, // Don't assume local user
@@ -225,14 +242,18 @@ func (c *Client) ConnectWithContext(ctx context.Context) error {
 		} else {
 			ntlmInitiator.Password = c.Password
 		}
-
-		options.Initiator = ntlmInitiator
 	} else {
 		// Default to null session if no credentials provided
-		options.Initiator = &spnego.NTLMInitiator{
+		ntlmInitiator = &spnego.NTLMInitiator{
 			NullSession: true,
 		}
 	}
+
+	// Wrap the NTLM initiator with our capturing wrapper to get raw challenge data
+	c.capturingNTLM = &CapturingNTLM{
+		NTLMInitiator: ntlmInitiator,
+	}
+	options.Initiator = c.capturingNTLM
 
 	// Attempt connection
 	session, err := gosmb.NewConnection(options)
@@ -419,10 +440,6 @@ func (c *Client) extractServerInfoWithContext(ctx context.Context) error {
 	}
 
 	signingRequired := c.session.IsSigningRequired()
-	capabilities := []string{"DFS", "Leasing"}
-	if signingRequired {
-		capabilities = append(capabilities, "Signing")
-	}
 
 	// If we already have server info with nested structures (from ExtractServerInfoFromChallenge),
 	// preserve them and only add/update the connection-specific details
@@ -432,7 +449,6 @@ func (c *Client) extractServerInfoWithContext(ctx context.Context) error {
 
 	// Update connection-specific fields
 	c.serverInfo.SigningRequired = &signingRequired
-	c.serverInfo.Capabilities = capabilities
 	c.serverInfo.SupportedSmbVersions = []commonprotocolfern.SmbVersion{
 		commonprotocolfern.SmbVersionSmb302,
 		commonprotocolfern.SmbVersionSmb30,
@@ -443,44 +459,13 @@ func (c *Client) extractServerInfoWithContext(ctx context.Context) error {
 	// Extract detailed information from NTLM target info using centralized parsing
 	targetInfo := c.session.GetTargetInfo()
 	if targetInfo != nil {
-		// Convert go-smb TargetInfo to our centralized format
-		goSMBTargetInfo := &ntlm.GoSMBTargetInfo{
-			DNSComputerName:  targetInfo.DnsComputerName,
-			DNSDomainName:    targetInfo.DnsDomainName,
-			NBComputerName:   targetInfo.NBComputerName,
-			NBDomainName:     targetInfo.NBDomainName,
-			OS:               targetInfo.OS,
-			GuessedOSVersion: targetInfo.GuessedOSVersion,
-		}
-
 		log := svc1log.FromContext(ctx)
-		log.Debug("Raw TargetInfo from go-smb",
+		log.Debug("TargetInfo available from go-smb session",
 			svc1log.SafeParam("dnsComputer", targetInfo.DnsComputerName),
 			svc1log.SafeParam("dnsDomain", targetInfo.DnsDomainName),
 			svc1log.SafeParam("nbComputer", targetInfo.NBComputerName),
-			svc1log.SafeParam("nbDomain", targetInfo.NBDomainName),
-			svc1log.SafeParam("osValue", fmt.Sprintf("0x%016x", targetInfo.OS)),
-			svc1log.SafeParam("guessedOS", targetInfo.GuessedOSVersion))
-
-		// Use centralized NTLM parsing to get base server info
-		ntlmInfo, err := ntlm.ExtractServerInfoFromGoSMBTargetInfo(goSMBTargetInfo, log)
-		if err != nil {
-			log.Warn("Failed to extract server info from go-smb target info", svc1log.SafeParam("error", err))
-		} else {
-			// Convert to SMB-specific server info and merge with existing info
-			smbInfoFromNtlm := convertNtlmToSmbServerInfo(ntlmInfo)
-
-			// Only set fields if they're not already set (preserving any previously set values)
-			if c.serverInfo.ParsedOsVersion == nil {
-				c.serverInfo.ParsedOsVersion = smbInfoFromNtlm.ParsedOsVersion
-			}
-			if c.serverInfo.TargetInfo == nil {
-				c.serverInfo.TargetInfo = smbInfoFromNtlm.TargetInfo
-			}
-			if c.serverInfo.OsInfo == nil {
-				c.serverInfo.OsInfo = smbInfoFromNtlm.OsInfo
-			}
-		}
+			svc1log.SafeParam("nbDomain", targetInfo.NBDomainName))
+		// Note: Detailed server info extraction is now handled by ExtractServerInfoFromChallenge
 	} else {
 		log := svc1log.FromContext(ctx)
 		log.Warn("NTLM target info not available")

--- a/internal/protocol/smb/client.go
+++ b/internal/protocol/smb/client.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Method-Security/networkscan/internal/common"
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	gosmb "github.com/jfjallid/go-smb/smb"
 	"github.com/jfjallid/go-smb/spnego"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -27,32 +28,8 @@ type Client struct {
 	session         *gosmb.Connection
 	isConnected     bool
 	isAuthenticated bool
-	serverInfo      *ServerInfo
-}
-
-// ServerInfo contains basic server information extracted from SMB connection
-type ServerInfo struct {
-	ServerName        string
-	Domain            string
-	NetBIOSDomainName string
-	OSVersion         string
-	RawOSVersion      string
-	ServerType        string
-	Capabilities      []string
-	SigningRequired   bool
-	SupportedVersions []string
-}
-
-// ShareInfo represents SMB share information
-type ShareInfo struct {
-	Name            string
-	Type            string
-	Accessible      bool
-	Access          string
-	AnonymousAccess bool
-	GuestAccess     bool
-	Hidden          bool
-	Comment         string
+	serverInfo      *commonprotocolfern.SmbServerInfo
+	skipServerInfo  bool // If true, skip automatic server info extraction on connect
 }
 
 // NewClient creates a new SMB client with the given configuration
@@ -111,7 +88,7 @@ func (c *Client) Connect() error {
 
 // ExtractServerInfoFromChallenge attempts to extract server information from NTLM challenge
 // This works even when authentication fails, as the challenge contains server metadata
-func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*ServerInfo, error) {
+func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*commonprotocolfern.SmbServerInfo, error) {
 	log := svc1log.FromContext(ctx)
 	log.Debug("Starting ExtractServerInfoFromChallenge using go-smb NTLM challenge", svc1log.SafeParam("host", c.Host), svc1log.SafeParam("port", c.Port))
 
@@ -141,55 +118,45 @@ func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*ServerInf
 		return nil, fmt.Errorf("no target info available from NTLM challenge")
 	}
 
-	log.Debug("Successfully retrieved target info from NTLM challenge")
+	log.Debug("Successfully retrieved target info from NTLM challenge",
+		svc1log.SafeParam("dnsComputer", targetInfo.DnsComputerName),
+		svc1log.SafeParam("dnsDomain", targetInfo.DnsDomainName),
+		svc1log.SafeParam("nbComputer", targetInfo.NBComputerName),
+		svc1log.SafeParam("nbDomain", targetInfo.NBDomainName),
+		svc1log.SafeParam("osValue", fmt.Sprintf("0x%016x", targetInfo.OS)),
+		svc1log.SafeParam("guessedOS", targetInfo.GuessedOSVersion))
 
-	// Convert go-smb TargetInfo to our ServerInfo structure
-	serverInfo := &ServerInfo{
-		SigningRequired: c.session.IsSigningRequired(),
+	// Use centralized NTLM parsing to convert go-smb TargetInfo to unified server info
+	goSMBTargetInfo := &ntlm.GoSMBTargetInfo{
+		DNSComputerName:  targetInfo.DnsComputerName,
+		DNSDomainName:    targetInfo.DnsDomainName,
+		NBComputerName:   targetInfo.NBComputerName,
+		NBDomainName:     targetInfo.NBDomainName,
+		OS:               targetInfo.OS,
+		GuessedOSVersion: targetInfo.GuessedOSVersion,
 	}
 
-	// Extract server information from target info
-	if targetInfo.DnsComputerName != "" {
-		serverInfo.ServerName = targetInfo.DnsComputerName
-	} else if targetInfo.NBComputerName != "" {
-		serverInfo.ServerName = targetInfo.NBComputerName
+	// Use centralized NTLM parsing to get base server info
+	ntlmInfo, err := ntlm.ExtractServerInfoFromGoSMBTargetInfo(goSMBTargetInfo, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract server info from go-smb target info: %v", err)
 	}
 
-	if targetInfo.DnsDomainName != "" {
-		serverInfo.Domain = targetInfo.DnsDomainName
-	} else if targetInfo.NBDomainName != "" {
-		serverInfo.Domain = targetInfo.NBDomainName
-	}
+	// Convert to SMB-specific server info with additional fields
+	smbInfo := convertNtlmToSmbServerInfo(ntlmInfo)
 
-	// Always set NetBIOS domain name if available
-	if targetInfo.NBDomainName != "" {
-		serverInfo.NetBIOSDomainName = targetInfo.NBDomainName
-	}
+	// Set signing requirement based on actual session state
+	signingRequired := c.session.IsSigningRequired()
+	smbInfo.SigningRequired = &signingRequired
 
-	// Parse and enhance the OS version
-	if targetInfo.GuessedOSVersion != "" {
-		serverInfo.RawOSVersion = targetInfo.GuessedOSVersion
-		serverInfo.OSVersion = parseWindowsVersion(targetInfo.GuessedOSVersion)
-	} else {
-		serverInfo.OSVersion = "Windows Server"
-	}
-
-	// Set capabilities based on actual server state
-	var capabilities []string
-	if serverInfo.SigningRequired {
-		capabilities = append(capabilities, "Signing")
-	}
-	serverInfo.Capabilities = capabilities
-
-	// SupportedVersions should be extracted from actual SMB negotiation, not hardcoded
-	serverInfo.SupportedVersions = []string{}
+	// SMB version detection - would need actual negotiation data
+	smbInfo.SmbVersion = nil                                         // Set when we have negotiation info
+	smbInfo.SupportedSmbVersions = []commonprotocolfern.SmbVersion{} // Set when we have negotiation info
 
 	log.Debug("Successfully extracted server info from NTLM challenge",
-		svc1log.SafeParam("serverName", serverInfo.ServerName),
-		svc1log.SafeParam("domain", serverInfo.Domain),
-		svc1log.SafeParam("osVersion", serverInfo.OSVersion))
+		svc1log.SafeParam("parsedOsVersion", smbInfo.ParsedOsVersion))
 
-	return serverInfo, nil
+	return smbInfo, nil
 }
 
 // GetDomainFromServerInfo extracts domain information from server info for authentication
@@ -198,7 +165,10 @@ func (c *Client) GetDomainFromServerInfo(ctx context.Context) string {
 	if err != nil || serverInfo == nil {
 		return ""
 	}
-	return serverInfo.Domain
+	if serverInfo.Domain != nil {
+		return *serverInfo.Domain
+	}
+	return ""
 }
 
 // ConnectWithContext establishes connection to SMB server and performs authentication with context
@@ -236,7 +206,7 @@ func (c *Client) ConnectWithContext(ctx context.Context) error {
 
 		// Use hash if available, otherwise use password
 		if c.NTLMHash != "" {
-			processor := common.NewNTLMHashProcessor()
+			processor := ntlm.NewHashProcessor()
 			ntHash, err := processor.ProcessHashForSMB(c.NTLMHash)
 			if err != nil {
 				return fmt.Errorf("failed to process NTLM hash for SMB: %v", err)
@@ -267,8 +237,8 @@ func (c *Client) ConnectWithContext(ctx context.Context) error {
 	// Attempt connection
 	session, err := gosmb.NewConnection(options)
 	if err != nil {
-		// Even if connection failed, try to extract server info from NTLM challenge
-		if session != nil {
+		// Even if connection failed, try to extract server info from NTLM challenge (unless skipped)
+		if session != nil && !c.skipServerInfo {
 			c.session = session
 			// Use the existing server info extraction logic
 			if err := c.extractServerInfoWithContext(ctx); err != nil {
@@ -289,9 +259,11 @@ func (c *Client) ConnectWithContext(ctx context.Context) error {
 		svc1log.SafeParam("port", c.Port),
 		svc1log.SafeParam("authenticated", c.isAuthenticated))
 
-	// Extract server information
-	if err := c.extractServerInfoWithContext(ctx); err != nil {
-		log.Warn("Failed to extract server info", svc1log.SafeParam("error", err))
+	// Extract server information (unless skipped)
+	if !c.skipServerInfo {
+		if err := c.extractServerInfoWithContext(ctx); err != nil {
+			log.Warn("Failed to extract server info", svc1log.SafeParam("error", err))
+		}
 	}
 
 	return nil
@@ -308,8 +280,18 @@ func (c *Client) IsAuthenticated() bool {
 }
 
 // GetServerInfo returns extracted server information
-func (c *Client) GetServerInfo() *ServerInfo {
+func (c *Client) GetServerInfo() *commonprotocolfern.SmbServerInfo {
 	return c.serverInfo
+}
+
+// SetServerInfo sets server info from external source (to avoid redundant extraction)
+func (c *Client) SetServerInfo(serverInfo *commonprotocolfern.SmbServerInfo) {
+	c.serverInfo = serverInfo
+}
+
+// SkipServerInfoExtraction configures whether to skip automatic server info extraction on connect
+func (c *Client) SkipServerInfoExtraction(skip bool) {
+	c.skipServerInfo = skip
 }
 
 // TestCredentials tests if the provided credentials are valid
@@ -354,49 +336,64 @@ func (c *Client) TestCredentials(username, password, domain string) (bool, strin
 }
 
 // EnumerateShares lists available shares using TreeConnect testing
-func (c *Client) EnumerateShares() ([]*ShareInfo, error) {
+func (c *Client) EnumerateShares() ([]*commonprotocolfern.SmbShare, error) {
 	return c.EnumerateSharesWithContext(context.Background())
 }
 
 // EnumerateSharesWithContext lists available shares using TreeConnect testing with context
-func (c *Client) EnumerateSharesWithContext(ctx context.Context) ([]*ShareInfo, error) {
+func (c *Client) EnumerateSharesWithContext(ctx context.Context) ([]*commonprotocolfern.SmbShare, error) {
 	if !c.isConnected {
 		return nil, fmt.Errorf("not connected to SMB server")
 	}
 
 	commonShares := []string{"C$", "D$", "E$", "ADMIN$", "IPC$", "PRINT$", "FAX$", "SYSVOL", "NETLOGON", "Users", "Public", "Share", "Data", "Files", "Shared", "Transfer", "Backup", "Archive", "Home", "Homes"}
-	var shares []*ShareInfo
+	var shares []*commonprotocolfern.SmbShare
 
 	log := svc1log.FromContext(ctx)
 	log.Info("Testing common share names for accessibility", svc1log.SafeParam("shareCount", len(commonShares)))
 
 	for _, shareName := range commonShares {
-		shareInfo := &ShareInfo{
+		shareType := c.determineShareType(shareName)
+		accessible := false
+		access := commonprotocolfern.ShareAccessNoAccess
+		anonymousAccess := c.UseAnonymous || c.UseNullSession
+		guestAccess := false
+		hidden := strings.HasSuffix(shareName, "$")
+
+		shareInfo := &commonprotocolfern.SmbShare{
 			Name:            shareName,
-			Type:            c.determineShareType(shareName),
-			Accessible:      false,
-			Access:          "No Access",
-			AnonymousAccess: c.UseAnonymous || c.UseNullSession,
-			GuestAccess:     false,
-			Hidden:          strings.HasSuffix(shareName, "$"),
+			Type:            shareType,
+			Accessible:      &accessible,
+			Access:          &access,
+			AnonymousAccess: &anonymousAccess,
+			GuestAccess:     &guestAccess,
+			Hidden:          &hidden,
 		}
 
 		// Test share accessibility
 		err := c.session.TreeConnect(shareName)
 		if err == nil {
 			// Share is accessible
-			shareInfo.Accessible = true
-			shareInfo.Access = "Read" // Assume read access if TreeConnect succeeded
+			accessible = true
+			access = commonprotocolfern.ShareAccessReadOnly // Assume read access if TreeConnect succeeded
+			shareInfo.Accessible = &accessible
+			shareInfo.Access = &access
 			_ = c.session.TreeDisconnect(shareName)
-
 		}
 
 		shares = append(shares, shareInfo)
 	}
 
+	accessibleCount := 0
+	for _, share := range shares {
+		if share.Accessible != nil && *share.Accessible {
+			accessibleCount++
+		}
+	}
+
 	log.Info("Share enumeration completed",
 		svc1log.SafeParam("totalShares", len(shares)),
-		svc1log.SafeParam("accessibleShares", c.countAccessibleShares(shares)))
+		svc1log.SafeParam("accessibleShares", accessibleCount))
 	return shares, nil
 }
 
@@ -421,79 +418,100 @@ func (c *Client) extractServerInfoWithContext(ctx context.Context) error {
 		return fmt.Errorf("no active session")
 	}
 
-	c.serverInfo = &ServerInfo{
-		SigningRequired:   c.session.IsSigningRequired(),
-		Capabilities:      []string{"DFS", "Leasing"},
-		SupportedVersions: []string{"SMB3.0.2", "SMB3.0", "SMB2.1", "SMB2.0"},
+	signingRequired := c.session.IsSigningRequired()
+	capabilities := []string{"DFS", "Leasing"}
+	if signingRequired {
+		capabilities = append(capabilities, "Signing")
 	}
 
-	if c.session.IsSigningRequired() {
-		c.serverInfo.Capabilities = append(c.serverInfo.Capabilities, "Signing")
+	// If we already have server info with nested structures (from ExtractServerInfoFromChallenge),
+	// preserve them and only add/update the connection-specific details
+	if c.serverInfo == nil {
+		c.serverInfo = &commonprotocolfern.SmbServerInfo{}
 	}
 
-	// Extract detailed information from NTLM target info
+	// Update connection-specific fields
+	c.serverInfo.SigningRequired = &signingRequired
+	c.serverInfo.Capabilities = capabilities
+	c.serverInfo.SupportedSmbVersions = []commonprotocolfern.SmbVersion{
+		commonprotocolfern.SmbVersionSmb302,
+		commonprotocolfern.SmbVersionSmb30,
+		commonprotocolfern.SmbVersionSmb21,
+		commonprotocolfern.SmbVersionSmb20,
+	}
+
+	// Extract detailed information from NTLM target info using centralized parsing
 	targetInfo := c.session.GetTargetInfo()
 	if targetInfo != nil {
-		// Use DNS domain name if available, fallback to NetBIOS domain
-		if targetInfo.DnsDomainName != "" {
-			c.serverInfo.Domain = targetInfo.DnsDomainName
-		} else if targetInfo.NBDomainName != "" {
-			c.serverInfo.Domain = targetInfo.NBDomainName
-		}
-
-		// Always set NetBIOS domain name if available
-		if targetInfo.NBDomainName != "" {
-			c.serverInfo.NetBIOSDomainName = targetInfo.NBDomainName
-		}
-
-		// Use DNS computer name if available, fallback to NetBIOS computer name
-		if targetInfo.DnsComputerName != "" {
-			c.serverInfo.ServerName = targetInfo.DnsComputerName
-		} else if targetInfo.NBComputerName != "" {
-			c.serverInfo.ServerName = targetInfo.NBComputerName
-		}
-
-		// Parse and enhance the OS version
-		if targetInfo.GuessedOSVersion != "" {
-			c.serverInfo.RawOSVersion = targetInfo.GuessedOSVersion
-			c.serverInfo.OSVersion = parseWindowsVersion(targetInfo.GuessedOSVersion)
-		} else {
-			c.serverInfo.OSVersion = "Windows Server"
+		// Convert go-smb TargetInfo to our centralized format
+		goSMBTargetInfo := &ntlm.GoSMBTargetInfo{
+			DNSComputerName:  targetInfo.DnsComputerName,
+			DNSDomainName:    targetInfo.DnsDomainName,
+			NBComputerName:   targetInfo.NBComputerName,
+			NBDomainName:     targetInfo.NBDomainName,
+			OS:               targetInfo.OS,
+			GuessedOSVersion: targetInfo.GuessedOSVersion,
 		}
 
 		log := svc1log.FromContext(ctx)
-		log.Info("Extracted server info",
-			svc1log.SafeParam("server", c.serverInfo.ServerName),
-			svc1log.SafeParam("domain", c.serverInfo.Domain),
-			svc1log.SafeParam("os", c.serverInfo.OSVersion))
+		log.Debug("Raw TargetInfo from go-smb",
+			svc1log.SafeParam("dnsComputer", targetInfo.DnsComputerName),
+			svc1log.SafeParam("dnsDomain", targetInfo.DnsDomainName),
+			svc1log.SafeParam("nbComputer", targetInfo.NBComputerName),
+			svc1log.SafeParam("nbDomain", targetInfo.NBDomainName),
+			svc1log.SafeParam("osValue", fmt.Sprintf("0x%016x", targetInfo.OS)),
+			svc1log.SafeParam("guessedOS", targetInfo.GuessedOSVersion))
+
+		// Use centralized NTLM parsing to get base server info
+		ntlmInfo, err := ntlm.ExtractServerInfoFromGoSMBTargetInfo(goSMBTargetInfo, log)
+		if err != nil {
+			log.Warn("Failed to extract server info from go-smb target info", svc1log.SafeParam("error", err))
+		} else {
+			// Convert to SMB-specific server info and merge with existing info
+			smbInfoFromNtlm := convertNtlmToSmbServerInfo(ntlmInfo)
+
+			// Only set fields if they're not already set (preserving any previously set values)
+			if c.serverInfo.ParsedOsVersion == nil {
+				c.serverInfo.ParsedOsVersion = smbInfoFromNtlm.ParsedOsVersion
+			}
+			if c.serverInfo.TargetInfo == nil {
+				c.serverInfo.TargetInfo = smbInfoFromNtlm.TargetInfo
+			}
+			if c.serverInfo.OsInfo == nil {
+				c.serverInfo.OsInfo = smbInfoFromNtlm.OsInfo
+			}
+		}
 	} else {
-		c.serverInfo.OSVersion = "Windows Server"
 		log := svc1log.FromContext(ctx)
 		log.Warn("NTLM target info not available")
 	}
+
+	log := svc1log.FromContext(ctx)
+	log.Info("Extracted server info",
+		svc1log.SafeParam("parsedOsVersion", c.serverInfo.ParsedOsVersion))
 
 	return nil
 }
 
 // determineShareType determines the share type based on share name patterns
-func (c *Client) determineShareType(shareName string) string {
+func (c *Client) determineShareType(shareName string) commonprotocolfern.ShareType {
 	switch {
 	case shareName == "IPC$":
-		return "IPC"
+		return commonprotocolfern.ShareTypeIpc
 	case shareName == "PRINT$" || shareName == "FAX$":
-		return "Print"
+		return commonprotocolfern.ShareTypePrint
 	case strings.HasSuffix(shareName, "$"):
-		return "Disk" // Administrative shares
+		return commonprotocolfern.ShareTypeDisk // Administrative shares
 	default:
-		return "Disk" // Regular disk shares
+		return commonprotocolfern.ShareTypeDisk // Regular disk shares
 	}
 }
 
 // countAccessibleShares counts the number of accessible shares
-func (c *Client) countAccessibleShares(shares []*ShareInfo) int {
+func (c *Client) countAccessibleShares(shares []*commonprotocolfern.SmbShare) int {
 	count := 0
 	for _, share := range shares {
-		if share.Accessible {
+		if share.Accessible != nil && *share.Accessible {
 			count++
 		}
 	}
@@ -506,4 +524,20 @@ func (c *Client) GetSMBSession() (*gosmb.Connection, error) {
 		return nil, fmt.Errorf("no active SMB session")
 	}
 	return c.session, nil
+}
+
+// convertNtlmToSmbServerInfo converts NtlmServerInfo to SmbServerInfo, preserving nested structures
+func convertNtlmToSmbServerInfo(ntlmInfo *commonprotocolfern.NtlmServerInfo) *commonprotocolfern.SmbServerInfo {
+	return &commonprotocolfern.SmbServerInfo{
+		ParsedOsVersion:      ntlmInfo.ParsedOsVersion,
+		SigningRequired:      ntlmInfo.SigningRequired,
+		TargetInfo:           ntlmInfo.TargetInfo,
+		OsInfo:               ntlmInfo.OsInfo,
+		SmbVersion:           nil,                               // SMB-specific field, set separately
+		SupportedSmbVersions: []commonprotocolfern.SmbVersion{}, // SMB-specific field, set separately
+		SigningEnabled:       nil,                               // SMB-specific field, set separately
+		EncryptionSupported:  nil,                               // SMB-specific field, set separately
+		EncryptionRequired:   nil,                               // SMB-specific field, set separately
+		LanManagerVersion:    nil,                               // SMB-specific field, set separately
+	}
 }

--- a/internal/protocol/smb/helpers.go
+++ b/internal/protocol/smb/helpers.go
@@ -27,7 +27,7 @@ func MapProtocolVersionToEnum(version string) (commonprotocolfern.SmbVersion, bo
 // ConnectionResult holds the result of a connection test
 type ConnectionResult struct {
 	Client     *Client
-	ServerInfo *ServerInfo
+	ServerInfo *commonprotocolfern.SmbServerInfo
 	Success    bool
 	Error      error
 }

--- a/internal/protocol/smb/sam.go
+++ b/internal/protocol/smb/sam.go
@@ -17,7 +17,7 @@ import (
 	"unicode/utf16"
 
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
-	"github.com/Method-Security/networkscan/internal/common"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	"github.com/jfjallid/go-smb/smb/dcerpc/msrrp"
 	"github.com/jfjallid/go-smb/smb/encoder"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -504,7 +504,7 @@ func DumpSAM(ctx context.Context, rpccon *msrrp.RPCCon, hKey []byte, modifyDacl 
 				continue
 			}
 			samSecret.NtHash = fmt.Sprintf("%x", hash)
-			lmHash := common.StandardLMHash // Standard empty LM hash
+			lmHash := ntlm.StandardLMHash // Standard empty LM hash
 			samSecret.LmHash = &lmHash
 		}
 

--- a/internal/protocol/smb/windows.go
+++ b/internal/protocol/smb/windows.go
@@ -1,10 +1,5 @@
 package smb
 
-import (
-	"fmt"
-	"regexp"
-)
-
 // Windows OS version constants (byte values for crypto operations)
 const (
 	WinUnknown      byte = 0x00
@@ -24,97 +19,6 @@ const (
 	WinServer2019   byte = 0x16
 	WinServer2022   byte = 0x17
 )
-
-// WindowsBuildMapping maps Windows build numbers to human-readable versions
-var WindowsBuildMapping = map[string]string{
-	// Windows Server builds
-	"20348": "Windows Server 2022",
-	"19041": "Windows Server 2022 (Insider)",
-	"17763": "Windows Server 2019",
-	"14393": "Windows Server 2016",
-	"10586": "Windows Server 2016 (Technical Preview)",
-	"9600":  "Windows Server 2012 R2",
-	"9200":  "Windows Server 2012",
-	"7601":  "Windows Server 2008 R2 SP1 / Windows 7 SP1",
-	"6002":  "Windows Server 2008 SP2 / Windows Vista SP2",
-	"6001":  "Windows Server 2008 SP1 / Windows Vista SP1",
-	"6000":  "Windows Server 2008 / Windows Vista",
-
-	// Windows 11 builds
-	"22631": "Windows 11 23H2",
-	"22621": "Windows 11 22H2",
-	"22000": "Windows 11 21H2",
-
-	// Windows 10 builds
-	"19045": "Windows 10 22H2",
-	"19044": "Windows 10 21H2",
-	"19043": "Windows 10 21H1",
-	"19042": "Windows 10 20H2",
-	"18363": "Windows 10 1909",
-	"18362": "Windows 10 1903",
-	"17134": "Windows 10 1803",
-	"16299": "Windows 10 1709",
-	"15063": "Windows 10 1703",
-	"10240": "Windows 10 RTM",
-
-	// Windows 8/8.1
-	"9431": "Windows 8.1 Update 1",
-
-	// Windows 7 (additional builds)
-	"7600": "Windows 7 RTM",
-}
-
-// parseWindowsVersion extracts and enhances Windows version information
-func parseWindowsVersion(rawOSVersion string) string {
-	if rawOSVersion == "" {
-		return "Windows Server"
-	}
-
-	// Extract build number using regex
-	buildRegex := regexp.MustCompile(`Build (\d+)`)
-	matches := buildRegex.FindStringSubmatch(rawOSVersion)
-
-	if len(matches) > 1 {
-		buildNumber := matches[1]
-
-		// Look up human-readable version
-		if readableVersion, exists := WindowsBuildMapping[buildNumber]; exists {
-			return readableVersion
-		}
-
-		// If not found, try to classify by build number ranges
-		return classifyWindowsByBuildNumber(buildNumber, rawOSVersion)
-	}
-
-	// Fallback to original version if no build number found
-	return rawOSVersion
-}
-
-// classifyWindowsByBuildNumber classifies Windows versions by build number ranges
-func classifyWindowsByBuildNumber(buildNumber, rawVersion string) string {
-	build := parseInt(buildNumber)
-
-	switch {
-	case build >= 22000:
-		return fmt.Sprintf("Windows 11 (Build %s)", buildNumber)
-	case build >= 19000:
-		return fmt.Sprintf("Windows 10/Server 2019-2022 (Build %s)", buildNumber)
-	case build >= 17000:
-		return fmt.Sprintf("Windows 10/Server 2016-2019 (Build %s)", buildNumber)
-	case build >= 14000:
-		return fmt.Sprintf("Windows 10/Server 2016 (Build %s)", buildNumber)
-	case build >= 10000:
-		return fmt.Sprintf("Windows 10 (Build %s)", buildNumber)
-	case build >= 9000:
-		return fmt.Sprintf("Windows 8/Server 2012 (Build %s)", buildNumber)
-	case build >= 7000:
-		return fmt.Sprintf("Windows 7/Server 2008 (Build %s)", buildNumber)
-	case build >= 6000:
-		return fmt.Sprintf("Windows Vista/Server 2008 (Build %s)", buildNumber)
-	default:
-		return rawVersion // Return original if can't classify
-	}
-}
 
 // GetOSVersion determines Windows OS version byte constant from build and version info
 func GetOSVersion(currentBuild int, currentVersion float64, server bool) byte {
@@ -164,11 +68,4 @@ func GetOSVersion(currentBuild int, currentVersion float64, server bool) byte {
 // IsWin10After1607 checks if Windows version is Windows 10 Anniversary Update or later
 func IsWin10After1607(build int, version float64) (bool, error) {
 	return build >= 14393, nil
-}
-
-// parseInt safely converts string to int
-func parseInt(s string) int {
-	var result int
-	_, _ = fmt.Sscanf(s, "%d", &result)
-	return result
 }

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/authenticate.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/authenticate.go
@@ -1,0 +1,291 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+type Authenticate struct {
+	// sig - 8 bytes
+	Signature []byte
+	// message type - 4 bytes
+	MessageType uint32
+
+	// The LmChallenge Response can be v1 or v2
+	LmChallengeResponse *PayloadStruct // 8 bytes
+	LmV1Response        *LmV1Response
+	LmV2Response        *LmV2Response
+
+	// The NtChallengeResponse can be v1 or v2
+	NtChallengeResponseFields *PayloadStruct // 8 bytes
+	NtlmV1Response            *NtlmV1Response
+	NtlmV2Response            *NtlmV2Response
+
+	DomainName  *PayloadStruct // 8 bytes
+	UserName    *PayloadStruct // 8 bytes
+	Workstation *PayloadStruct // 8 bytes
+
+	// If the NTLMSSP_NEGOTIATE_KEY_EXCH flag is set in the neogitate flags then this will point to the offset in the payload
+	// with the key, otherwise it will have Len = 0. According to Davenport these bytes are optional (see Type3 message).
+	// The MS-NLMP docs do not mention this.
+	EncryptedRandomSessionKey *PayloadStruct // 8 bytes
+
+	/// MS-NLMP 2.2.1.3 - In connectionless mode, a NEGOTIATE structure that contains a set of bit flags (section 2.2.2.5) and represents the
+	// conclusion of negotiation—the choices the client has made from the options the server offered in the CHALLENGE_MESSAGE.
+	// In connection-oriented mode, a NEGOTIATE structure that contains the set of bit flags (section 2.2.2.5) negotiated in
+	// the previous messages.
+	NegotiateFlags uint32 // 4 bytes
+
+	// Version (8 bytes): A VERSION structure (section 2.2.2.10) that is present only when the NTLMSSP_NEGOTIATE_VERSION
+	// flag is set in the NegotiateFlags field. This structure is used for debugging purposes only. In normal protocol
+	// messages, it is ignored and does not affect the NTLM message processing.<9>
+	Version *VersionStruct
+
+	// The message integrity for the NTLM NEGOTIATE_MESSAGE, CHALLENGE_MESSAGE, and AUTHENTICATE_MESSAGE.<10>
+	Mic []byte // 16 bytes
+
+	// payload - variable
+	Payload []byte
+}
+
+func ParseAuthenticateMessage(body []byte, ntlmVersion int) (*Authenticate, error) {
+	am := new(Authenticate)
+
+	am.Signature = body[0:8]
+	if !bytes.Equal(am.Signature, []byte("NTLMSSP\x00")) {
+		return nil, errors.New("Invalid NTLM message signature")
+	}
+
+	am.MessageType = binary.LittleEndian.Uint32(body[8:12])
+	if am.MessageType != 3 {
+		return nil, errors.New("Invalid NTLM message type should be 0x00000003 for authenticate message")
+	}
+
+	var err error
+
+	am.LmChallengeResponse, err = ReadBytePayload(12, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if ntlmVersion == 2 {
+		am.LmV2Response = ReadLmV2Response(am.LmChallengeResponse.Payload)
+	} else {
+		am.LmV1Response = ReadLmV1Response(am.LmChallengeResponse.Payload)
+	}
+
+	am.NtChallengeResponseFields, err = ReadBytePayload(20, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check to see if this is a v1 or v2 response
+	if ntlmVersion == 2 {
+		am.NtlmV2Response, err = ReadNtlmV2Response(am.NtChallengeResponseFields.Payload)
+	} else {
+		am.NtlmV1Response, err = ReadNtlmV1Response(am.NtChallengeResponseFields.Payload)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	am.DomainName, err = ReadStringPayload(28, body)
+	if err != nil {
+		return nil, err
+	}
+
+	am.UserName, err = ReadStringPayload(36, body)
+	if err != nil {
+		return nil, err
+	}
+
+	am.Workstation, err = ReadStringPayload(44, body)
+	if err != nil {
+		return nil, err
+	}
+
+	lowestOffset := am.getLowestPayloadOffset()
+	offset := 52
+
+	// If the lowest payload offset is 52 then:
+	// The Session Key, flags, and OS Version structure are omitted. The data (payload) block in this case starts after the Workstation Name
+	// security buffer header, at offset 52. This form is seen in older Win9x-based systems. This is from the davenport notes about Type 3
+	// messages and this information does not seem to be present in the MS-NLMP document
+	if lowestOffset > 52 {
+		am.EncryptedRandomSessionKey, err = ReadBytePayload(offset, body)
+		if err != nil {
+			return nil, err
+		}
+		offset = offset + 8
+
+		am.NegotiateFlags = binary.LittleEndian.Uint32(body[offset : offset+4])
+		offset = offset + 4
+
+		// Version (8 bytes): A VERSION structure (section 2.2.2.10) that is present only when the NTLMSSP_NEGOTIATE_VERSION flag is set in the NegotiateFlags field. This structure is used for debugging purposes only. In normal protocol messages, it is ignored and does not affect the NTLM message processing.<9>
+		if NTLMSSP_NEGOTIATE_VERSION.IsSet(am.NegotiateFlags) {
+			am.Version, err = ReadVersionStruct(body[offset : offset+8])
+			if err != nil {
+				return nil, err
+			}
+			offset = offset + 8
+		}
+
+		// The MS-NLMP has this to say about the MIC
+		//   "An AUTHENTICATE_MESSAGE indicates the presence of a MIC field if the TargetInfo field has an AV_PAIR structure whose two fields are:
+		//   AvId == MsvAvFlags Value bit 0x2 == 1"
+		// However there is no TargetInfo structure in the Authenticate Message! There is one in the Challenge Message though. So I'm using
+		// a hack to check to see if there is a MIC. I look to see if there is room for the MIC before the payload starts. If so I assume
+		// there is a MIC and read it out.
+		var lowestOffset = am.getLowestPayloadOffset()
+		if lowestOffset > offset {
+			// MIC - 16 bytes
+			am.Mic = body[offset : offset+16]
+			offset = offset + 16
+		}
+	}
+
+	am.Payload = body[offset:]
+
+	return am, nil
+}
+
+func (a *Authenticate) ClientChallenge() (response []byte) {
+	if a.NtlmV2Response != nil {
+		response = a.NtlmV2Response.NtlmV2ClientChallenge.ChallengeFromClient
+	} else if a.NtlmV1Response != nil && NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY.IsSet(a.NegotiateFlags) {
+		response = a.LmV1Response.Response[0:8]
+	}
+
+	return response
+}
+
+func (a *Authenticate) getLowestPayloadOffset() int {
+	payloadStructs := [...]*PayloadStruct{a.LmChallengeResponse, a.NtChallengeResponseFields, a.DomainName, a.UserName, a.Workstation, a.EncryptedRandomSessionKey}
+
+	// Find the lowest offset value
+	lowest := 9999
+	for i := range payloadStructs {
+		p := payloadStructs[i]
+		if p != nil && p.Offset > 0 && int(p.Offset) < lowest {
+			lowest = int(p.Offset)
+		}
+	}
+
+	return lowest
+}
+
+func (a *Authenticate) Bytes() []byte {
+	payloadLen := int(a.LmChallengeResponse.Len + a.NtChallengeResponseFields.Len + a.DomainName.Len + a.UserName.Len + a.Workstation.Len + a.EncryptedRandomSessionKey.Len)
+	messageLen := 8 + 4 + 6*8 + 4 + 8 + 16
+	payloadOffset := uint32(messageLen)
+
+	messageBytes := make([]byte, 0, messageLen+payloadLen)
+	buffer := bytes.NewBuffer(messageBytes)
+
+	buffer.Write(a.Signature)
+
+	binary.Write(buffer, binary.LittleEndian, a.MessageType)
+
+	a.LmChallengeResponse.Offset = payloadOffset
+	payloadOffset += uint32(a.LmChallengeResponse.Len)
+	buffer.Write(a.LmChallengeResponse.Bytes())
+
+	a.NtChallengeResponseFields.Offset = payloadOffset
+	payloadOffset += uint32(a.NtChallengeResponseFields.Len)
+	buffer.Write(a.NtChallengeResponseFields.Bytes())
+
+	a.DomainName.Offset = payloadOffset
+	payloadOffset += uint32(a.DomainName.Len)
+	buffer.Write(a.DomainName.Bytes())
+
+	a.UserName.Offset = payloadOffset
+	payloadOffset += uint32(a.UserName.Len)
+	buffer.Write(a.UserName.Bytes())
+
+	a.Workstation.Offset = payloadOffset
+	payloadOffset += uint32(a.Workstation.Len)
+	buffer.Write(a.Workstation.Bytes())
+
+	a.EncryptedRandomSessionKey.Offset = payloadOffset
+	payloadOffset += uint32(a.EncryptedRandomSessionKey.Len)
+	buffer.Write(a.EncryptedRandomSessionKey.Bytes())
+
+	buffer.Write(Uint32ToBytes(a.NegotiateFlags))
+
+	if a.Version != nil {
+		buffer.Write(a.Version.Bytes())
+	} else {
+		buffer.Write(make([]byte, 8))
+	}
+
+	if a.Mic != nil {
+		buffer.Write(a.Mic)
+	} else {
+		buffer.Write(make([]byte, 16))
+	}
+
+	// Write out the payloads
+	buffer.Write(a.LmChallengeResponse.Payload)
+	buffer.Write(a.NtChallengeResponseFields.Payload)
+	buffer.Write(a.DomainName.Payload)
+	buffer.Write(a.UserName.Payload)
+	buffer.Write(a.Workstation.Payload)
+	buffer.Write(a.EncryptedRandomSessionKey.Payload)
+
+	return buffer.Bytes()
+}
+
+func (a *Authenticate) String() string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("Authenticate NTLM Message\n")
+	buffer.WriteString(fmt.Sprintf("Payload Offset: %d Length: %d\n", a.getLowestPayloadOffset(), len(a.Payload)))
+
+	if a.LmV2Response != nil {
+		buffer.WriteString(a.LmV2Response.String())
+		buffer.WriteString("\n")
+	}
+
+	if a.LmV1Response != nil {
+		buffer.WriteString(a.LmV1Response.String())
+		buffer.WriteString("\n")
+	}
+
+	if a.NtlmV2Response != nil {
+		buffer.WriteString(a.NtlmV2Response.String())
+		buffer.WriteString("\n")
+	}
+
+	if a.NtlmV1Response != nil {
+		buffer.WriteString(fmt.Sprintf("NtlmResponse Length: %d\n", a.NtChallengeResponseFields.Len))
+		buffer.WriteString(a.NtlmV1Response.String())
+		buffer.WriteString("\n")
+	}
+
+	buffer.WriteString(fmt.Sprintf("UserName: %s\n", a.UserName.String()))
+	buffer.WriteString(fmt.Sprintf("DomainName: %s\n", a.DomainName.String()))
+	buffer.WriteString(fmt.Sprintf("Workstation: %s\n", a.Workstation.String()))
+
+	if a.EncryptedRandomSessionKey != nil {
+		buffer.WriteString(fmt.Sprintf("EncryptedRandomSessionKey: %s\n", a.EncryptedRandomSessionKey.String()))
+	}
+
+	if a.Version != nil {
+		buffer.WriteString(fmt.Sprintf("Version: %s\n", a.Version.String()))
+	}
+
+	if a.Mic != nil {
+		buffer.WriteString(fmt.Sprintf("MIC: %s\n", hex.EncodeToString(a.Mic)))
+	}
+
+	buffer.WriteString(fmt.Sprintf("Flags %d\n", a.NegotiateFlags))
+	buffer.WriteString(FlagsToString(a.NegotiateFlags))
+
+	return buffer.String()
+}

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/av_pairs.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/av_pairs.go
@@ -1,0 +1,187 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+)
+
+type AvPairType uint16
+
+// MS-NLMP - 2.2.2.1 AV_PAIR
+const (
+	// Indicates that this is the last AV_PAIR in the list. AvLen MUST be 0. This type of information MUST be present in the AV pair list.
+	MsvAvEOL AvPairType = iota
+	// The server's NetBIOS computer name. The name MUST be in Unicode, and is not null-terminated. This type of information MUST be present in the AV_pair list.
+	MsvAvNbComputerName
+	// The server's NetBIOS domain name. The name MUST be in Unicode, and is not null-terminated. This type of information MUST be present in the AV_pair list.
+	MsvAvNbDomainName
+	// The fully qualified domain name (FQDN (1)) of the computer. The name MUST be in Unicode, and is not null-terminated.
+	MsvAvDnsComputerName
+	// The FQDN (2) of the domain. The name MUST be in Unicode, and is not null-terminate.
+	MsvAvDnsDomainName
+	// The FQDN (2) of the forest. The name MUST be in Unicode, and is not null-terminated.<11>
+	MsvAvDnsTreeName
+	// A 32-bit value indicating server or client configuration.
+	// 0x00000001: indicates to the client that the account authentication is constrained.
+	// 0x00000002: indicates that the client is providing message integrity in the MIC field (section 2.2.1.3) in the AUTHENTICATE_MESSAGE.<12>
+	// 0x00000004: indicates that the client is providing a target SPN generated from an untrusted source.<13>
+	MsvAvFlags
+	// A FILETIME structure ([MS-DTYP] section 2.3.1) in little-endian byte order that contains the server local time.<14>
+	MsvAvTimestamp
+	//A Restriction_Encoding (section 2.2.2.2) structure. The Value field contains a structure representing the integrity level of the security principal, as well as a MachineID created at computer startup to identify the calling machine.<15>
+	MsAvRestrictions
+	// The SPN of the target server. The name MUST be in Unicode and is not null-terminated.<16>
+	MsvAvTargetName
+	// annel bindings hash. The Value field contains an MD5 hash ([RFC4121] section 4.1.1.2) of a gss_channel_bindings_struct ([RFC2744] section 3.11).
+	// An all-zero value of the hash is used to indicate absence of channel bindings.<17>
+	MsvChannelBindings
+)
+
+// Helper struct that contains a list of AvPairs with helper methods for running through them
+type AvPairs struct {
+	List []AvPair
+}
+
+func (p *AvPairs) AddAvPair(avId AvPairType, bytes []byte) {
+	a := &AvPair{AvId: avId, AvLen: uint16(len(bytes)), Value: bytes}
+	p.List = append(p.List, *a)
+}
+
+func ReadAvPairs(data []byte) *AvPairs {
+	pairs := new(AvPairs)
+
+	// Get the number of AvPairs and allocate enough AvPair structures to hold them
+	offset := 0
+	for i := 0; len(data) > 0 && i < 11; i++ {
+		pair := ReadAvPair(data, offset)
+		offset = offset + 4 + int(pair.AvLen)
+		pairs.List = append(pairs.List, *pair)
+		if pair.AvId == MsvAvEOL {
+			break
+		}
+	}
+
+	return pairs
+}
+
+func (p *AvPairs) Bytes() (result []byte) {
+	totalLength := 0
+	for i := range p.List {
+		a := p.List[i]
+		totalLength = totalLength + int(a.AvLen) + 4
+	}
+
+	result = make([]byte, 0, totalLength)
+	for i := range p.List {
+		a := p.List[i]
+		result = append(result, a.Bytes()...)
+	}
+
+	return result
+}
+
+func (p *AvPairs) String() string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString(fmt.Sprintf("Av Pairs (Total %d pairs)\n", len(p.List)))
+
+	for i := range p.List {
+		buffer.WriteString(p.List[i].String())
+		buffer.WriteString("\n")
+	}
+
+	return buffer.String()
+}
+
+func (p *AvPairs) Find(avType AvPairType) (result *AvPair) {
+	for i := range p.List {
+		pair := p.List[i]
+		if avType == pair.AvId {
+			result = &pair
+			break
+		}
+	}
+	return
+}
+
+func (p *AvPairs) ByteValue(avType AvPairType) (result []byte) {
+	pair := p.Find(avType)
+	if pair != nil {
+		result = pair.Value
+	}
+	return
+}
+
+func (p *AvPairs) StringValue(avType AvPairType) (result string) {
+	pair := p.Find(avType)
+	if pair != nil {
+		result = pair.UnicodeStringValue()
+	}
+	return
+}
+
+// AvPair as described by MS-NLMP
+type AvPair struct {
+	AvId  AvPairType
+	AvLen uint16
+	Value []byte
+}
+
+func ReadAvPair(data []byte, offset int) *AvPair {
+	pair := new(AvPair)
+	pair.AvId = AvPairType(binary.LittleEndian.Uint16(data[offset : offset+2]))
+	pair.AvLen = binary.LittleEndian.Uint16(data[offset+2 : offset+4])
+	pair.Value = data[offset+4 : offset+4+int(pair.AvLen)]
+	return pair
+}
+
+func (a *AvPair) UnicodeStringValue() string {
+	return Utf16ToString(a.Value)
+}
+
+func (a *AvPair) Bytes() (result []byte) {
+	result = make([]byte, 4, a.AvLen+4)
+	result[0] = byte(a.AvId)
+	result[1] = byte(a.AvId >> 8)
+	result[2] = byte(a.AvLen)
+	result[3] = byte(a.AvLen >> 8)
+	result = append(result, a.Value...)
+	return
+}
+
+func (a *AvPair) String() string {
+	var outString string
+
+	switch a.AvId {
+	case MsvAvEOL:
+		outString = "MsvAvEOL"
+	case MsvAvNbComputerName:
+		outString = "MsAvNbComputerName: " + a.UnicodeStringValue()
+	case MsvAvNbDomainName:
+		outString = "MsvAvNbDomainName: " + a.UnicodeStringValue()
+	case MsvAvDnsComputerName:
+		outString = "MsvAvDnsComputerName: " + a.UnicodeStringValue()
+	case MsvAvDnsDomainName:
+		outString = "MsvAvDnsDomainName: " + a.UnicodeStringValue()
+	case MsvAvDnsTreeName:
+		outString = "MsvAvDnsTreeName: " + a.UnicodeStringValue()
+	case MsvAvFlags:
+		outString = "MsvAvFlags: " + hex.EncodeToString(a.Value)
+	case MsvAvTimestamp:
+		outString = "MsvAvTimestamp: " + hex.EncodeToString(a.Value)
+	case MsAvRestrictions:
+		outString = "MsAvRestrictions: " + hex.EncodeToString(a.Value)
+	case MsvAvTargetName:
+		outString = "MsvAvTargetName: " + a.UnicodeStringValue()
+	case MsvChannelBindings:
+		outString = "MsvChannelBindings: " + hex.EncodeToString(a.Value)
+	default:
+		outString = fmt.Sprintf("unknown pair type: '%d'", a.AvId)
+	}
+
+	return outString
+}

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/challenge.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/challenge.go
@@ -1,0 +1,171 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+type Challenge struct {
+	// sig - 8 bytes
+	Signature []byte
+	// message type - 4 bytes
+	MessageType uint32
+	// targetname - 12 bytes
+	TargetName *PayloadStruct
+	// negotiate flags - 4bytes
+	NegotiateFlags uint32
+	// server challenge - 8 bytes
+	ServerChallenge []byte
+
+	// MS-NLMP and Davenport disagree a little on the next few fields and how optional they are
+	// This is what Davenport has to say:
+	// As with the Type 1 message, there are a few versions of the Type 2 that have been observed:
+	//
+	// Version 1 -- The Context, Target Information, and OS Version structure are all omitted. The data block
+	// (containing only the contents of the Target Name security buffer) begins at offset 32. This form
+	// is seen in older Win9x-based systems, and is roughly documented in the Open Group's ActiveX reference
+	// documentation (Section 11.2.3).
+	//
+	// Version 2 -- The Context and Target Information fields are present, but the OS Version structure is not.
+	// The data block begins after the Target Information header, at offset 48. This form is seen in most out-of-box
+	// shipping versions of Windows.
+	//
+	// Version 3 -- The Context, Target Information, and OS Version structure are all present. The data block begins
+	// after the OS Version structure, at offset 56. Again, the buffers may be empty (yielding a zero-length data block).
+	// This form was introduced in a relatively recent Service Pack, and is seen on currently-patched versions of Windows 2000,
+	// Windows XP, and Windows 2003.
+
+	// reserved - 8 bytes (set to 0). This field is also known as 'context' in the davenport documentation
+	Reserved []byte
+
+	// targetinfo  - 12 bytes
+	TargetInfoPayloadStruct *PayloadStruct
+	TargetInfo              *AvPairs
+
+	// version - 8 bytes
+	Version *VersionStruct
+	// payload - variable
+	Payload []byte
+}
+
+func ParseChallengeMessage(body []byte) (*Challenge, error) {
+	challenge := new(Challenge)
+
+	challenge.Signature = body[0:8]
+	if !bytes.Equal(challenge.Signature, []byte("NTLMSSP\x00")) {
+		return challenge, errors.New("Invalid NTLM message signature")
+	}
+
+	challenge.MessageType = binary.LittleEndian.Uint32(body[8:12])
+	if challenge.MessageType != 2 {
+		return challenge, errors.New("Invalid NTLM message type should be 0x00000002 for challenge message")
+	}
+
+	var err error
+
+	challenge.TargetName, err = ReadStringPayload(12, body)
+	if err != nil {
+		return nil, err
+	}
+
+	challenge.NegotiateFlags = binary.LittleEndian.Uint32(body[20:24])
+
+	challenge.ServerChallenge = body[24:32]
+
+	challenge.Reserved = body[32:40]
+
+	challenge.TargetInfoPayloadStruct, err = ReadBytePayload(40, body)
+	if err != nil {
+		return nil, err
+	}
+
+	challenge.TargetInfo = ReadAvPairs(challenge.TargetInfoPayloadStruct.Payload)
+
+	offset := 48
+
+	if NTLMSSP_NEGOTIATE_VERSION.IsSet(challenge.NegotiateFlags) {
+		challenge.Version, err = ReadVersionStruct(body[offset : offset+8])
+		if err != nil {
+			return nil, err
+		}
+		offset = offset + 8
+	}
+
+	challenge.Payload = body[offset:]
+
+	return challenge, nil
+}
+
+func (c *Challenge) Bytes() []byte {
+	payloadLen := int(c.TargetName.Len + c.TargetInfoPayloadStruct.Len)
+	messageLen := 8 + 4 + 8 + 4 + 8 + 8 + 8 + 8
+	payloadOffset := uint32(messageLen)
+
+	messageBytes := make([]byte, 0, messageLen+payloadLen)
+	buffer := bytes.NewBuffer(messageBytes)
+
+	buffer.Write(c.Signature)
+	binary.Write(buffer, binary.LittleEndian, c.MessageType)
+
+	c.TargetName.Offset = payloadOffset
+	buffer.Write(c.TargetName.Bytes())
+	payloadOffset += uint32(c.TargetName.Len)
+
+	binary.Write(buffer, binary.LittleEndian, c.NegotiateFlags)
+	buffer.Write(c.ServerChallenge)
+	buffer.Write(make([]byte, 8))
+
+	c.TargetInfoPayloadStruct.Offset = payloadOffset
+	buffer.Write(c.TargetInfoPayloadStruct.Bytes())
+	payloadOffset += uint32(c.TargetInfoPayloadStruct.Len)
+
+	// if(c.Version != nil) {
+	buffer.Write(c.Version.Bytes())
+	// } else {
+	//  buffer.Write(make([]byte, 8))
+	//}
+
+	// Write out the payloads
+	buffer.Write(c.TargetName.Payload)
+	buffer.Write(c.TargetInfoPayloadStruct.Payload)
+
+	return buffer.Bytes()
+}
+
+func (c *Challenge) getLowestPayloadOffset() int {
+	payloadStructs := [...]*PayloadStruct{c.TargetName, c.TargetInfoPayloadStruct}
+
+	// Find the lowest offset value
+	lowest := 9999
+	for i := range payloadStructs {
+		p := payloadStructs[i]
+		if p != nil && p.Offset > 0 && int(p.Offset) < lowest {
+			lowest = int(p.Offset)
+		}
+	}
+
+	return lowest
+}
+
+func (c *Challenge) String() string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("Challenge NTLM Message")
+	buffer.WriteString(fmt.Sprintf("\nPayload Offset: %d Length: %d", c.getLowestPayloadOffset(), len(c.Payload)))
+	buffer.WriteString(fmt.Sprintf("\nTargetName: %s", c.TargetName.String()))
+	buffer.WriteString(fmt.Sprintf("\nServerChallenge: %s", hex.EncodeToString(c.ServerChallenge)))
+	if c.Version != nil {
+		buffer.WriteString(fmt.Sprintf("\nVersion: %s\n", c.Version.String()))
+	}
+	buffer.WriteString("\nTargetInfo")
+	buffer.WriteString(c.TargetInfo.String())
+	buffer.WriteString(fmt.Sprintf("\nFlags %d\n", c.NegotiateFlags))
+	buffer.WriteString(FlagsToString(c.NegotiateFlags))
+
+	return buffer.String()
+}

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/challenge_responses.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/challenge_responses.go
@@ -1,0 +1,154 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+// NTLMv1
+// ******
+type NtlmV1Response struct {
+	// 24 byte array
+	Response []byte
+}
+
+func (n *NtlmV1Response) String() string {
+	return fmt.Sprintf("NtlmV1Response: %s", hex.EncodeToString(n.Response))
+}
+
+func ReadNtlmV1Response(bytes []byte) (*NtlmV1Response, error) {
+	r := new(NtlmV1Response)
+	r.Response = bytes[0:24]
+	return r, nil
+}
+
+// *** NTLMv2
+// The NTLMv2_CLIENT_CHALLENGE structure defines the client challenge in the AUTHENTICATE_MESSAGE.
+// This structure is used only when NTLM v2 authentication is configured.
+type NtlmV2ClientChallenge struct {
+	// An 8-bit unsigned char that contains the current version of the challenge response type.
+	// This field MUST be 0x01.
+	RespType byte
+	// An 8-bit unsigned char that contains the maximum supported version of the challenge response type.
+	// This field MUST be 0x01.
+	HiRespType byte
+	// A 16-bit unsigned integer that SHOULD be 0x0000 and MUST be ignored on receipt.
+	Reserved1 uint16
+	// A 32-bit unsigned integer that SHOULD be 0x00000000 and MUST be ignored on receipt.
+	Reserved2 uint32
+	// A 64-bit unsigned integer that contains the current system time, represented as the number of 100 nanosecond
+	// ticks elapsed since midnight of January 1, 1601 (UTC).
+	TimeStamp []byte
+	// An 8-byte array of unsigned char that contains the client's ClientChallenge (section 3.1.5.1.2).
+	ChallengeFromClient []byte
+	// A 32-bit unsigned integer that SHOULD be 0x00000000 and MUST be ignored on receipt.
+	Reserved3 uint32
+	AvPairs   *AvPairs
+}
+
+func (n *NtlmV2ClientChallenge) String() string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("NTLM v2 ClientChallenge\n")
+	buffer.WriteString(fmt.Sprintf("Timestamp: %s\n", hex.EncodeToString(n.TimeStamp)))
+	buffer.WriteString(fmt.Sprintf("ChallengeFromClient: %s\n", hex.EncodeToString(n.ChallengeFromClient)))
+	buffer.WriteString("AvPairs\n")
+	buffer.WriteString(n.AvPairs.String())
+
+	return buffer.String()
+}
+
+// The NTLMv2_RESPONSE structure defines the NTLMv2 authentication NtChallengeResponse in the AUTHENTICATE_MESSAGE.
+// This response is used only when NTLMv2 authentication is configured.
+type NtlmV2Response struct {
+	// A 16-byte array of unsigned char that contains the client's NT challenge- response as defined in section 3.3.2.
+	// Response corresponds to the NTProofStr variable from section 3.3.2.
+	Response []byte
+	// A variable-length byte array that contains the ClientChallenge as defined in section 3.3.2.
+	// ChallengeFromClient corresponds to the temp variable from section 3.3.2.
+	NtlmV2ClientChallenge *NtlmV2ClientChallenge
+}
+
+func (n *NtlmV2Response) String() string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("NTLM v2 Response\n")
+	buffer.WriteString(fmt.Sprintf("Response: %s\n", hex.EncodeToString(n.Response)))
+	buffer.WriteString(n.NtlmV2ClientChallenge.String())
+
+	return buffer.String()
+}
+
+func ReadNtlmV2Response(bytes []byte) (*NtlmV2Response, error) {
+	r := new(NtlmV2Response)
+	r.Response = bytes[0:16]
+	r.NtlmV2ClientChallenge = new(NtlmV2ClientChallenge)
+	c := r.NtlmV2ClientChallenge
+	c.RespType = bytes[16]
+	c.HiRespType = bytes[17]
+
+	if c.RespType != 1 || c.HiRespType != 1 {
+		return nil, errors.New("Does not contain a valid NTLM v2 client challenge - could be NTLMv1.")
+	}
+
+	// Ignoring - 2 bytes reserved
+	// c.Reserved1
+	// Ignoring - 4 bytes reserved
+	// c.Reserved2
+	c.TimeStamp = bytes[24:32]
+	c.ChallengeFromClient = bytes[32:40]
+	// Ignoring - 4 bytes reserved
+	// c.Reserved3
+	c.AvPairs = ReadAvPairs(bytes[44:])
+	return r, nil
+}
+
+// LMv1
+// ****
+type LmV1Response struct {
+	// 24 bytes
+	Response []byte
+}
+
+func ReadLmV1Response(bytes []byte) *LmV1Response {
+	r := new(LmV1Response)
+	r.Response = bytes[0:24]
+	return r
+}
+
+func (l *LmV1Response) String() string {
+	return fmt.Sprintf("LmV1Response: %s", hex.EncodeToString(l.Response))
+}
+
+// *** LMv2
+type LmV2Response struct {
+	// A 16-byte array of unsigned char that contains the client's LM challenge-response.
+	// This is the portion of the LmChallengeResponse field to which the HMAC_MD5 algorithm
+	/// has been applied, as defined in section 3.3.2. Specifically, Response corresponds
+	// to the result of applying the HMAC_MD5 algorithm, using the key ResponseKeyLM, to a
+	// message consisting of the concatenation of the ResponseKeyLM, ServerChallenge and ClientChallenge.
+	Response []byte
+	// An 8-byte array of unsigned char that contains the client's ClientChallenge, as defined in section 3.1.5.1.2.
+	ChallengeFromClient []byte
+}
+
+func ReadLmV2Response(bytes []byte) *LmV2Response {
+	r := new(LmV2Response)
+	r.Response = bytes[0:16]
+	r.ChallengeFromClient = bytes[16:24]
+	return r
+}
+
+func (l *LmV2Response) String() string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("LM v2 Response\n")
+	buffer.WriteString(fmt.Sprintf("Response: %s\n", hex.EncodeToString(l.Response)))
+	buffer.WriteString(fmt.Sprintf("ChallengeFromClient: %s\n", hex.EncodeToString(l.ChallengeFromClient)))
+
+	return buffer.String()
+}

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/helpers.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/helpers.go
@@ -1,0 +1,39 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+import (
+	"encoding/binary"
+	"unicode/utf16"
+)
+
+// Convert a UTF16 string to UTF8 string for Go usage
+func Utf16ToString(bytes []byte) string {
+	var data []uint16
+
+	// NOTE: This is definitely not the best way to do this, but when I tried using a buffer.Read I could not get it to work
+	for offset := 0; offset < len(bytes); offset = offset + 2 {
+		i := binary.LittleEndian.Uint16(bytes[offset : offset+2])
+		data = append(data, i)
+	}
+
+	return string(utf16.Decode(data))
+}
+
+func StringToUtf16(value string) []byte {
+	result := make([]byte, len(value)*2)
+	stringBytes := []byte(value)
+	for i := 0; i < len(value); i++ {
+		result[i*2] = stringBytes[i]
+	}
+	return result
+}
+
+func Uint32ToBytes(v uint32) []byte {
+	bytes := make([]byte, 4)
+	bytes[0] = byte(v & 0xff)
+	bytes[1] = byte((v >> 8) & 0xff)
+	bytes[2] = byte((v >> 16) & 0xff)
+	bytes[3] = byte((v >> 24) & 0xff)
+	return bytes
+}

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/negotiate.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/negotiate.go
@@ -1,0 +1,27 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+type Negotiate struct {
+	// All bytes of the message
+	Bytes []byte
+
+	// sig - 8 bytes
+	Signature []byte
+	// message type - 4 bytes
+	MessageType uint32
+	// negotiate flags - 4bytes
+	NegotiateFlags uint32
+	// If the NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED flag is not set in NegotiateFlags,
+	// indicating that no DomainName is supplied in Payload  - then this should have Len 0 / MaxLen 0
+	// this contains a domain name
+	DomainNameFields *PayloadStruct
+	// If the NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED flag is not set in NegotiateFlags,
+	// indicating that no WorkstationName is supplied in Payload - then this should have Len 0 / MaxLen 0
+	WorkstationFields *PayloadStruct
+	// version - 8 bytes
+	Version *VersionStruct
+	// payload - variable
+	Payload       []byte
+	PayloadOffset int
+}

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/negotiate_flags.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/negotiate_flags.go
@@ -1,0 +1,202 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+// During NTLM authentication, each of the following flags is a possible value of the NegotiateFlags field of the NEGOTIATE_MESSAGE,
+// CHALLENGE_MESSAGE, and AUTHENTICATE_MESSAGE, unless otherwise noted. These flags define client or server NTLM capabilities
+// ssupported by the sender.
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+)
+
+type NegotiateFlag uint32
+
+const (
+	// A (1 bit): If set, requests Unicode character set encoding. An alternate name for this field is NTLMSSP_NEGOTIATE_UNICODE.
+	NTLMSSP_NEGOTIATE_UNICODE NegotiateFlag = 1 << iota
+	// B (1 bit): If set, requests OEM character set encoding. An alternate name for this field is NTLM_NEGOTIATE_OEM. See bit A for details.
+	NTLM_NEGOTIATE_OEM
+	// The A and B bits are evaluated together as follows:
+	// A==1: The choice of character set encoding MUST be Unicode.
+	// A==0 and B==1: The choice of character set encoding MUST be OEM.
+	// A==0 and B==0: The protocol MUST return SEC_E_INVALID_TOKEN.
+	// C (1 bit): If set, a TargetName field of the CHALLENGE_MESSAGE (section 2.2.1.2) MUST be supplied. An alternate name for this field is NTLMSSP_REQUEST_TARGET.
+	NTLMSSP_REQUEST_TARGET
+	// r10 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R10
+	// D (1 bit): If set, requests session key negotiation for message signatures. If the client sends NTLMSSP_NEGOTIATE_SIGN to the server
+	// in the NEGOTIATE_MESSAGE, the server MUST return NTLMSSP_NEGOTIATE_SIGN to the client in the CHALLENGE_MESSAGE. An alternate name
+	// for this field is NTLMSSP_NEGOTIATE_SIGN.
+	NTLMSSP_NEGOTIATE_SIGN
+	// E (1 bit): If set, requests session key negotiation for message confidentiality. If the client sends NTLMSSP_NEGOTIATE_SEAL
+	// to the server in the NEGOTIATE_MESSAGE, the server MUST return NTLMSSP_NEGOTIATE_SEAL to the client in the CHALLENGE_MESSAGE.
+	// Clients and servers that set NTLMSSP_NEGOTIATE_SEAL SHOULD always set NTLMSSP_NEGOTIATE_56 and NTLMSSP_NEGOTIATE_128,
+	// if they are supported. An alternate name for this field is NTLMSSP_NEGOTIATE_SEAL.
+	NTLMSSP_NEGOTIATE_SEAL
+	// F (1 bit): If set, requests connectionless authentication. If NTLMSSP_NEGOTIATE_DATAGRAM is set, then NTLMSSP_NEGOTIATE_KEY_EXCH
+	// MUST always be set in the AUTHENTICATE_MESSAGE to the server and the CHALLENGE_MESSAGE to the client. An alternate name for
+	// this field is NTLMSSP_NEGOTIATE_DATAGRAM.
+	NTLMSSP_NEGOTIATE_DATAGRAM
+	// G (1 bit): If set, requests LAN Manager (LM) session key computation. NTLMSSP_NEGOTIATE_LM_KEY and NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY
+	// are mutually exclusive. If both NTLMSSP_NEGOTIATE_LM_KEY and NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY are requested,
+	// NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY alone MUST be returned to the client. NTLM v2 authentication session key generation
+	// MUST be supported by both the client and the DC in order to be used, and extended session security signing and sealing requires
+	// support from the client and the server to be used. An alternate name for this field is NTLMSSP_NEGOTIATE_LM_KEY.
+	NTLMSSP_NEGOTIATE_LM_KEY
+	// r9 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R9
+	// H (1 bit): If set, requests usage of the NTLM v1 session security protocol. NTLMSSP_NEGOTIATE_NTLM MUST be set in the
+	// NEGOTIATE_MESSAGE to the server and the CHALLENGE_MESSAGE to the client. An alternate name for this field is NTLMSSP_NEGOTIATE_NTLM.
+	NTLMSSP_NEGOTIATE_NTLM
+	// r8 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R8
+	// J (1 bit): If set, the connection SHOULD be anonymous.<26> r8 (1 bit): This bit is unused and SHOULD be zero.<27>
+	NTLMSSP_ANONYMOUS
+	// K (1 bit): If set, the domain name is provided (section 2.2.1.1).<25> An alternate name for this field is NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED.
+	NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED
+	// L (1 bit): This flag indicates whether the Workstation field is present. If this flag is not set, the Workstation field
+	// MUST be ignored. If this flag is set, the length field of the Workstation field specifies whether the workstation name
+	// is nonempty or not.<24> An alternate name for this field is NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED.
+	NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED
+	// r7 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R7
+	// M (1 bit): If set, requests the presence of a signature block on all messages. NTLMSSP_NEGOTIATE_ALWAYS_SIGN MUST be
+	// set in the NEGOTIATE_MESSAGE to the server and the CHALLENGE_MESSAGE to the client. NTLMSSP_NEGOTIATE_ALWAYS_SIGN is
+	// overridden by NTLMSSP_NEGOTIATE_SIGN and NTLMSSP_NEGOTIATE_SEAL, if they are supported. An alternate name for this field
+	// is NTLMSSP_NEGOTIATE_ALWAYS_SIGN.
+	NTLMSSP_NEGOTIATE_ALWAYS_SIGN
+	// N (1 bit): If set, TargetName MUST be a domain name. The data corresponding to this flag is provided by the server in the
+	// TargetName field of the CHALLENGE_MESSAGE. If set, then NTLMSSP_TARGET_TYPE_SERVER MUST NOT be set. This flag MUST be ignored
+	// in the NEGOTIATE_MESSAGE and the AUTHENTICATE_MESSAGE. An alternate name for this field is NTLMSSP_TARGET_TYPE_DOMAIN.
+	NTLMSSP_TARGET_TYPE_DOMAIN
+	// O (1 bit): If set, TargetName MUST be a server name. The data corresponding to this flag is provided by the server in the
+	// TargetName field of the CHALLENGE_MESSAGE. If this bit is set, then NTLMSSP_TARGET_TYPE_DOMAIN MUST NOT be set. This flag MUST
+	// be ignored in the NEGOTIATE_MESSAGE and the AUTHENTICATE_MESSAGE. An alternate name for this field is NTLMSSP_TARGET_TYPE_SERVER.
+	NTLMSSP_TARGET_TYPE_SERVER
+	// r6 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R6
+	// P (1 bit): If set, requests usage of the NTLM v2 session security. NTLM v2 session security is a misnomer because it is not
+	// NTLM v2. It is NTLM v1 using the extended session security that is also in NTLM v2. NTLMSSP_NEGOTIATE_LM_KEY and
+	// NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY are mutually exclusive. If both NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY and
+	// NTLMSSP_NEGOTIATE_LM_KEY are requested, NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY alone MUST be returned to the client.
+	// NTLM v2 authentication session key generation MUST be supported by both the client and the DC in order to be used, and extended
+	// session security signing and sealing requires support from the client and the server in order to be used.<23> An alternate name
+	// for this field is NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY.
+	NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY
+	// Q (1 bit): If set, requests an identify level token. An alternate name for this field is NTLMSSP_NEGOTIATE_IDENTIFY.
+	NTLMSSP_NEGOTIATE_IDENTIFY
+	// r5 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R5
+	// R (1 bit): If set, requests the usage of the LMOWF (section 3.3). An alternate name for this field is NTLMSSP_REQUEST_NON_NT_SESSION_KEY.
+	NTLMSSP_REQUEST_NON_NT_SESSION_KEY
+	// S (1 bit): If set, indicates that the TargetInfo fields in the CHALLENGE_MESSAGE (section 2.2.1.2) are populated. An alternate
+	// name for this field is NTLMSSP_NEGOTIATE_TARGET_INFO.
+	NTLMSSP_NEGOTIATE_TARGET_INFO
+	//  r4 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R4
+	// T (1 bit): If set, requests the protocol version number. The data corresponding to this flag is provided in the Version field of the
+	// NEGOTIATE_MESSAGE, the CHALLENGE_MESSAGE, and the AUTHENTICATE_MESSAGE.<22> An alternate name for this field is NTLMSSP_NEGOTIATE_VERSION.
+	NTLMSSP_NEGOTIATE_VERSION
+	// r3 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R3
+	// r2 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R2
+	// r1 (1 bit): This bit is unused and MUST be zero.
+	NTLMSSP_R1
+	// U (1 bit): If set, requests 128-bit session key negotiation. An alternate name for this field is NTLMSSP_NEGOTIATE_128. If the client
+	// sends NTLMSSP_NEGOTIATE_128 to the server in the NEGOTIATE_MESSAGE, the server MUST return NTLMSSP_NEGOTIATE_128 to the client in the
+	// CHALLENGE_MESSAGE only if the client sets NTLMSSP_NEGOTIATE_SEAL or NTLMSSP_NEGOTIATE_SIGN. Otherwise it is ignored. If both
+	// NTLMSSP_NEGOTIATE_56 and NTLMSSP_NEGOTIATE_128 are requested and supported by the client and server, NTLMSSP_NEGOTIATE_56 and
+	// NTLMSSP_NEGOTIATE_128 will both be returned to the client. Clients and servers that set NTLMSSP_NEGOTIATE_SEAL SHOULD set
+	// NTLMSSP_NEGOTIATE_128 if it is supported. An alternate name for this field is NTLMSSP_NEGOTIATE_128.<21>
+	NTLMSSP_NEGOTIATE_128
+	// V (1 bit): If set, requests an explicit key exchange. This capability SHOULD be used because it improves security for message integrity or
+	// confidentiality. See sections 3.2.5.1.2, 3.2.5.2.1, and 3.2.5.2.2 for details. An alternate name for this field is NTLMSSP_NEGOTIATE_KEY_EXCH.
+	NTLMSSP_NEGOTIATE_KEY_EXCH
+	// If set, requests 56-bit encryption. If the client sends NTLMSSP_NEGOTIATE_SEAL or NTLMSSP_NEGOTIATE_SIGN with NTLMSSP_NEGOTIATE_56 to the
+	// server in the NEGOTIATE_MESSAGE, the server MUST return NTLMSSP_NEGOTIATE_56 to the client in the CHALLENGE_MESSAGE. Otherwise it is ignored.
+	// If both NTLMSSP_NEGOTIATE_56 and NTLMSSP_NEGOTIATE_128 are requested and supported by the client and server, NTLMSSP_NEGOTIATE_56 and
+	// NTLMSSP_NEGOTIATE_128 will both be returned to the client. Clients and servers that set NTLMSSP_NEGOTIATE_SEAL SHOULD set NTLMSSP_NEGOTIATE_56
+	// if it is supported. An alternate name for this field is NTLMSSP_NEGOTIATE_56.
+	NTLMSSP_NEGOTIATE_56
+)
+
+func (f NegotiateFlag) Set(flags uint32) uint32 {
+	return flags | uint32(f)
+}
+
+func (f NegotiateFlag) IsSet(flags uint32) bool {
+	return (flags & uint32(f)) != 0
+}
+
+func (f NegotiateFlag) Unset(flags uint32) uint32 {
+	return flags &^ uint32(f)
+}
+
+func (f NegotiateFlag) String() string {
+	return reflect.TypeOf(f).Name()
+}
+
+func GetFlagName(flag NegotiateFlag) string {
+	nameMap := map[NegotiateFlag]string{
+		NTLMSSP_NEGOTIATE_56:                       "NTLMSSP_NEGOTIATE_56",
+		NTLMSSP_NEGOTIATE_KEY_EXCH:                 "NTLMSSP_NEGOTIATE_KEY_EXCH",
+		NTLMSSP_NEGOTIATE_128:                      "NTLMSSP_NEGOTIATE_128",
+		NTLMSSP_NEGOTIATE_VERSION:                  "NTLMSSP_NEGOTIATE_VERSION",
+		NTLMSSP_NEGOTIATE_TARGET_INFO:              "NTLMSSP_NEGOTIATE_TARGET_INFO",
+		NTLMSSP_REQUEST_NON_NT_SESSION_KEY:         "NTLMSSP_REQUEST_NON_NT_SESSION_KEY",
+		NTLMSSP_NEGOTIATE_IDENTIFY:                 "NTLMSSP_NEGOTIATE_IDENTIFY",
+		NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY: "NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY",
+		NTLMSSP_TARGET_TYPE_SERVER:                 "NTLMSSP_TARGET_TYPE_SERVER",
+		NTLMSSP_TARGET_TYPE_DOMAIN:                 "NTLMSSP_TARGET_TYPE_DOMAIN",
+		NTLMSSP_NEGOTIATE_ALWAYS_SIGN:              "NTLMSSP_NEGOTIATE_ALWAYS_SIGN",
+		NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED: "NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED",
+		NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED:      "NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED",
+		NTLMSSP_ANONYMOUS:                          "NTLMSSP_ANONYMOUS",
+		NTLMSSP_NEGOTIATE_NTLM:                     "NTLMSSP_NEGOTIATE_NTLM",
+		NTLMSSP_NEGOTIATE_LM_KEY:                   "NTLMSSP_NEGOTIATE_LM_KEY",
+		NTLMSSP_NEGOTIATE_DATAGRAM:                 "NTLMSSP_NEGOTIATE_DATAGRAM",
+		NTLMSSP_NEGOTIATE_SEAL:                     "NTLMSSP_NEGOTIATE_SEAL",
+		NTLMSSP_NEGOTIATE_SIGN:                     "NTLMSSP_NEGOTIATE_SIGN",
+		NTLMSSP_REQUEST_TARGET:                     "NTLMSSP_REQUEST_TARGET",
+		NTLM_NEGOTIATE_OEM:                         "NTLM_NEGOTIATE_OEM",
+		NTLMSSP_NEGOTIATE_UNICODE:                  "NTLMSSP_NEGOTIATE_UNICODE"}
+
+	return nameMap[flag]
+}
+
+func FlagsToString(flags uint32) string {
+	allFlags := [...]NegotiateFlag{
+		NTLMSSP_NEGOTIATE_56,
+		NTLMSSP_NEGOTIATE_KEY_EXCH,
+		NTLMSSP_NEGOTIATE_128,
+		NTLMSSP_NEGOTIATE_VERSION,
+		NTLMSSP_NEGOTIATE_TARGET_INFO,
+		NTLMSSP_REQUEST_NON_NT_SESSION_KEY,
+		NTLMSSP_NEGOTIATE_IDENTIFY,
+		NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY,
+		NTLMSSP_TARGET_TYPE_SERVER,
+		NTLMSSP_TARGET_TYPE_DOMAIN,
+		NTLMSSP_NEGOTIATE_ALWAYS_SIGN,
+		NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED,
+		NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED,
+		NTLMSSP_ANONYMOUS,
+		NTLMSSP_NEGOTIATE_NTLM,
+		NTLMSSP_NEGOTIATE_LM_KEY,
+		NTLMSSP_NEGOTIATE_DATAGRAM,
+		NTLMSSP_NEGOTIATE_SEAL,
+		NTLMSSP_NEGOTIATE_SIGN,
+		NTLMSSP_REQUEST_TARGET,
+		NTLM_NEGOTIATE_OEM,
+		NTLMSSP_NEGOTIATE_UNICODE}
+
+	var buffer bytes.Buffer
+	for i := range allFlags {
+		f := allFlags[i]
+		buffer.WriteString(fmt.Sprintf("%s: %v\n", GetFlagName(f), f.IsSet(flags)))
+	}
+	return buffer.String()
+}

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/payload.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/payload.go
@@ -1,0 +1,94 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+)
+
+const (
+	UnicodeStringPayload = iota
+	OemStringPayload
+	BytesPayload
+)
+
+type PayloadStruct struct {
+	Type    int
+	Len     uint16
+	MaxLen  uint16
+	Offset  uint32
+	Payload []byte
+}
+
+func (p *PayloadStruct) Bytes() []byte {
+	dest := make([]byte, 0, 8)
+	buffer := bytes.NewBuffer(dest)
+
+	binary.Write(buffer, binary.LittleEndian, p.Len)
+	binary.Write(buffer, binary.LittleEndian, p.MaxLen)
+	binary.Write(buffer, binary.LittleEndian, p.Offset)
+
+	return buffer.Bytes()
+}
+
+func (p *PayloadStruct) String() string {
+	var returnString string
+
+	switch p.Type {
+	case UnicodeStringPayload:
+		returnString = Utf16ToString(p.Payload)
+	case OemStringPayload:
+		returnString = string(p.Payload)
+	case BytesPayload:
+		returnString = hex.EncodeToString(p.Payload)
+	default:
+		returnString = "unknown type"
+	}
+	return returnString
+}
+
+func CreateBytePayload(bytes []byte) (*PayloadStruct, error) {
+	p := new(PayloadStruct)
+	p.Type = BytesPayload
+	p.Len = uint16(len(bytes))
+	p.MaxLen = uint16(len(bytes))
+	p.Payload = bytes // TODO: Copy these bytes instead of keeping a reference
+	return p, nil
+}
+
+func CreateStringPayload(value string) (*PayloadStruct, error) {
+	// Create UTF16 unicode bytes from string
+	bytes := StringToUtf16(value)
+	p := new(PayloadStruct)
+	p.Type = UnicodeStringPayload
+	p.Len = uint16(len(bytes))
+	p.MaxLen = uint16(len(bytes))
+	p.Payload = bytes // TODO: Copy these bytes instead of keeping a reference
+	return p, nil
+}
+
+func ReadStringPayload(startByte int, bytes []byte) (*PayloadStruct, error) {
+	return ReadPayloadStruct(startByte, bytes, UnicodeStringPayload)
+}
+
+func ReadBytePayload(startByte int, bytes []byte) (*PayloadStruct, error) {
+	return ReadPayloadStruct(startByte, bytes, BytesPayload)
+}
+
+func ReadPayloadStruct(startByte int, bytes []byte, PayloadType int) (*PayloadStruct, error) {
+	p := new(PayloadStruct)
+
+	p.Type = PayloadType
+	p.Len = binary.LittleEndian.Uint16(bytes[startByte : startByte+2])
+	p.MaxLen = binary.LittleEndian.Uint16(bytes[startByte+2 : startByte+4])
+	p.Offset = binary.LittleEndian.Uint32(bytes[startByte+4 : startByte+8])
+
+	if p.Len > 0 {
+		endOffset := p.Offset + uint32(p.Len)
+		p.Payload = bytes[p.Offset:endOffset]
+	}
+
+	return p, nil
+}

--- a/vendor/github.com/rbetts/go-ntlm/ntlm/messages/version.go
+++ b/vendor/github.com/rbetts/go-ntlm/ntlm/messages/version.go
@@ -1,0 +1,46 @@
+//Copyright 2013 Thomson Reuters Global Resources.  All Rights Reserved.  Proprietary and confidential information of TRGR.  Disclosure, use, or reproduction without written authorization of TRGR is prohibited.
+
+package messages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+type VersionStruct struct {
+	ProductMajorVersion uint8
+	ProductMinorVersion uint8
+	ProductBuild        uint16
+	Reserved            []byte
+	NTLMRevisionCurrent uint8
+}
+
+func ReadVersionStruct(structSource []byte) (*VersionStruct, error) {
+	versionStruct := new(VersionStruct)
+
+	versionStruct.ProductMajorVersion = uint8(structSource[0])
+	versionStruct.ProductMinorVersion = uint8(structSource[1])
+	versionStruct.ProductBuild = binary.LittleEndian.Uint16(structSource[2:4])
+	versionStruct.Reserved = structSource[4:7]
+	versionStruct.NTLMRevisionCurrent = uint8(structSource[7])
+
+	return versionStruct, nil
+}
+
+func (v *VersionStruct) String() string {
+	return fmt.Sprintf("%d.%d.%d Ntlm %d", v.ProductMajorVersion, v.ProductMinorVersion, v.ProductBuild, v.NTLMRevisionCurrent)
+}
+
+func (v *VersionStruct) Bytes() []byte {
+	dest := make([]byte, 0, 8)
+	buffer := bytes.NewBuffer(dest)
+
+	binary.Write(buffer, binary.LittleEndian, v.ProductMajorVersion)
+	binary.Write(buffer, binary.LittleEndian, v.ProductMinorVersion)
+	binary.Write(buffer, binary.LittleEndian, v.ProductBuild)
+	buffer.Write(make([]byte, 3))
+	binary.Write(buffer, binary.LittleEndian, uint8(v.NTLMRevisionCurrent))
+
+	return buffer.Bytes()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -534,6 +534,9 @@ github.com/projectdiscovery/wappalyzergo
 # github.com/quic-go/quic-go v0.48.2
 ## explicit; go 1.22
 github.com/quic-go/quic-go/quicvarint
+# github.com/rbetts/go-ntlm v0.0.0-20130522135510-f22198915663
+## explicit
+github.com/rbetts/go-ntlm/ntlm/messages
 # github.com/refraction-networking/utls v1.5.4
 ## explicit; go 1.20
 github.com/refraction-networking/utls


### PR DESCRIPTION
### TL;DR

Unified NTLM server information extraction across protocols with a centralized implementation.

### What changed?

- Created a new centralized NTLM server info extraction system in `internal/common/ntlm/` that standardizes how we extract and process server information from NTLM challenges
- Added a new `ntlm.yml` schema with common NTLM server information structures
- Modified LDAP and SMB protocol schemas to extend the common NTLM server info structure
- Implemented a phased approach for pentest operations (PROBE → AUTH → ACTION) that separates server info gathering from authentication
- Added new PROBE actions for both SMB and LDAP protocols to gather server information without authentication
- Enhanced Windows OS version detection with a comprehensive build number mapping table

### How to test?

1. Run SMB pentest operations with the new PROBE action to verify server info extraction
2. Run LDAP pentest operations with the new PROBE action to verify server info extraction
3. Verify that the phased approach works correctly by running a full pentest operation that includes PROBE, AUTH, and other actions
4. Check that the extracted server information includes detailed OS version, domain information, and other NTLM-specific details

### Why make this change?

This change improves our ability to extract and process server information from NTLM challenges in a consistent way across different protocols. By centralizing the NTLM server info extraction logic, we can:

1. Ensure consistent server information extraction across SMB, LDAP, and other protocols
2. Separate server information gathering from authentication for better error handling
3. Provide more detailed and accurate OS version information
4. Enable a phased approach to pentest operations that allows for more granular control and better error handling

The phased approach also allows us to fail fast if server information cannot be extracted, preventing unnecessary authentication attempts against servers that may not be available or compatible.