### PR TITLE
Stealth Credential Spray

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -109,6 +109,8 @@ func (a *NetworkScan) createUsernameSprayCommand(parent *cobra.Command) {
 	usernameCmd.Flags().String("username-scheme", "", "Generate usernames using scheme (FLAST, FIRST_DOT_LAST, FIRSTLAST, LASTFIRST, FIRST, LAST, F_LAST, FIRST_LAST)")
 	usernameCmd.Flags().StringP("domain", "d", "", "Domain for Kerberos authentication")
 	usernameCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
+	usernameCmd.Flags().Int("sleep", 0, "Delay between username attempts in seconds")
+	usernameCmd.Flags().Int("jitter", 0, "Random jitter percentage (0-100) to apply to sleep delays")
 	usernameCmd.Flags().Bool("successful-only", false, "Only show successful username enumerations in output")
 
 	// Mark required flags
@@ -893,13 +895,23 @@ func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []st
 		return nil, fmt.Errorf("timeout must be positive")
 	}
 
+	sleep, err := cmd.Flags().GetInt("sleep")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sleep: %v", err)
+	}
+
+	jitter, err := cmd.Flags().GetInt("jitter")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get jitter: %v", err)
+	}
+
 	successfulOnly, err := cmd.Flags().GetBool("successful-only")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get successful-only: %v", err)
 	}
 
 	// Set Config
-	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, usernameScheme, domain, timeout, successfulOnly)
+	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, usernameScheme, domain, timeout, sleep, jitter, successfulOnly)
 
 	return config, nil
 }
@@ -948,7 +960,12 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 }
 
 // getSprayUsernameConfig creates a configuration for username enumeration operations with the provided parameters.
-func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetService, usernameLists []pentestfern.WordlistType, usernames []string, usernameScheme *pentestfern.UsernameScheme, domain string, timeout int, successfulOnly bool) *pentestfern.PentestSprayConfig {
+func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetService, usernameLists []pentestfern.WordlistType, usernames []string, usernameScheme *pentestfern.UsernameScheme, domain string, timeout int, sleep int, jitter int, successfulOnly bool) *pentestfern.PentestSprayConfig {
+	var jitterPtr *int
+	if jitter > 0 {
+		jitterPtr = &jitter
+	}
+
 	return &pentestfern.PentestSprayConfig{
 		SprayMode: strings.ToLower(string(pentestfern.SprayModeUsername)),
 		Username: &pentestfern.SprayUsernameConfig{
@@ -959,8 +976,10 @@ func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetSer
 			UsernameScheme:  usernameScheme,
 			Domain:          domain,
 			Timeout:         timeout,
+			Sleep:           sleep,
 			ContinueOnError: true,
 			SuccessfulOnly:  successfulOnly,
+			Jitter:          jitterPtr,
 		},
 	}
 }

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -134,10 +134,14 @@ types:
 
       # Attack configuration
       timeout: integer
+      sleep: integer
 
       # Behavior configuration
       continueOnError: boolean
       successfulOnly: boolean
+
+      # Rate limiting and stealth
+      jitter: optional<integer>
 
   # Report Types (following three-part pattern: config, result, errors)
   PentestSprayConfig:

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -151,7 +151,7 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 		config.Timeout = timeoutMs
 
 		attemptNumber := 1
-		for _, username := range usernames {
+		for i, username := range usernames {
 			attempt, err := e.performUsernameEnumAttempt(ctx, target, config.Service, username, attemptNumber, config)
 			if err != nil {
 				errors = append(errors, err.Error())
@@ -173,7 +173,24 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 				log.Info("Valid username found", svc1log.SafeParam("username", username))
 			}
 
-			// Username enumeration does not use sleep - each username is only tested once
+			// Apply delay with jitter between username attempts (except after last username)
+			if config.Sleep > 0 && i < len(usernames)-1 {
+				var jitterPercent int
+				if config.Jitter != nil {
+					jitterPercent = *config.Jitter
+				}
+
+				delay := calculateDelayWithJitter(config.Sleep, jitterPercent)
+
+				if delay > 0 {
+					log.Info("Sleeping between username attempts",
+						svc1log.SafeParam("base_sleep_seconds", config.Sleep),
+						svc1log.SafeParam("actual_delay_ms", delay.Milliseconds()),
+						svc1log.SafeParam("jitter_percent", jitterPercent))
+					time.Sleep(delay)
+				}
+			}
+
 			attemptNumber++
 		}
 	} else {


### PR DESCRIPTION
### TL;DR

Added sleep and jitter options to username spray attacks for more controlled and stealthy enumeration.

### What changed?

- Added two new command-line flags to the username spray command:
  - `--sleep`: Delay between username attempts in seconds
  - `--jitter`: Random jitter percentage (0-100) to apply to sleep delays
- Updated the `SprayUsernameConfig` type in the API definition to include the new sleep and jitter fields
- Implemented the delay logic in the username enumeration process to pause between attempts with optional randomized jitter
- Modified the function signatures and parameter passing to support these new options

### How to test?

1. Run a username spray attack with sleep delay:
   ```
   ./pentest username-spray --target 192.168.1.1 --service smb --username-list common --sleep 2
   ```

2. Run a username spray attack with sleep and jitter for more randomized timing:
   ```
   ./pentest username-spray --target 192.168.1.1 --service smb --username-list common --sleep 5 --jitter 30
   ```

3. Verify in logs that the tool is sleeping between attempts with the specified parameters

### Why make this change?

This change helps prevent triggering security alerts during username enumeration by allowing for controlled delays between attempts. The addition of jitter introduces randomness to the timing, making the enumeration pattern less predictable and more likely to evade detection by security monitoring systems. This is particularly important in penetration testing scenarios where stealth is required.