### PR TITLE
Stealth Host Discovery

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -10,6 +10,7 @@ import (
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 	// Internal
 	discover "github.com/Method-Security/networkscan/internal/discover"
+	discoverhost "github.com/Method-Security/networkscan/internal/discover/host"
 	discoverport "github.com/Method-Security/networkscan/internal/discover/port"
 
 	// External
@@ -32,11 +33,6 @@ func (a *NetworkScan) InitDiscoverCommand() {
 		Short: "Identify live hosts within a given IP, hostname, or CIDR range using various discovery techniques.",
 		Long:  `Identify live hosts within a given IP, hostname, or CIDR range using various discovery techniques.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if !privileges.IsPrivileged {
-				a.OutputSignal.AddError(errors.New("discover host can only be run as a privileged user"))
-				return
-			}
-
 			// Target flags
 			target, err := cmd.Flags().GetString("target")
 			if err != nil {
@@ -45,19 +41,56 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Config flags
+			var scanTypeEnum *discoverfern.HostScanType
 			scanType, err := cmd.Flags().GetString("scan-type")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			scanTypeEnum, err := discoverfern.NewHostScanTypeFromString(scanType)
+			if scanType != "" {
+				scanTypeEnumValue, err := discoverfern.NewHostScanTypeFromString(scanType)
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
+				}
+				scanTypeEnum = &scanTypeEnumValue
+			}
+
+			// Check privileges for stealth scan
+			stealth, err := cmd.Flags().GetBool("stealth")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
+			// Validate that either stealth or scan-type is specified
+			if !stealth && scanTypeEnum == nil {
+				a.OutputSignal.AddError(errors.New("either --stealth or --scan-type must be specified"))
+				return
+			}
+
+			if !privileges.IsPrivileged && stealth {
+				a.OutputSignal.AddError(errors.New("stealth host discovery requires root privileges for ICMP ping"))
+				return
+			}
+
+			// Stealth flags
+			sleep, err := cmd.Flags().GetInt("sleep")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			reverseLookup, err := cmd.Flags().GetBool("reverse-lookup")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Set Config
+			config := getDiscoverHostConfig(target, scanTypeEnum, stealth, sleep, reverseLookup)
+
 			// Generate the report
-			report, err := discover.RunHostDiscovery(cmd.Context(), target, scanTypeEnum)
+			report, err := discoverhost.RunHostDiscovery(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -66,7 +99,10 @@ func (a *NetworkScan) InitDiscoverCommand() {
 		},
 	}
 	discoverHostCmd.Flags().String("target", "", "Target IP address, hostname, or CIDR range to scan for live hosts")
-	discoverHostCmd.Flags().String("scan-type", "ICMP_ECHO", "Discovery scan type: TCP_SYN, TCP_ACK, ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK")
+	discoverHostCmd.Flags().String("scan-type", "", "Discovery scan type: TCP_SYN, TCP_ACK, ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK (not needed for stealth mode)")
+	discoverHostCmd.Flags().Bool("stealth", false, "Enable stealth host discovery using custom ICMP ping implementation")
+	discoverHostCmd.Flags().Int("sleep", 100, "Sleep delay in milliseconds between hosts for stealth scan")
+	discoverHostCmd.Flags().Bool("reverse-lookup", false, "Perform reverse DNS lookup sweep first to identify potential targets")
 
 	// Mark Required Flags
 	_ = discoverHostCmd.MarkFlagRequired("target")
@@ -190,6 +226,11 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Stealth flags
+			stealth, err := cmd.Flags().GetBool("stealth")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			sleep, err := cmd.Flags().GetInt("sleep")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -203,7 +244,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPortConfig(target, ports, topPorts, threads, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, sleep)
+			config := getDiscoverPortConfig(target, ports, topPorts, threads, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, stealth, sleep)
 
 			// Generate the report
 			report, err := discoverport.RunPortScan(cmd.Context(), config)
@@ -218,12 +259,13 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverPortCmd.Flags().String("ports", "", "Comma-separated list or range of TCP ports to scan (e.g., 22,80,443 or 1-1024)")
 	discoverPortCmd.Flags().String("top-ports", "", "Scan the top N most common TCP ports (options: full, 100, 1000)")
 	discoverPortCmd.Flags().Int("threads", 25, "Number of concurrent threads to use during port scanning")
-	discoverPortCmd.Flags().String("scan-type", "SYN", "Port scan type: SYN (default, requires root), CONNECT, or STEALTH")
+	discoverPortCmd.Flags().String("scan-type", "SYN", "Port scan type: SYN (default, requires root) or CONNECT")
 	discoverPortCmd.Flags().Bool("validate", false, "Validate open ports by using service detection techniques")
 	discoverPortCmd.Flags().String("validate-hostname", "", "Hostname to validate against (e.g., example.com)")
 	discoverPortCmd.Flags().Int("validate-attempt-timeout", 10, "Timeout in seconds for each service detection attempt")
 	discoverPortCmd.Flags().Int("validate-threads", 0, "Number of concurrent threads to use during service detection")
-	discoverPortCmd.Flags().Int("sleep", 100, "Sleep delay in milliseconds between port scans for STEALTH scan type")
+	discoverPortCmd.Flags().Bool("stealth", false, "Enable stealth port scanning with custom delay control")
+	discoverPortCmd.Flags().Int("sleep", 100, "Sleep delay in milliseconds between port scans for stealth scan")
 
 	// Mark Required Flags
 	_ = discoverPortCmd.MarkFlagRequired("target")
@@ -358,7 +400,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 
 // getDiscoverPortConfig creates a configuration for port scanning with the provided parameters.
 // It handles both specific port ranges and top ports scanning modes.
-func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, sleep int) discoverfern.DiscoverPortConfig {
+func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, stealth bool, sleep int) discoverfern.DiscoverPortConfig {
 	config := discoverfern.DiscoverPortConfig{
 		Target:   target,
 		Ports:    &ports,
@@ -376,8 +418,10 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 	if validateThreads != nil {
 		config.ValidateThreads = validateThreads
 	}
-	if sleep > 0 {
-		config.Sleep = &sleep
+	if stealth {
+		config.Stealth = &discoverfern.PortStealthConfig{
+			Sleep: &sleep,
+		}
 	}
 	return config
 }
@@ -399,6 +443,24 @@ func getDiscoverTLSConfig(targets []string, timeout int, verifyTLS bool) discove
 		Targets:   targets,
 		Timeout:   timeout,
 		VerifyTls: verifyTLS,
+	}
+	return config
+}
+
+// getDiscoverHostConfig creates a configuration for host discovery with the provided parameters.
+// It sets up the target, scan type, and stealth-specific options.
+func getDiscoverHostConfig(target string, scanType *discoverfern.HostScanType, stealth bool, sleep int, reverseLookup bool) discoverfern.DiscoverHostConfig {
+	config := discoverfern.DiscoverHostConfig{
+		Target: target,
+	}
+	if scanType != nil {
+		config.ScanType = scanType
+	}
+	if stealth {
+		config.Stealth = &discoverfern.HostStealthConfig{
+			Sleep:         &sleep,
+			ReverseLookup: &reverseLookup,
+		}
 	}
 	return config
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -237,9 +237,9 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				return
 			}
 
-			// Validate that sleep can only be set when using STEALTH scan type
-			if sleep > 0 && scanTypeEnum != discoverfern.PortScanTypeStealth {
-				a.OutputSignal.AddError(fmt.Errorf("sleep parameter can only be used with STEALTH scan type"))
+			// Validate that sleep can only be set when using stealth mode
+			if sleep > 0 && !stealth {
+				a.OutputSignal.AddError(fmt.Errorf("sleep parameter can only be used with stealth mode (--stealth flag)"))
 				return
 			}
 

--- a/fern/definition/common/common.yml
+++ b/fern/definition/common/common.yml
@@ -50,3 +50,4 @@ types:
       - TCPTLS
       - UDP
       - UNKNOWN
+

--- a/fern/definition/discover/host.yml
+++ b/fern/definition/discover/host.yml
@@ -7,13 +7,29 @@ types:
       - ICMP_TIMESTAMP
       - ARP
       - ICMP_ADDRESS_MASK
+  # Stealth config
+  HostStealthConfig:
+    properties:
+      sleep: optional<integer>          # Sleep delay in milliseconds between hosts
+      reverseLookup: optional<boolean>  # Perform reverse DNS lookup sweep first
   # Report structs
   HostDetails:
     properties:
       ip: string
       host: string
+  # Config
+  DiscoverHostConfig:
+    properties:
+      target: string
+      scanType: optional<HostScanType>
+      stealth: optional<HostStealthConfig>
+  # Result
+  DiscoverHostResult:
+    properties:
+      hosts: optional<list<HostDetails>>
   # Final report
   DiscoverHostReport:
     properties:
-      hosts: list<HostDetails>
-      errors: list<string>
+      config: DiscoverHostConfig
+      result: DiscoverHostResult
+      errors: optional<list<string>>

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -6,7 +6,10 @@ types:
     enum:
       - SYN
       - CONNECT
-      - STEALTH
+  # Stealth config
+  PortStealthConfig:
+    properties:
+      sleep: optional<integer>  # Sleep delay in milliseconds between ports
   # Report structs
   PortDetails:
     properties:
@@ -32,7 +35,7 @@ types:
       validateHostname: optional<string>
       validateAttemptTimeout: optional<integer>
       validateThreads: optional<integer>
-      sleep: optional<integer>
+      stealth: optional<PortStealthConfig>
   # Final report
   DiscoverPortReport:
     properties:

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
 	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/net v0.43.0 // indirect
+	golang.org/x/net v0.43.0
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect

--- a/internal/discover/host/host.go
+++ b/internal/discover/host/host.go
@@ -14,19 +14,30 @@ import (
 	runner "github.com/projectdiscovery/naabu/v2/pkg/runner"
 )
 
-// RunHostDiscovery performs host discovery on the specified target using the given scan type.
+// RunHostDiscovery performs host discovery on the specified target using the provided configuration.
 // It returns a report containing discovered hosts and any errors encountered during the process.
 // The target can be a single IP, hostname, or CIDR range.
-func RunHostDiscovery(ctx context.Context, target string, scantype discoverfern.HostScanType) (discoverfern.DiscoverHostReport, error) {
+func RunHostDiscovery(ctx context.Context, config discoverfern.DiscoverHostConfig) (*discoverfern.DiscoverHostReport, error) {
 	errors := []string{}
 
-	hostDiscoverResult, err := getHostDiscover(ctx, target, scantype)
+	var hostDiscoverResult []*discoverfern.HostDetails
+	var err error
+
+	if config.Stealth != nil {
+		hostDiscoverResult, err = getStealthHostDiscovery(ctx, config)
+	} else if config.ScanType != nil {
+		hostDiscoverResult, err = getHostDiscover(ctx, config.Target, *config.ScanType)
+	} else {
+		return nil, fmt.Errorf("either scan-type or stealth mode must be specified")
+	}
+
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
 
-	return discoverfern.DiscoverHostReport{
-		Hosts:  hostDiscoverResult,
+	return &discoverfern.DiscoverHostReport{
+		Config: &config,
+		Result: &discoverfern.DiscoverHostResult{Hosts: hostDiscoverResult},
 		Errors: errors,
 	}, nil
 }

--- a/internal/discover/host/stealth.go
+++ b/internal/discover/host/stealth.go
@@ -1,0 +1,208 @@
+package discover
+
+import (
+	// Standard
+	"context"
+	"net"
+	"time"
+
+	// Generated
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	// Internal
+	"github.com/Method-Security/networkscan/utils"
+	// External
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+)
+
+// performReverseLookupSweep performs reverse DNS lookups on all IPs in a CIDR range
+// Returns a list of IPs that have reverse DNS entries (potential active hosts)
+func performReverseLookupSweep(target string) ([]string, error) {
+	// Get all possible IPs from the target
+	allHosts, err := utils.ParseTargetHosts(target)
+	if err != nil {
+		return nil, err
+	}
+
+	var hostsWithReverseDNS []string
+
+	// Perform reverse lookup on each IP
+	for _, host := range allHosts {
+		ip := net.ParseIP(host)
+		if ip == nil {
+			// If it's not an IP, assume it's a hostname and include it
+			hostsWithReverseDNS = append(hostsWithReverseDNS, host)
+			continue
+		}
+
+		// Perform reverse lookup
+		names, err := net.LookupAddr(host)
+		if err == nil && len(names) > 0 {
+			// Found reverse DNS entry, likely an active host
+			hostsWithReverseDNS = append(hostsWithReverseDNS, host)
+		}
+	}
+
+	return hostsWithReverseDNS, nil
+}
+
+// getStealthHostDiscovery performs stealth host discovery using ICMP ping
+// Requires root privileges for raw socket access
+func getStealthHostDiscovery(ctx context.Context, config discoverfern.DiscoverHostConfig) ([]*discoverfern.HostDetails, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Default delay of 100ms between hosts if not specified
+	delay := time.Duration(100) * time.Millisecond
+	if config.Stealth != nil && config.Stealth.Sleep != nil {
+		delay = time.Duration(*config.Stealth.Sleep) * time.Millisecond
+	}
+
+	// Determine target hosts based on reverse lookup setting
+	var targetHosts []string
+	var err error
+
+	if config.Stealth.ReverseLookup != nil && *config.Stealth.ReverseLookup {
+		// Perform reverse lookup sweep first
+		log.Debug("Performing reverse DNS lookup sweep", svc1log.SafeParam("target", config.Target))
+		targetHosts, err = performReverseLookupSweep(config.Target)
+		if err != nil {
+			return nil, err
+		}
+
+		// If no hosts found with reverse DNS, fall back to full range scan
+		if len(targetHosts) == 0 {
+			log.Debug("No reverse DNS entries found, falling back to full range scan")
+			targetHosts, err = utils.ParseTargetHosts(config.Target)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			log.Debug("Found hosts with reverse DNS entries", svc1log.SafeParam("count", len(targetHosts)))
+		}
+	} else {
+		// Parse target hosts using the utility function
+		targetHosts, err = utils.ParseTargetHosts(config.Target)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	log.Debug("Starting stealth host discovery",
+		svc1log.SafeParam("target", config.Target),
+		svc1log.SafeParam("hosts", len(targetHosts)),
+		svc1log.SafeParam("delay_ms", delay.Milliseconds()))
+
+	var liveHosts []*discoverfern.HostDetails
+
+	// Scan each host with delay
+	for i, host := range targetHosts {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		// Progress logging every 50 hosts for stealth
+		if i%50 == 0 && i > 0 {
+			log.Debug("Stealth scan progress",
+				svc1log.SafeParam("completed", i),
+				svc1log.SafeParam("total", len(targetHosts)),
+				svc1log.SafeParam("found", len(liveHosts)))
+		}
+
+		hostDetail := checkHostAlive(ctx, host)
+		if hostDetail != nil {
+			liveHosts = append(liveHosts, hostDetail)
+			log.Debug("Found live host", svc1log.SafeParam("host", hostDetail.Ip))
+		}
+	}
+
+	return liveHosts, nil
+}
+
+// checkHostAlive performs ICMP ping to determine if a host is alive
+func checkHostAlive(ctx context.Context, host string) *discoverfern.HostDetails {
+	if pingHost(ctx, host) {
+		return &discoverfern.HostDetails{
+			Ip:   host,
+			Host: host,
+		}
+	}
+	return nil
+}
+
+// pingHost performs ICMP ping to check if a host is reachable
+func pingHost(ctx context.Context, host string) bool {
+	// Parse the target IP
+	targetIP := net.ParseIP(host)
+	if targetIP == nil {
+		// Try to resolve hostname to IP
+		addrs, err := net.LookupIP(host)
+		if err != nil || len(addrs) == 0 {
+			return false
+		}
+		targetIP = addrs[0]
+	}
+
+	// Create ICMP connection
+	conn, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	// Create ICMP message
+	msg := &icmp.Message{
+		Type: ipv4.ICMPTypeEcho,
+		Code: 0,
+		Body: &icmp.Echo{
+			ID:   1,
+			Seq:  1,
+			Data: []byte("ping"),
+		},
+	}
+
+	msgBytes, err := msg.Marshal(nil)
+	if err != nil {
+		return false
+	}
+
+	// Set timeout
+	deadline := time.Now().Add(2 * time.Second)
+	err = conn.SetDeadline(deadline)
+	if err != nil {
+		return false
+	}
+
+	// Send ping
+	_, err = conn.WriteTo(msgBytes, &net.IPAddr{IP: targetIP})
+	if err != nil {
+		return false
+	}
+
+	// Read response
+	reply := make([]byte, 1500)
+	n, _, err := conn.ReadFrom(reply)
+	if err != nil {
+		return false
+	}
+
+	// Parse reply - use protocol number 1 for ICMPv4
+	replyMsg, err := icmp.ParseMessage(1, reply[:n])
+	if err != nil {
+		return false
+	}
+
+	// Check if it's an echo reply and verify it's our ping
+	if replyMsg.Type == ipv4.ICMPTypeEchoReply {
+		if echoReply, ok := replyMsg.Body.(*icmp.Echo); ok {
+			return echoReply.ID == 1
+		}
+	}
+	return false
+}

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -37,7 +37,7 @@ func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*
 	var portscanResult []*discoverfern.SocketDetails
 	var err error
 
-	if config.ScanType == discoverfern.PortScanTypeStealth {
+	if config.Stealth != nil {
 		portscanResult, err = getStealthPortScan(ctx, config)
 	} else {
 		portscanResult, err = getPortScan(ctx, config)

--- a/internal/discover/port/stealth.go
+++ b/internal/discover/port/stealth.go
@@ -42,8 +42,8 @@ func getStealthPortScan(ctx context.Context, config discoverfern.DiscoverPortCon
 
 	// Default delay of 100ms between port scans if not specified
 	delay := time.Duration(100) * time.Millisecond
-	if config.Sleep != nil {
-		delay = time.Duration(*config.Sleep) * time.Millisecond
+	if config.Stealth != nil && config.Stealth.Sleep != nil {
+		delay = time.Duration(*config.Stealth.Sleep) * time.Millisecond
 	}
 
 	// Get target ports to scan

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -3,11 +3,13 @@ package utils
 
 import (
 	"bufio"
+	"fmt"
 	"math/rand"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
 )
@@ -97,4 +99,68 @@ func GenerateRandomString(length int) string {
 		b[i] = charset[rand.Intn(len(charset))]
 	}
 	return string(b)
+}
+
+// ParseTargetHosts expands CIDR ranges and hostnames into individual IP addresses
+func ParseTargetHosts(target string) ([]string, error) {
+	var hosts []string
+
+	if strings.Contains(target, "/") {
+		// Must be a valid CIDR - no smart parsing
+		ip, ipnet, err := net.ParseCIDR(target)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR: %s", target)
+		}
+
+		// Verify the IP is actually the network address
+		if !ip.Equal(ipnet.IP) {
+			return nil, fmt.Errorf("invalid CIDR: %s is not a network address", target)
+		}
+
+		// Generate all IPs in the CIDR range
+		for ip := ipnet.IP.Mask(ipnet.Mask); ipnet.Contains(ip); IncIP(ip) {
+			hosts = append(hosts, ip.String())
+		}
+
+		// Remove network and broadcast addresses for /24 and smaller
+		ones, _ := ipnet.Mask.Size()
+		if ones >= 24 && len(hosts) > 2 {
+			hosts = hosts[1 : len(hosts)-1]
+		}
+	} else if strings.Contains(target, "-") {
+		// IP range like 192.168.1.1-192.168.1.10
+		parts := strings.Split(target, "-")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid IP range: %s", target)
+		}
+
+		startIP := net.ParseIP(strings.TrimSpace(parts[0]))
+		endIP := net.ParseIP(strings.TrimSpace(parts[1]))
+		if startIP == nil || endIP == nil {
+			return nil, fmt.Errorf("invalid IP range: %s", target)
+		}
+
+		// Generate IPs in range
+		for ip := make(net.IP, len(startIP)); copy(ip, startIP) > 0; IncIP(ip) {
+			hosts = append(hosts, ip.String())
+			if ip.Equal(endIP) {
+				break
+			}
+		}
+	} else {
+		// Single host or hostname
+		hosts = append(hosts, target)
+	}
+
+	return hosts, nil
+}
+
+// IncIP increments an IP address
+func IncIP(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
 }


### PR DESCRIPTION
### TL;DR

Added stealth host discovery mode with custom ICMP ping implementation and improved port scanning options.

### What changed?

- Added a new stealth host discovery mode using custom ICMP ping implementation
- Moved host discovery code to a dedicated package (`internal/discover/host`)
- Added reverse DNS lookup sweep capability to identify potential targets
- Restructured port scanning to use a dedicated stealth configuration
- Updated Fern definitions to support new stealth configurations for both host and port scanning
- Added privilege checking only when stealth mode is enabled (rather than for all host discovery)
- Added new CLI flags for host discovery:
  - `--stealth` to enable stealth mode
  - `--sleep` to control delay between scans
  - `--reverse-lookup` to perform DNS lookups first
- Added utility functions for parsing target hosts and IP ranges

### How to test?

1. Test host discovery with stealth mode:
   ```
   sudo ./networkscan discover host --target 192.168.1.0/24 --stealth
   ```

2. Test with reverse DNS lookup:
   ```
   sudo ./networkscan discover host --target 192.168.1.0/24 --stealth --reverse-lookup
   ```

3. Test port scanning with stealth mode:
   ```
   ./networkscan discover port --target example.com --ports 1-1000 --stealth --sleep 200
   ```

4. Verify regular host discovery still works:
   ```
   sudo ./networkscan discover host --target 192.168.1.0/24 --scan-type ICMP_ECHO
   ```

### Why make this change?

This change improves the tool's stealthiness capabilities by implementing a custom ICMP ping method that provides more control over timing and behavior. The stealth mode helps avoid detection by intrusion detection systems during security assessments. The reverse DNS lookup feature helps optimize scanning by focusing on hosts that are more likely to be active, reducing scan time and network noise.