### PR TITLE
Enhance LDAP pentest command with multiple targets and credential options

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -359,34 +359,37 @@ Additional actions can be specified to layer more functionality on top.`,
 func (a *NetworkScan) createLDAPPentestCommand(parent *cobra.Command) {
 	ldapCmd := &cobra.Command{
 		Use:   "ldap",
-		Short: "Perform LDAP penetration testing operations including domain dumping.",
-		Long:  `Perform LDAP penetration testing operations including domain dumping.`,
+		Short: "Perform pentest operations against LDAP services",
+		Long: `Perform pentest operations against LDAP services.
+
+Base enumeration is always performed to extract server info, domain, etc.
+Additional actions can be specified to layer more functionality on top.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			a.runLDAPPentest(cmd, args)
 		},
 	}
 
 	// Target configuration
-	ldapCmd.Flags().StringP("target", "t", "", "Target LDAP server (host:port or host, defaults to port 389 for LDAP or 636 for LDAPS)")
+	ldapCmd.Flags().StringSlice("targets", []string{}, "Target hosts")
+	_ = ldapCmd.MarkFlagRequired("targets")
 
 	// Action flags
 	ldapCmd.Flags().StringSlice("actions", []string{}, fmt.Sprintf("Actions to perform: %s", strings.Join(utils.GetLDAPParser().GetValidActions(), ",")))
 
 	// Authentication flags
-	ldapCmd.Flags().StringP("domain", "d", "", "Domain name for authentication")
-	ldapCmd.Flags().StringP("username", "u", "", "Username for authentication")
-	ldapCmd.Flags().StringP("password", "p", "", "Password for authentication")
+	ldapCmd.Flags().StringSliceP("usernames", "u", []string{}, "Usernames for authentication")
+	ldapCmd.Flags().StringSliceP("passwords", "p", []string{}, "Passwords for authentication")
+	ldapCmd.Flags().String("username-file", "", "File containing usernames (one per line)")
+	ldapCmd.Flags().String("password-file", "", "File containing passwords (one per line)")
+	ldapCmd.Flags().String("credentials", "", "Credentials in user:pass format")
+	ldapCmd.Flags().StringP("domain", "d", "", "Domain for authentication")
 	ldapCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
 
 	// Behavior flags
-	ldapCmd.Flags().Int("timeout", 30, "Connection timeout in seconds")
-
-	// Mark Required Flags
-	_ = ldapCmd.MarkFlagRequired("target")
-	_ = ldapCmd.MarkFlagRequired("actions")
-	_ = ldapCmd.MarkFlagRequired("domain")
-	_ = ldapCmd.MarkFlagRequired("username")
-	// Note: password is not required since we can use NTLM hash instead
+	ldapCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
+	ldapCmd.Flags().Int("retries", 2, "Number of retry attempts")
+	ldapCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
+	ldapCmd.Flags().Bool("successful-only", false, "Show only successful results")
 
 	parent.AddCommand(ldapCmd)
 }
