### PR TITLE
Remove retries parameter from pentest commands and configurations

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -79,7 +79,6 @@ func (a *NetworkScan) createPasswordSprayCommand(parent *cobra.Command) {
 	passwordCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
 	passwordCmd.Flags().Int("sleep", 0, "Delay between password attempts in seconds")
 	passwordCmd.Flags().Int("jitter", 0, "Random jitter percentage (0-100) to apply to sleep delays")
-	passwordCmd.Flags().Int("retries", 1, "Number of retries per credential")
 	passwordCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful authentication")
 	passwordCmd.Flags().Bool("successful-only", false, "Only show successful authentications in output")
 
@@ -110,7 +109,6 @@ func (a *NetworkScan) createUsernameSprayCommand(parent *cobra.Command) {
 	usernameCmd.Flags().String("username-scheme", "", "Generate usernames using scheme (FLAST, FIRST_DOT_LAST, FIRSTLAST, LASTFIRST, FIRST, LAST, F_LAST, FIRST_LAST)")
 	usernameCmd.Flags().StringP("domain", "d", "", "Domain for Kerberos authentication")
 	usernameCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
-	usernameCmd.Flags().Int("retries", 1, "Number of retries per username")
 	usernameCmd.Flags().Bool("successful-only", false, "Only show successful username enumerations in output")
 
 	// Mark required flags
@@ -262,7 +260,6 @@ Additional actions can be specified to layer more functionality on top.`,
 
 	// Behavior flags
 	smbCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
-	smbCmd.Flags().Int("retries", 2, "Number of retry attempts")
 	smbCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
 	smbCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	smbCmd.Flags().Bool("verbose", false, "Verbose output")
@@ -308,7 +305,6 @@ Additional actions can be specified to layer more functionality on top.`,
 
 	// Behavior flags
 	sshCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
-	sshCmd.Flags().Int("retries", 2, "Number of retry attempts")
 	sshCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
 	sshCmd.Flags().Bool("successful-only", false, "Show only successful results")
 
@@ -348,7 +344,6 @@ Additional actions can be specified to layer more functionality on top.`,
 
 	// Behavior flags
 	telnetCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
-	telnetCmd.Flags().Int("retries", 2, "Number of retry attempts")
 	telnetCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
 	telnetCmd.Flags().Bool("successful-only", false, "Show only successful results")
 
@@ -387,7 +382,6 @@ Additional actions can be specified to layer more functionality on top.`,
 
 	// Behavior flags
 	ldapCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
-	ldapCmd.Flags().Int("retries", 2, "Number of retry attempts")
 	ldapCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
 	ldapCmd.Flags().Bool("successful-only", false, "Show only successful results")
 
@@ -426,7 +420,6 @@ func (a *NetworkScan) runSMBPentest(cmd *cobra.Command, args []string) {
 
 	// Parse behavior options
 	timeout, _ := cmd.Flags().GetInt("timeout")
-	retries, _ := cmd.Flags().GetInt("retries")
 	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
 	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
 
@@ -469,7 +462,7 @@ func (a *NetworkScan) runSMBPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, timeout, retries, stopFirstSuccess, successfulOnly, domain, ntlmHash)
+	config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -517,7 +510,6 @@ func (a *NetworkScan) runSSHPentest(cmd *cobra.Command, args []string) {
 
 	// Parse behavior options
 	timeout, _ := cmd.Flags().GetInt("timeout")
-	retries, _ := cmd.Flags().GetInt("retries")
 	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
 	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
 
@@ -560,7 +552,7 @@ func (a *NetworkScan) runSSHPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getSSHPentestConfig(targets, actions, usernames, passwords, commands, uploadFiles, downloads, timeout, retries, stopFirstSuccess, successfulOnly, keyFile)
+	config := getSSHPentestConfig(targets, actions, usernames, passwords, commands, uploadFiles, downloads, timeout, stopFirstSuccess, successfulOnly, keyFile)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -603,7 +595,6 @@ func (a *NetworkScan) runTelnetPentest(cmd *cobra.Command, args []string) {
 
 	// Parse behavior options
 	timeout, _ := cmd.Flags().GetInt("timeout")
-	retries, _ := cmd.Flags().GetInt("retries")
 	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
 	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
 
@@ -637,7 +628,7 @@ func (a *NetworkScan) runTelnetPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getTelnetPentestConfig(targets, actions, usernames, passwords, commands, timeout, retries, stopFirstSuccess, successfulOnly)
+	config := getTelnetPentestConfig(targets, actions, usernames, passwords, commands, timeout, stopFirstSuccess, successfulOnly)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -679,7 +670,6 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 
 	// Parse behavior options
 	timeout, _ := cmd.Flags().GetInt("timeout")
-	retries, _ := cmd.Flags().GetInt("retries")
 	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
 	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
 
@@ -712,7 +702,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, retries, stopFirstSuccess, successfulOnly, domain, ntlmHash)
+	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -826,14 +816,6 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 		return nil, fmt.Errorf("jitter must be between 0 and 100")
 	}
 
-	retries, err := cmd.Flags().GetInt("retries")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get retries: %v", err)
-	}
-	if retries < 1 {
-		return nil, fmt.Errorf("retries must be at least 1")
-	}
-
 	stopFirstSuccess, err := cmd.Flags().GetBool("stop-on-first-success")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stop-on-first-success: %v", err)
@@ -845,7 +827,7 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 	}
 
 	// Set Config
