### PR TITLE
SAN for TLS Configs

### DIFF
--- a/fern/definition/discover/tls.yml
+++ b/fern/definition/discover/tls.yml
@@ -58,6 +58,7 @@ types:
       version: integer
       issuerCommonName: optional<string> # Can be empty
       subjectCommonName: optional<string> # Can be empty
+      subjectAlternativeNames: list<string>
   TlsDetails:
     properties:
       version: TlsVersion

--- a/internal/discover/tls.go
+++ b/internal/discover/tls.go
@@ -153,14 +153,15 @@ func convertToTLSInfo(state *tls.ConnectionState) *discoverfern.TlsDetails {
 		certString := string(certPEM)
 		signatureHex := hex.EncodeToString(cert.Signature)
 		certificate := &discoverfern.Certificate{
-			Certificate:       certString,
-			SerialNumber:      serialNumber,
-			Signature:         signatureHex,
-			SubjectCommonName: &cert.Subject.CommonName,
-			IssuerCommonName:  &cert.Issuer.CommonName,
-			ValidFrom:         cert.NotBefore,
-			ValidTo:           cert.NotAfter,
-			Version:           cert.Version,
+			Certificate:             certString,
+			SerialNumber:            serialNumber,
+			Signature:               signatureHex,
+			SubjectCommonName:       &cert.Subject.CommonName,
+			IssuerCommonName:        &cert.Issuer.CommonName,
+			ValidFrom:               cert.NotBefore,
+			ValidTo:                 cert.NotAfter,
+			Version:                 cert.Version,
+			SubjectAlternativeNames: cert.DNSNames,
 		}
 
 		// Signature names defined in `signatureAlgorithmDetails` in the `x509` package have a hyphen


### PR DESCRIPTION
### TL;DR

ffAdded support for Subject Alternative Names (SANs) in TLS certificate information.

### What changed?

- Added a new field `subjectAlternativeNames` to the `Certificate` type in the Fern definition
- Updated the `convertToTLSInfo` function to populate the new field with DNS names from the certificate

### How to test?

1. Make a TLS connection to a server with certificates that have Subject Alternative Names
2. Verify that the `subjectAlternativeNames` field is populated with the correct DNS names from the certificate

### Why make this change?

Subject Alternative Names are an important part of modern TLS certificates, especially for servers that host multiple domains on a single IP address. Including this information provides more complete certificate details for discovery and analysis purposes, which is valuable for security assessments and troubleshooting.