@@ -650,43 +653,68 @@ func (a *NetworkScan) runTelnetPentest(cmd *cobra.Command, args []string) {
 
 // runLDAPPentest executes LDAP pentest operations
 func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
-	// Target flag
-	target, err := cmd.Flags().GetString("target")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	if target == "" {
-		a.OutputSignal.AddError(fmt.Errorf("target must be specified"))
+	// Get targets from flag
+	targets, _ := cmd.Flags().GetStringSlice("targets")
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
 		return
 	}
 
-	// Actions flag
-	actionsStr, err := cmd.Flags().GetStringSlice("actions")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	if len(actionsStr) == 0 {
-		a.OutputSignal.AddError(fmt.Errorf("at least one action must be specified"))
-		return
-	}
-
-	// Parse actions
-	actions, err := utils.GetLDAPParser().ParseActions(actionsStr)
+	// Parse LDAP actions
+	actionStrings, _ := cmd.Flags().GetStringSlice("actions")
+	actions, err := utils.GetLDAPParser().ParseActions(actionStrings)
 	if err != nil {
 		a.OutputSignal.AddError(err)
 		return
 	}
 
-	// Create config using helper function
-	config, err := a.createPentestLdapConfig(cmd, target, actions)
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
+	// Parse authentication options
+	usernames, _ := cmd.Flags().GetStringSlice("usernames")
+	passwords, _ := cmd.Flags().GetStringSlice("passwords")
+	usernameFile, _ := cmd.Flags().GetString("username-file")
+	passwordFile, _ := cmd.Flags().GetString("password-file")
+	credentials, _ := cmd.Flags().GetString("credentials")
+	domain, _ := cmd.Flags().GetString("domain")
+	ntlmHash, _ := cmd.Flags().GetString("ntlm-hash")
+
+	// Parse behavior options
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	retries, _ := cmd.Flags().GetInt("retries")
+	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
+	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
+
+	// Load credentials from files if specified
+	if usernameFile != "" {
+		fileUsernames, err := utils.GetEntriesFromTXTFiles([]string{usernameFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		usernames = append(usernames, fileUsernames...)
 	}
 
-	// Create engine and run LDAP pentest
+	if passwordFile != "" {
+		filePasswords, err := utils.GetEntriesFromTXTFiles([]string{passwordFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		passwords = append(passwords, filePasswords...)
+	}
+
+	// Parse credentials in user:pass format
+	if credentials != "" {
+		parts := strings.Split(credentials, ":")
+		if len(parts) == 2 {
+			usernames = append(usernames, parts[0])
+			passwords = append(passwords, parts[1])
+		}
+	}
+
+	// Set Config
+	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, retries, stopFirstSuccess, successfulOnly, domain, ntlmHash)
+
+	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
 	report, err := engine.RunLDAPPentest(cmd.Context(), config)
 	if err != nil {
@@ -694,7 +722,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// Output result
+	// Use the report directly since it already has the consolidated structure
 	a.OutputSignal.Content = report
 }
 
@@ -1023,67 +1051,26 @@ func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnet
 	}
 }
 
-// createPentestLdapConfig creates a PentestLdapConfig from command flags
-func (a *NetworkScan) createPentestLdapConfig(cmd *cobra.Command, target string, actions []ldapfern.PentestLdapAction) (*ldapfern.PentestLdapConfig, error) {
-	// Required flags
-	domain, err := cmd.Flags().GetString("domain")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get domain: %v", err)
+// getLDAPPentestConfig creates a configuration for LDAP pentest operations with the provided parameters.
+func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *ldapfern.PentestLdapConfig {
+	var domainPtr, ntlmHashPtr *string
+	if domain != "" {
+		domainPtr = &domain
 	}
-	if domain == "" {
-		return nil, fmt.Errorf("domain must be specified")
-	}
-
-	username, err := cmd.Flags().GetString("username")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get username: %v", err)
-	}
-	if username == "" {
-		return nil, fmt.Errorf("username must be specified")
-	}
-
-	password, err := cmd.Flags().GetString("password")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get password: %v", err)
-	}
-
-	ntlmHash, err := cmd.Flags().GetString("ntlm-hash")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ntlm-hash: %v", err)
-	}
-
-	// Either password or NTLM hash must be specified
-	if password == "" && ntlmHash == "" {
-		return nil, fmt.Errorf("either password or ntlm-hash must be specified")
-	}
-
-	timeout, err := cmd.Flags().GetInt("timeout")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get timeout: %v", err)
-	}
-	if timeout <= 0 {
-		return nil, fmt.Errorf("timeout must be positive")
-	}
-
-	var ntlmHashPtr *string
 	if ntlmHash != "" {
 		ntlmHashPtr = &ntlmHash
 	}
 
-	var passwordList []string
-	if password != "" {
-		passwordList = []string{password}
+	return &ldapfern.PentestLdapConfig{
+		Targets:          targets,
+		Actions:          actions,
+		Usernames:        usernames,
+		Passwords:        passwords,
+		Domain:           domainPtr,
+		Ntlmv2Hash:       ntlmHashPtr,
+		Timeout:          timeout,
+		Retries:          &retries,
+		StopFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:   &successfulOnly,
 	}
-
-	config := &ldapfern.PentestLdapConfig{
-		Targets:    []string{target},
-		Timeout:    timeout,
-		Actions:    actions,
-		Usernames:  []string{username},
-		Passwords:  passwordList,
-		Domain:     &domain,
-		Ntlmv2Hash: ntlmHashPtr,
-	}
-
-	return config, nil
 }

--- a/fern/definition/discover/domain.yml
+++ b/fern/definition/discover/domain.yml
@@ -12,10 +12,6 @@ types:
 
   DomainInfo:
     properties:
-      netBIOSDomainName: optional<string>
-      dnsDomainName: optional<string>
-      forestName: optional<string>
-      # Include full server info from initial target for complete NTLM information
       serverInfo: optional<smbProtocol.SmbServerInfo>
       domainControllers: optional<list<DomainControllerInfo>>
 