-	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, ntlmHash, timeout, sleep, jitter, retries, stopFirstSuccess, successfulOnly)
+	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, ntlmHash, timeout, sleep, jitter, stopFirstSuccess, successfulOnly)
 
 	return config, nil
 }
@@ -911,27 +893,19 @@ func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []st
 		return nil, fmt.Errorf("timeout must be positive")
 	}
 
-	retries, err := cmd.Flags().GetInt("retries")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get retries: %v", err)
-	}
-	if retries < 1 {
-		return nil, fmt.Errorf("retries must be at least 1")
-	}
-
 	successfulOnly, err := cmd.Flags().GetBool("successful-only")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get successful-only: %v", err)
 	}
 
 	// Set Config
-	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, usernameScheme, domain, timeout, retries, successfulOnly)
+	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, usernameScheme, domain, timeout, successfulOnly)
 
 	return config, nil
 }
 
 // getSprayPasswordConfig creates a configuration for password spray operations with the provided parameters.
-func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentestfern.WordlistType, passwordLists []pentestfern.WordlistType, domain string, ntlmHash string, timeout int, sleep int, jitter int, retries int, stopFirstSuccess bool, successfulOnly bool) *pentestfern.PentestSprayConfig {
+func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentestfern.WordlistType, passwordLists []pentestfern.WordlistType, domain string, ntlmHash string, timeout int, sleep int, jitter int, stopFirstSuccess bool, successfulOnly bool) *pentestfern.PentestSprayConfig {
 	// Create config
 	var usernameFilePtr, passwordFilePtr, domainPtr *string
 	if usernameFile != "" {
@@ -966,7 +940,6 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 			Timeout:            timeout,
 			Sleep:              sleep,
 			Jitter:             jitterPtr,
-			Retries:            retries,
 			StopOnFirstSuccess: stopFirstSuccess,
 			SuccessfulOnly:     successfulOnly,
 			ContinueOnError:    true,
@@ -975,7 +948,7 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 }
 
 // getSprayUsernameConfig creates a configuration for username enumeration operations with the provided parameters.
-func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetService, usernameLists []pentestfern.WordlistType, usernames []string, usernameScheme *pentestfern.UsernameScheme, domain string, timeout int, retries int, successfulOnly bool) *pentestfern.PentestSprayConfig {
+func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetService, usernameLists []pentestfern.WordlistType, usernames []string, usernameScheme *pentestfern.UsernameScheme, domain string, timeout int, successfulOnly bool) *pentestfern.PentestSprayConfig {
 	return &pentestfern.PentestSprayConfig{
 		SprayMode: strings.ToLower(string(pentestfern.SprayModeUsername)),
 		Username: &pentestfern.SprayUsernameConfig{
@@ -986,7 +959,6 @@ func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetSer
 			UsernameScheme:  usernameScheme,
 			Domain:          domain,
 			Timeout:         timeout,
-			Retries:         retries,
 			ContinueOnError: true,
 			SuccessfulOnly:  successfulOnly,
 		},
@@ -994,7 +966,7 @@ func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetSer
 }
 
 // getSMBPentestConfig creates a configuration for SMB pentest operations with the provided parameters.
-func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *smbfern.PentestSmbConfig {
+func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *smbfern.PentestSmbConfig {
 	var domainPtr, ntlmHashPtr *string
 	if domain != "" {
 		domainPtr = &domain
@@ -1011,14 +983,13 @@ func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, u
 		Domain:           domainPtr,
 		Ntlmv2Hash:       ntlmHashPtr,
 		Timeout:          timeout,
-		Retries:          &retries,
 		StopFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:   &successfulOnly,
 	}
 }
 
 // getSSHPentestConfig creates a configuration for SSH pentest operations with the provided parameters.
-func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
+func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, stopFirstSuccess bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
 	var keyFilePtr *string
 	if keyFile != "" {
 		keyFilePtr = &keyFile
@@ -1031,28 +1002,26 @@ func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, u
 		Passwords:        passwords,
 		KeyFile:          keyFilePtr,
 		Timeout:          timeout,
-		Retries:          &retries,
 		StopFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:   &successfulOnly,
 	}
 }
 
 // getTelnetPentestConfig creates a configuration for Telnet pentest operations with the provided parameters.
-func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnetAction, usernames []string, passwords []string, commands []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
+func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnetAction, usernames []string, passwords []string, commands []string, timeout int, stopFirstSuccess bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
 	return &telnetfern.PentestTelnetConfig{
 		Targets:          targets,
 		Actions:          actions,
 		Usernames:        usernames,
 		Passwords:        passwords,
 		Timeout:          timeout,
-		Retries:          &retries,
 		StopFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:   &successfulOnly,
 	}
 }
 
 // getLDAPPentestConfig creates a configuration for LDAP pentest operations with the provided parameters.
