### PR TITLE
Add CIDR and IP range support to port scanning

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -186,8 +186,8 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	// Port Command
 	discoverPortCmd := &cobra.Command{
 		Use:   "port",
-		Short: "Scan a target host for open TCP ports using customizable scan types and port ranges.",
-		Long:  `Scan a target host for open TCP ports using customizable scan types and port ranges.`,
+		Short: "Scan target hosts for open TCP ports using customizable scan types and port ranges.",
+		Long:  `Scan target hosts for open TCP ports using customizable scan types and port ranges. Supports single IPs, hostnames, CIDR ranges, and IP ranges.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Target flags
 			target, err := cmd.Flags().GetString("target")
@@ -307,7 +307,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	discoverPortCmd.Flags().String("target", "", "Target IP address or FQDN to scan for open ports")
+	discoverPortCmd.Flags().String("target", "", "Target IP address, FQDN, CIDR range, or IP range to scan for open ports")
 	discoverPortCmd.Flags().String("ports", "", "Comma-separated list or range of TCP ports to scan (e.g., 22,80,443 or 1-1024)")
 	discoverPortCmd.Flags().String("top-ports", "", "Scan the top N most common TCP ports (options: full, 100, 1000)")
 	discoverPortCmd.Flags().Int("threads", 25, "Number of concurrent threads to use during port scanning")
@@ -473,7 +473,7 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 		Ports:    &ports,
 		TopPorts: &topPorts,
 	}
-	
+
 	if stealth && sleep > 0 {
 		// Stealth mode - only set stealth-specific config
 		stealthConfig := &discoverfern.PortStealthConfig{
@@ -488,7 +488,7 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 		config.Threads = threads
 		config.ScanType = scanType
 		config.Validate = validate
-		
+
 		// Validation-related fields only apply to regular scans
 		if validateHostname != nil {
 			config.ValidateHostname = validateHostname
@@ -500,7 +500,7 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 			config.ValidateThreads = validateThreads
 		}
 	}
-	
+
 	return config
 }
 

--- a/internal/discover/host/stealth.go
+++ b/internal/discover/host/stealth.go
@@ -104,11 +104,11 @@ func getStealthHostDiscovery(ctx context.Context, config discoverfern.DiscoverHo
 		if i > 0 {
 			// Calculate a new jittered delay for each attempt
 			delay := utils.CalculateStealthDelay(sleepPtr, jitterPtr)
-			
+
 			log.Info("Applying stealth delay before scanning host",
 				svc1log.SafeParam("host", host),
 				svc1log.SafeParam("delay_ms", delay.Milliseconds()))
-			
+
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -12,6 +13,8 @@ import (
 	common "github.com/Method-Security/networkscan/generated/go/common"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 
+	// Internal
+	"github.com/Method-Security/networkscan/utils"
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	goflags "github.com/projectdiscovery/goflags"
@@ -72,6 +75,13 @@ func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*
 func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([]*discoverfern.SocketDetails, error) {
 	// Hide OS args from Naabu
 	hideOsArgsFromNaabu()
+
+	// Expand target hosts (handles CIDR ranges, IP ranges, and single hosts)
+	targetHosts, err := utils.ParseTargetHosts(config.Target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse target hosts: %w", err)
+	}
+
 	output := result.HostResult{}
 	hosts := []*discoverfern.SocketDetails{}
 	// These settings mimic naabu's default settings
@@ -83,7 +93,7 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 		Retries:           runner.DefaultRetriesConnectScan,
 		Threads:           config.Threads,
 		Timeout:           runner.DefaultPortTimeoutConnectScan,
-		Host:              goflags.StringSlice{config.Target},
+		Host:              goflags.StringSlice(targetHosts), // Use expanded hosts
 		SkipHostDiscovery: true,
 		WarmUpTime:        2,
 		InputReadTimeout:  180000000000, // This is their default

--- a/internal/discover/port/stealth.go
+++ b/internal/discover/port/stealth.go
@@ -34,11 +34,16 @@ var (
 	topPortsConfigLock sync.RWMutex
 )
 
-
 // getStealthPortScan performs a stealth port scan using native Go networking capabilities.
 // It provides delay control and top-N port targeting for more covert scanning.
 func getStealthPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([]*discoverfern.SocketDetails, error) {
 	log := svc1log.FromContext(ctx)
+
+	// Expand target hosts (handles CIDR ranges, IP ranges, and single hosts)
+	targetHosts, err := utils.ParseTargetHosts(config.Target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse target hosts: %w", err)
+	}
 
 	// Get stealth delay configuration (but don't calculate delay yet - do it per attempt)
 	var sleepPtr, jitterPtr *int
@@ -55,47 +60,58 @@ func getStealthPortScan(ctx context.Context, config discoverfern.DiscoverPortCon
 
 	// Calculate initial delay for logging purposes
 	initialDelay := utils.CalculateStealthDelay(sleepPtr, jitterPtr)
-	
+
 	log.Info("Starting stealth port scan",
 		svc1log.SafeParam("target", config.Target),
+		svc1log.SafeParam("hosts", len(targetHosts)),
 		svc1log.SafeParam("ports", len(targetPorts)),
 		svc1log.SafeParam("base_delay_ms", initialDelay.Milliseconds()))
 
-	var openPorts []*discoverfern.PortDetails
+	var allSocketDetails []*discoverfern.SocketDetails
 
-	// Scan each port with jittered delay
-	for i, port := range targetPorts {
-		if i > 0 {
-			// Calculate a new jittered delay for each attempt
-			delay := utils.CalculateStealthDelay(sleepPtr, jitterPtr)
-			
-			log.Info("Applying stealth delay before scanning port",
-				svc1log.SafeParam("port", port),
-				svc1log.SafeParam("delay_ms", delay.Milliseconds()))
-			
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(delay):
+	// Scan each host
+	for _, host := range targetHosts {
+		var openPorts []*discoverfern.PortDetails
+
+		// Scan each port on this host with jittered delay
+		for i, port := range targetPorts {
+			if i > 0 || len(allSocketDetails) > 0 {
+				// Calculate a new jittered delay for each attempt (skip first port of first host)
+				delay := utils.CalculateStealthDelay(sleepPtr, jitterPtr)
+
+				log.Debug("Applying stealth delay before scanning",
+					svc1log.SafeParam("host", host),
+					svc1log.SafeParam("port", port),
+					svc1log.SafeParam("delay_ms", delay.Milliseconds()))
+
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(delay):
+				}
+			}
+
+			if isPortOpen(ctx, host, port) {
+				openPorts = append(openPorts, &discoverfern.PortDetails{
+					Port:     port,
+					Protocol: common.TransportTypeTcp,
+				})
+				log.Debug("Found open port",
+					svc1log.SafeParam("host", host),
+					svc1log.SafeParam("port", port))
 			}
 		}
 
-		if isPortOpen(ctx, config.Target, port) {
-			openPorts = append(openPorts, &discoverfern.PortDetails{
-				Port:     port,
-				Protocol: common.TransportTypeTcp,
-			})
-			log.Debug("Found open port", svc1log.SafeParam("port", port))
+		socketDetails := &discoverfern.SocketDetails{
+			Host:  host,
+			Ip:    host, // For stealth scan, we'll use host as IP for simplicity
+			Ports: openPorts,
 		}
+
+		allSocketDetails = append(allSocketDetails, socketDetails)
 	}
 
-	socketDetails := &discoverfern.SocketDetails{
-		Host:  config.Target,
-		Ip:    config.Target, // For stealth scan, we'll use target as IP for simplicity
-		Ports: openPorts,
-	}
-
-	return []*discoverfern.SocketDetails{socketDetails}, nil
+	return allSocketDetails, nil
 }
 
 // getStealthTargetPorts determines which ports to scan based on the stealth configuration
@@ -284,4 +300,3 @@ func isPortOpen(ctx context.Context, host string, port int) bool {
 	_ = conn.Close()
 	return true
 }
-


### PR DESCRIPTION
### TL;DR

Enhanced port scanning to support multiple target formats including CIDR ranges and IP ranges.

### What changed?

- Updated the port scanning functionality to handle multiple target formats:
  - Single IP addresses
  - Hostnames/FQDNs
  - CIDR ranges (e.g., 192.168.1.0/24)
  - IP ranges (e.g., 192.168.1.1-192.168.1.254)
- Improved stealth scanning to work with multiple hosts by:
  - Adding proper host expansion in both regular and stealth scanning modes
  - Implementing jittered delays between scanning different hosts
  - Enhancing logging to include host information
- Updated command help text to reflect the expanded capabilities

### How to test?

Test the port scanning with various target formats:
```bash
# Single IP
networkscan discover port --target 192.168.1.1 --ports 80,443

# CIDR range
networkscan discover port --target 192.168.1.0/24 --ports 22,80,443

# IP range
networkscan discover port --target 192.168.1.1-192.168.1.10 --ports 1-1024

# With stealth mode
networkscan discover port --target 10.0.0.0/24 --ports 80,443 --stealth --sleep 500
```

### Why make this change?

This enhancement significantly improves the utility of the port scanning feature by allowing users to scan entire network ranges in a single command, rather than having to scan hosts individually. The stealth scanning improvements ensure that multi-host scanning maintains the same careful timing controls to avoid detection, making the tool more effective for security assessments across larger network segments.