--- a/internal/discover/domain.go
+++ b/internal/discover/domain.go
@@ -62,16 +62,11 @@ func RunDomainDiscovery(ctx context.Context, config discoverfern.DiscoverDomainC
 
 		// Step 3: Build the domain info with discovered information
 		domainInfo = &discoverfern.DomainInfo{
-			DnsDomainName:     &domainName,
-			ForestName:        &domainName,
 			DomainControllers: domainControllers,
 		}
 
 		// Add extracted info if available
 		if extractedInfo != nil {
-			if extractedInfo.netbiosDomainName != "" {
-				domainInfo.NetBiosDomainName = &extractedInfo.netbiosDomainName
-			}
 			// Include the full server info from the initial target
 			if extractedInfo.serverInfo != nil {
 				domainInfo.ServerInfo = extractedInfo.serverInfo

--- a/internal/pentest/ldap/auth.go
+++ b/internal/pentest/ldap/auth.go
@@ -3,6 +3,7 @@ package ldap
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -363,12 +364,19 @@ func TestConnection(ctx context.Context, target *Target, timeout int) error {
 func createLDAPConnection(target *Target, timeout int) (*ldap.Conn, error) {
 	address := fmt.Sprintf("%s:%d", target.Host, target.Port)
 
-	// Create connection based on SSL/TLS settings
+	// Convert timeout from milliseconds to time.Duration
+	timeoutDuration := time.Duration(timeout) * time.Millisecond
+
+	// Create connection based on SSL/TLS settings with custom timeout
 	if target.UseSSL {
-		return ldap.DialTLS("tcp", address, nil)
+		// Use DialURL with custom dialer for timeout support
+		ldapURL := fmt.Sprintf("ldaps://%s", address)
+		return ldap.DialURL(ldapURL, ldap.DialWithDialer(&net.Dialer{Timeout: timeoutDuration}))
 	}
 
-	conn, err := ldap.Dial("tcp", address)
+	// Use DialURL with custom dialer for timeout support
+	ldapURL := fmt.Sprintf("ldap://%s", address)
+	conn, err := ldap.DialURL(ldapURL, ldap.DialWithDialer(&net.Dialer{Timeout: timeoutDuration}))
 	if err != nil {
 		return nil, err
 	}
@@ -402,6 +410,22 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 	ldapTarget, err := ParseTarget(target)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse target: %v", err)
+	}
+
+	// Override domain with config domain if provided (instead of deriving from target IP)
+	if config.Domain != nil && *config.Domain != "" {
+		ldapTarget.Domain = *config.Domain
+		// Update BaseDN based on the proper domain
+		if strings.Contains(*config.Domain, ".") {
+			parts := strings.Split(*config.Domain, ".")
+			var dcParts []string
+			for _, part := range parts {
+				dcParts = append(dcParts, fmt.Sprintf("DC=%s", part))
+			}
+			ldapTarget.BaseDN = strings.Join(dcParts, ",")
+		} else {
+			ldapTarget.BaseDN = fmt.Sprintf("DC=%s", *config.Domain)
+		}
 	}
 
 	// Check if auth should be performed based on credentials or explicit actions


### PR DESCRIPTION
### TL;DR

Enhanced the LDAP penetration testing command with improved authentication options, better target handling, and more flexible configuration.

### What changed?

- Redesigned the LDAP pentest command interface with more comprehensive options:
  - Changed from single target to multiple targets with `--targets` flag
  - Replaced single username/password with multiple options: `--usernames`, `--passwords`, `--username-file`, `--password-file`, and `--credentials`
  - Added new behavior flags: `--retries`, `--stop-first-success`, and `--successful-only`
  - Updated timeout to use milliseconds instead of seconds
  - Improved command description and help text

- Enhanced LDAP connection handling:
  - Implemented proper timeout handling using custom dialers
  - Added support for domain override in authentication
  - Improved BaseDN construction from domain components

- Simplified configuration creation with the new `getLDAPPentestConfig` function

### How to test?

1. Run the LDAP pentest command with multiple targets:
   ```
   ./tool pentest ldap --targets 10.0.0.1,10.0.0.2 --actions enum
   ```

2. Test with credential files:
   ```
   ./tool pentest ldap --targets 10.0.0.1 --username-file users.txt --password-file passwords.txt --actions enum
   ```

3. Test with domain override:
   ```
   ./tool pentest ldap --targets 10.0.0.1 --usernames admin --passwords secret --domain example.com --actions enum
   ```

### Why make this change?

This update aligns the LDAP pentest command with other pentest modules by providing more flexible authentication options and target handling. The changes improve usability by supporting credential files and multiple authentication attempts, while also enhancing connection reliability with proper timeout handling and domain configuration.