-func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, retries int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *ldapfern.PentestLdapConfig {
+func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *ldapfern.PentestLdapConfig {
 	var domainPtr, ntlmHashPtr *string
 	if domain != "" {
 		domainPtr = &domain
@@ -1069,7 +1038,6 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 		Domain:           domainPtr,
 		Ntlmv2Hash:       ntlmHashPtr,
 		Timeout:          timeout,
-		Retries:          &retries,
 		StopFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:   &successfulOnly,
 	}

--- a/fern/definition/pentest/common.yml
+++ b/fern/definition/pentest/common.yml
@@ -11,7 +11,6 @@ types:
 
       # General options
       timeout: integer
-      retries: optional<integer>
       threads: optional<integer>
       verbose: optional<boolean>
 

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -107,7 +107,6 @@ types:
       # Attack configuration
       timeout: integer
       sleep: integer
-      retries: integer
 
       # Behavior configuration
       stopOnFirstSuccess: boolean
@@ -135,7 +134,6 @@ types:
 
       # Attack configuration
       timeout: integer
-      retries: integer
 
       # Behavior configuration
       continueOnError: boolean

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -456,13 +456,11 @@ func (e *Engine) performKerberosSpray(ctx context.Context, target string, cred *
 
 // performSSHSpray uses existing SSH auth functionality
 func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {
-	retries := 1
 	sshConfig := &sshfern.PentestSshConfig{
 		Targets:   []string{target},
 		Usernames: []string{cred.Username},
 		Passwords: []string{cred.Password},
 		Timeout:   config.Timeout,
-		Retries:   &retries, // We handle retries at spray level
 	}
 
 	details, err := sshpentest.PerformAuthenticationWithContext(ctx, target, sshConfig)
@@ -498,14 +496,12 @@ func (e *Engine) performFTPSpray(ctx context.Context, target string, cred *pente
 
 // performSMBSpray uses existing SMB auth functionality
 func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {
-	retries := 1
 	smbConfig := &smbfern.PentestSmbConfig{
 		Targets:   []string{target},
 		Usernames: []string{cred.Username},
 		Passwords: []string{cred.Password},
 		Domain:    cred.Domain,
 		Timeout:   config.Timeout,
-		Retries:   &retries, // We handle retries at spray level
 	}
 
 	details, err := smbpentest.PerformAuthenticationWithContext(ctx, target, smbConfig)
@@ -530,13 +526,11 @@ func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pente
 
 // performTelnetSpray uses existing Telnet auth functionality
 func (e *Engine) performTelnetSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {
-	retries := 1
 	telnetConfig := &telnetfern.PentestTelnetConfig{
 		Targets:   []string{target},
 		Usernames: []string{cred.Username},
 		Passwords: []string{cred.Password},
 		Timeout:   config.Timeout,
-		Retries:   &retries, // We handle retries at spray level
 	}
 
 	details, err := telnetpentest.PerformAuthenticationWithContext(ctx, target, telnetConfig)

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -314,39 +314,38 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 				Domain:   config.Domain,
 			}
 
-			for retry := 0; retry < config.Retries; retry++ {
-				attempt, err := e.performSprayAttempt(ctx, target, config.Service, cred, attemptNumber, config)
-				if err != nil {
-					errors = append(errors, err.Error())
-				}
-
-				// Only include attempt in output if not filtering to successful only, or if attempt was successful
-				if !config.SuccessfulOnly || attempt.Response.Success {
-					attempts = append(attempts, attempt)
-				}
-
-				if attempt.Response.Success {
-					targetWithPort := fmt.Sprintf("%s:%d", host, port)
-					credWithTarget := &pentestfern.Credential{
-						Username: cred.Username,
-						Password: cred.Password,
-						Domain:   cred.Domain,
-						Target:   &targetWithPort,
-						Service:  &config.Service,
-					}
-					successfulCredentials = append(successfulCredentials, credWithTarget)
-					log.Info("Successful authentication",
-						svc1log.SafeParam("target", target),
-						svc1log.SafeParam("username", cred.Username))
-
-					if config.StopOnFirstSuccess {
-						goto done
-					}
-					break // Success, no need to retry
-				}
-
-				attemptNumber++
+			// Single attempt - retries have been removed
+			attempt, err := e.performSprayAttempt(ctx, target, config.Service, cred, attemptNumber, config)
+			if err != nil {
+				errors = append(errors, err.Error())
 			}
+
+			// Only include attempt in output if not filtering to successful only, or if attempt was successful
+			if !config.SuccessfulOnly || attempt.Response.Success {
+				attempts = append(attempts, attempt)
+			}
+
+			if attempt.Response.Success {
+				targetWithPort := fmt.Sprintf("%s:%d", host, port)
+				credWithTarget := &pentestfern.Credential{
+					Username: cred.Username,
+					Password: cred.Password,
+					Domain:   cred.Domain,
+					Target:   &targetWithPort,
+					Service:  &config.Service,
+				}
+				successfulCredentials = append(successfulCredentials, credWithTarget)
+				log.Info("Successful authentication",
+					svc1log.SafeParam("target", target),
+					svc1log.SafeParam("username", cred.Username))
+
+				if config.StopOnFirstSuccess {
+					goto done
+				}
+				// Success, no retry needed since we removed retry logic
+			}
+
+			attemptNumber++
 		}
 
 		// Apply delay with jitter between password attempts (after testing password against all users)


### PR DESCRIPTION
### TL;DR

Removed the `retries` parameter from all pentest commands and configurations.

### What changed?

- Removed the `retries` flag from all pentest commands including password spray, username spray, SMB, SSH, Telnet, and LDAP
- Removed the `retries` parameter from all corresponding configuration structs and function signatures
- Updated the Fern definition files to remove the `retries` field from type definitions
- Simplified the internal spray implementation by removing retry handling at the spray level

### How to test?

1. Run any of the pentest commands to verify they work without the `retries` parameter:
2. Verify that authentication attempts still work correctly without the retry functionality

### Why make this change?

The retry functionality was likely redundant or causing issues in the pentest modules. By removing it, the code becomes simpler and more maintainable. The retry logic may have been moved to a different layer of the application or determined to be unnecessary since connection timeouts and other error handling mechanisms already provide sufficient reliability.