### PR TITLE
LDAP Domain Dump Stealth + Cred Spray Log Evasion

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -58,18 +58,8 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				scanTypeEnum = &scanTypeEnumValue
 			}
 
-			// Check privileges for stealth scan
-			stealth, err := cmd.Flags().GetBool("stealth")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			// Validate that either stealth or scan-type is specified
-			if !stealth && scanTypeEnum == nil {
-				a.OutputSignal.AddError(errors.New("either --stealth or --scan-type must be specified"))
-				return
-			}
+			// Determine if stealth mode should be used (when sleep is specified)
+			stealth := false
 
 			// Stealth flags - get these early for validation
 			sleep, err := cmd.Flags().GetInt("sleep")
@@ -88,19 +78,12 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				return
 			}
 
-			// Validate that sleep and jitter can only be set when using stealth mode
-			if sleep > 0 && !stealth {
-				a.OutputSignal.AddError(fmt.Errorf("sleep parameter can only be used with stealth mode (--stealth flag)"))
-				return
-			}
-			if jitter > 0 && !stealth {
-				a.OutputSignal.AddError(fmt.Errorf("jitter parameter can only be used with stealth mode (--stealth flag)"))
-				return
-			}
+			// Determine if stealth mode should be used (when sleep > 0)
+			stealth = sleep > 0 || reverseLookup
 
-			// Validate stealth mode requirements
-			if stealth && sleep == 0 {
-				a.OutputSignal.AddError(errors.New("--sleep must be specified (> 0) when using --stealth"))
+			// Validate that if not stealth mode, we need a scan type
+			if !stealth && scanTypeEnum == nil {
+				a.OutputSignal.AddError(errors.New("--scan-type must be specified when not using stealth mode (sleep > 0)"))
 				return
 			}
 
@@ -130,8 +113,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	}
 	discoverHostCmd.Flags().String("target", "", "Target IP address, hostname, or CIDR range to scan for live hosts")
 	discoverHostCmd.Flags().String("scan-type", "", "Discovery scan type: TCP_SYN, TCP_ACK, ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK (not needed for stealth mode)")
-	discoverHostCmd.Flags().Bool("stealth", false, "Enable stealth host discovery using custom ICMP ping implementation")
-	discoverHostCmd.Flags().Int("sleep", 0, "Sleep delay in seconds between hosts for stealth scan (required when using --stealth)")
+	discoverHostCmd.Flags().Int("sleep", 0, "Sleep delay in seconds between hosts for stealth scan (stealth mode enabled when sleep > 0)")
 	discoverHostCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delay for stealth scan")
 	discoverHostCmd.Flags().Bool("reverse-lookup", false, "Perform reverse DNS lookup sweep first to identify potential targets")
 
@@ -257,11 +239,6 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Stealth flags
-			stealth, err := cmd.Flags().GetBool("stealth")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			sleep, err := cmd.Flags().GetInt("sleep")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -273,21 +250,8 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				return
 			}
 
-			// Validate that sleep and jitter can only be set when using stealth mode
-			if sleep > 0 && !stealth {
-				a.OutputSignal.AddError(fmt.Errorf("sleep parameter can only be used with stealth mode (--stealth flag)"))
-				return
-			}
-			if jitter > 0 && !stealth {
-				a.OutputSignal.AddError(fmt.Errorf("jitter parameter can only be used with stealth mode (--stealth flag)"))
-				return
-			}
-
-			// Validate stealth mode requirements
-			if stealth && sleep == 0 {
-				a.OutputSignal.AddError(errors.New("--sleep must be specified (> 0) when using --stealth"))
-				return
-			}
+			// Determine if stealth mode should be used (when sleep > 0)
+			stealth := sleep > 0
 
 			// Validate jitter range
 			if jitter < 0 || jitter > 100 {
@@ -316,8 +280,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverPortCmd.Flags().String("validate-hostname", "", "Hostname to validate against (e.g., example.com)")
 	discoverPortCmd.Flags().Int("validate-attempt-timeout", 10, "Timeout in seconds for each service detection attempt")
 	discoverPortCmd.Flags().Int("validate-threads", 0, "Number of concurrent threads to use during service detection")
-	discoverPortCmd.Flags().Bool("stealth", false, "Enable stealth port scanning with custom delay control")
-	discoverPortCmd.Flags().Int("sleep", 0, "Sleep delay in seconds between port scans for stealth scan (required when using --stealth)")
+	discoverPortCmd.Flags().Int("sleep", 0, "Sleep delay in seconds between port scans for stealth scan (stealth mode enabled when sleep > 0)")
 	discoverPortCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delay for stealth scan")
 
 	// Mark Required Flags
@@ -344,22 +307,14 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Stealth flags
-			stealth, err := cmd.Flags().GetBool("stealth")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			serviceType, err := cmd.Flags().GetString("service-type")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
-			// Validate stealth mode requirements
-			if stealth && serviceType == "" {
-				a.OutputSignal.AddError(errors.New("--service-type must be specified when using --stealth"))
-				return
-			}
+			// Determine if stealth mode should be used (when service-type is specified)
+			stealth := serviceType != ""
 
 			// Set Config
 			config := getDiscoverServiceConfig(target, timeout, stealth, serviceType)
@@ -375,8 +330,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	}
 	discoverServiceCmd.Flags().String("target", "", "Target address in format IP:port or hostname:port (e.g., 192.168.1.1:443)")
 	discoverServiceCmd.Flags().Int("timeout", 5, "Timeout in seconds for each service fingerprinting attempt")
-	discoverServiceCmd.Flags().Bool("stealth", false, "Enable stealth service fingerprinting for specific protocols")
-	discoverServiceCmd.Flags().String("service-type", "", "Service type to fingerprint in stealth mode: SSH, HTTP, GRPC, KERBEROS, LDAP, SMB")
+	discoverServiceCmd.Flags().String("service-type", "", "Service type to fingerprint for stealth mode: SSH, HTTP, GRPC, KERBEROS, LDAP, SMB (stealth mode enabled when specified)")
 
 	// Mark Required Flags
 	_ = discoverServiceCmd.MarkFlagRequired("target")

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -58,9 +58,6 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				scanTypeEnum = &scanTypeEnumValue
 			}
 
-			// Determine if stealth mode should be used (when sleep is specified)
-			stealth := false
-
 			// Stealth flags - get these early for validation
 			sleep, err := cmd.Flags().GetInt("sleep")
 			if err != nil {
@@ -72,18 +69,13 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			if jitter > 0 && sleep == 0 {
+				a.OutputSignal.AddError(fmt.Errorf("jitter parameter can only be used when sleep is also specified"))
+				return
+			}
 			reverseLookup, err := cmd.Flags().GetBool("reverse-lookup")
 			if err != nil {
 				a.OutputSignal.AddError(err)
-				return
-			}
-
-			// Determine if stealth mode should be used (when sleep > 0)
-			stealth = sleep > 0 || reverseLookup
-
-			// Validate that if not stealth mode, we need a scan type
-			if !stealth && scanTypeEnum == nil {
-				a.OutputSignal.AddError(errors.New("--scan-type must be specified when not using stealth mode (sleep > 0)"))
 				return
 			}
 
@@ -94,13 +86,13 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Check privileges for stealth scan (after other validations)
-			if !privileges.IsPrivileged && stealth {
+			if !privileges.IsPrivileged {
 				a.OutputSignal.AddError(errors.New("stealth host discovery requires root privileges for ICMP ping"))
 				return
 			}
 
 			// Set Config
-			config := getDiscoverHostConfig(target, scanTypeEnum, stealth, sleep, jitter, reverseLookup)
+			config := getDiscoverHostConfig(target, scanTypeEnum, sleep, jitter, reverseLookup)
 
 			// Generate the report
 			report, err := discoverhost.RunHostDiscovery(cmd.Context(), config)
@@ -112,7 +104,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 		},
 	}
 	discoverHostCmd.Flags().String("target", "", "Target IP address, hostname, or CIDR range to scan for live hosts")
-	discoverHostCmd.Flags().String("scan-type", "", "Discovery scan type: TCP_SYN, TCP_ACK, ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK (not needed for stealth mode)")
+	discoverHostCmd.Flags().String("scan-type", "ICMP_ECHO", "Discovery scan type: TCP_SYN, TCP_ACK, ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK (not needed for stealth mode)")
 	discoverHostCmd.Flags().Int("sleep", 0, "Sleep delay in seconds between hosts for stealth scan (stealth mode enabled when sleep > 0)")
 	discoverHostCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delay for stealth scan")
 	discoverHostCmd.Flags().Bool("reverse-lookup", false, "Perform reverse DNS lookup sweep first to identify potential targets")
@@ -249,9 +241,10 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-
-			// Determine if stealth mode should be used (when sleep > 0)
-			stealth := sleep > 0
+			if jitter > 0 && sleep == 0 {
+				a.OutputSignal.AddError(fmt.Errorf("jitter parameter can only be used when sleep is also specified"))
+				return
+			}
 
 			// Validate jitter range
 			if jitter < 0 || jitter > 100 {
@@ -260,7 +253,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPortConfig(target, ports, topPorts, threads, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, stealth, sleep, jitter)
+			config := getDiscoverPortConfig(target, ports, topPorts, threads, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, sleep, jitter)
 
 			// Generate the report
 			report, err := discoverport.RunPortScan(cmd.Context(), config)
@@ -313,11 +306,8 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				return
 			}
 
-			// Determine if stealth mode should be used (when service-type is specified)
-			stealth := serviceType != ""
-
 			// Set Config
-			config := getDiscoverServiceConfig(target, timeout, stealth, serviceType)
+			config := getDiscoverServiceConfig(target, timeout, serviceType)
 
 			// Generate the report
 			report, err := discoverservice.RunServiceFingerprint(cmd.Context(), config)
@@ -420,7 +410,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 
 // getDiscoverPortConfig creates a configuration for port scanning with the provided parameters.
 // It handles both specific port ranges and top ports scanning modes.
-func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, stealth bool, sleep int, jitter int) discoverfern.DiscoverPortConfig {
+func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, sleep int, jitter int) discoverfern.DiscoverPortConfig {
 	// Start with common fields that apply to both stealth and regular scans
 	config := discoverfern.DiscoverPortConfig{
 		Target:   target,
@@ -428,10 +418,11 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 		TopPorts: &topPorts,
 	}
 
-	if stealth && sleep > 0 {
+	if sleep > 0 || jitter > 0 {
 		// Stealth mode - only set stealth-specific config
-		stealthConfig := &discoverfern.PortStealthConfig{
-			Sleep: sleep,
+		stealthConfig := &discoverfern.PortStealthConfig{}
+		if sleep > 0 {
+			stealthConfig.Sleep = &sleep
 		}
 		if jitter > 0 {
 			stealthConfig.Jitter = &jitter
@@ -460,12 +451,12 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 
 // getDiscoverServiceConfig creates a configuration for service fingerprinting with the provided parameters.
 // It sets up the target (in IP:port format), timeout, and stealth-specific options.
-func getDiscoverServiceConfig(target string, timeout int, stealth bool, serviceType string) discoverfern.DiscoverServiceConfig {
+func getDiscoverServiceConfig(target string, timeout int, serviceType string) discoverfern.DiscoverServiceConfig {
 	config := discoverfern.DiscoverServiceConfig{
 		Target:  target,
 		Timeout: timeout,
 	}
-	if stealth && serviceType != "" {
+	if serviceType != "" {
 		// Convert to uppercase for enum parsing
 		serviceTypeEnum, err := discoverfern.NewStealthServiceTypeFromString(strings.ToUpper(serviceType))
 		if err == nil {
@@ -490,23 +481,26 @@ func getDiscoverTLSConfig(targets []string, timeout int, verifyTLS bool) discove
 
 // getDiscoverHostConfig creates a configuration for host discovery with the provided parameters.
 // It sets up the target, scan type, and stealth-specific options.
-func getDiscoverHostConfig(target string, scanType *discoverfern.HostScanType, stealth bool, sleep int, jitter int, reverseLookup bool) discoverfern.DiscoverHostConfig {
+func getDiscoverHostConfig(target string, scanType *discoverfern.HostScanType, sleep int, jitter int, reverseLookup bool) discoverfern.DiscoverHostConfig {
 	config := discoverfern.DiscoverHostConfig{
 		Target: target,
 	}
 	if scanType != nil {
 		config.ScanType = scanType
 	}
-	if stealth && sleep > 0 {
+	if sleep > 0 || jitter > 0 || reverseLookup {
 		stealthConfig := &discoverfern.HostStealthConfig{
-			Sleep:         sleep,
 			ReverseLookup: &reverseLookup,
+		}
+		if sleep > 0 {
+			stealthConfig.Sleep = &sleep
 		}
 		if jitter > 0 {
 			stealthConfig.Jitter = &jitter
 		}
 		config.Stealth = stealthConfig
 	}
+
 	return config
 }
 

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -79,6 +79,7 @@ func (a *NetworkScan) createPasswordSprayCommand(parent *cobra.Command) {
 	passwordCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
 	passwordCmd.Flags().Int("sleep", 0, "Delay between password attempts in seconds")
 	passwordCmd.Flags().Int("jitter", 0, "Random jitter percentage (0-100) to apply to sleep delays")
+	passwordCmd.Flags().Int("max-attempts", 0, "Maximum number of attempts to make (0 = unlimited)")
 	passwordCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful authentication")
 	passwordCmd.Flags().Bool("successful-only", false, "Only show successful authentications in output")
 
@@ -111,6 +112,7 @@ func (a *NetworkScan) createUsernameSprayCommand(parent *cobra.Command) {
 	usernameCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
 	usernameCmd.Flags().Int("sleep", 0, "Delay between username attempts in seconds")
 	usernameCmd.Flags().Int("jitter", 0, "Random jitter percentage (0-100) to apply to sleep delays")
+	usernameCmd.Flags().Int("max-attempts", 0, "Maximum number of attempts to make (0 = unlimited)")
 	usernameCmd.Flags().Bool("successful-only", false, "Only show successful username enumerations in output")
 
 	// Mark required flags
@@ -818,6 +820,14 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 		return nil, fmt.Errorf("jitter must be between 0 and 100")
 	}
 
+	maxAttempts, err := cmd.Flags().GetInt("max-attempts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get max-attempts: %v", err)
+	}
+	if maxAttempts < 0 {
+		return nil, fmt.Errorf("max-attempts must be non-negative")
+	}
+
 	stopFirstSuccess, err := cmd.Flags().GetBool("stop-on-first-success")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stop-on-first-success: %v", err)
@@ -829,7 +839,7 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 	}
 
 	// Set Config
-	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, ntlmHash, timeout, sleep, jitter, stopFirstSuccess, successfulOnly)
+	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, ntlmHash, timeout, sleep, jitter, maxAttempts, stopFirstSuccess, successfulOnly)
 
 	return config, nil
 }
@@ -905,19 +915,27 @@ func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []st
 		return nil, fmt.Errorf("failed to get jitter: %v", err)
 	}
 
+	maxAttempts, err := cmd.Flags().GetInt("max-attempts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get max-attempts: %v", err)
+	}
+	if maxAttempts < 0 {
+		return nil, fmt.Errorf("max-attempts must be non-negative")
+	}
+
 	successfulOnly, err := cmd.Flags().GetBool("successful-only")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get successful-only: %v", err)
 	}
 
 	// Set Config
-	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, usernameScheme, domain, timeout, sleep, jitter, successfulOnly)
+	config := getSprayUsernameConfig(targets, service, usernameListEnums, usernames, usernameScheme, domain, timeout, sleep, jitter, maxAttempts, successfulOnly)
 
 	return config, nil
 }
 
 // getSprayPasswordConfig creates a configuration for password spray operations with the provided parameters.
-func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentestfern.WordlistType, passwordLists []pentestfern.WordlistType, domain string, ntlmHash string, timeout int, sleep int, jitter int, stopFirstSuccess bool, successfulOnly bool) *pentestfern.PentestSprayConfig {
+func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentestfern.WordlistType, passwordLists []pentestfern.WordlistType, domain string, ntlmHash string, timeout int, sleep int, jitter int, maxAttempts int, stopFirstSuccess bool, successfulOnly bool) *pentestfern.PentestSprayConfig {
 	// Create config
 	var usernameFilePtr, passwordFilePtr, domainPtr *string
 	if usernameFile != "" {
@@ -932,12 +950,17 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 	// TODO: Add NTLM hash support to spray functionality
 	_ = ntlmHash // Temporarily suppress unused warning
 
-	// Create stealth config if sleep or jitter is set
+	// Create stealth config if sleep, jitter, or maxAttempts is set
 	var stealthConfig *pentestfern.SprayStealthConfig
-	if sleep > 0 {
+	if sleep > 0 || maxAttempts > 0 {
+		var maxAttemptsPtr *int
+		if maxAttempts > 0 {
+			maxAttemptsPtr = &maxAttempts
+		}
 		stealthConfig = &pentestfern.SprayStealthConfig{
-			Sleep:  sleep,
-			Jitter: &jitter,
+			Sleep:       sleep,
+			Jitter:      &jitter,
+			MaxAttempts: maxAttemptsPtr,
 		}
 	}
 
@@ -963,13 +986,18 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 }
 
 // getSprayUsernameConfig creates a configuration for username enumeration operations with the provided parameters.
-func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetService, usernameLists []pentestfern.WordlistType, usernames []string, usernameScheme *pentestfern.UsernameScheme, domain string, timeout int, sleep int, jitter int, successfulOnly bool) *pentestfern.PentestSprayConfig {
-	// Create stealth config if sleep or jitter is set
+func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetService, usernameLists []pentestfern.WordlistType, usernames []string, usernameScheme *pentestfern.UsernameScheme, domain string, timeout int, sleep int, jitter int, maxAttempts int, successfulOnly bool) *pentestfern.PentestSprayConfig {
+	// Create stealth config if sleep, jitter, or maxAttempts is set
 	var stealthConfig *pentestfern.SprayStealthConfig
-	if sleep > 0 {
+	if sleep > 0 || maxAttempts > 0 {
+		var maxAttemptsPtr *int
+		if maxAttempts > 0 {
+			maxAttemptsPtr = &maxAttempts
+		}
 		stealthConfig = &pentestfern.SprayStealthConfig{
-			Sleep:  sleep,
-			Jitter: &jitter,
+			Sleep:       sleep,
+			Jitter:      &jitter,
+			MaxAttempts: maxAttemptsPtr,
 		}
 	}
 

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -644,7 +644,7 @@ func (a *NetworkScan) runTelnetPentest(cmd *cobra.Command, args []string) {
 	engine := pentest_internal.NewEngine()
 	report, err := engine.RunTelnetPentest(cmd.Context(), config)
 	if err != nil {
-		a.OutputSignal.AddError(fmt.Errorf("Telnet pentest failed: %v", err))
+		a.OutputSignal.AddError(fmt.Errorf("telnet pentest failed: %v", err))
 		return
 	}
 
@@ -688,6 +688,12 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	jitter, _ := cmd.Flags().GetInt("jitter")
 	maxQueries, _ := cmd.Flags().GetInt("max-queries")
 	minimalQueries, _ := cmd.Flags().GetBool("minimal-queries")
+
+	// Validate jitter can only be used with sleep
+	if jitter > 0 && sleep == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("jitter parameter can only be used when sleep is also specified"))
+		return
+	}
 
 	// Load credentials from files if specified
 	if usernameFile != "" {
@@ -831,6 +837,9 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 	if jitter < 0 || jitter > 100 {
 		return nil, fmt.Errorf("jitter must be between 0 and 100")
 	}
+	if jitter > 0 && sleep == 0 {
+		return nil, fmt.Errorf("jitter parameter can only be used when sleep is also specified")
+	}
 
 	maxAttempts, err := cmd.Flags().GetInt("max-attempts")
 	if err != nil {
@@ -926,6 +935,9 @@ func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []st
 	if err != nil {
 		return nil, fmt.Errorf("failed to get jitter: %v", err)
 	}
+	if jitter > 0 && sleep == 0 {
+		return nil, fmt.Errorf("jitter parameter can only be used when sleep is also specified")
+	}
 
 	maxAttempts, err := cmd.Flags().GetInt("max-attempts")
 	if err != nil {
@@ -962,16 +974,22 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 	// TODO: Add NTLM hash support to spray functionality
 	_ = ntlmHash // Temporarily suppress unused warning
 
-	// Create stealth config if sleep, jitter, or maxAttempts is set
+	// Create stealth config if any stealth parameters are set
 	var stealthConfig *pentestfern.SprayStealthConfig
-	if sleep > 0 || maxAttempts > 0 {
-		var maxAttemptsPtr *int
+	if sleep > 0 || jitter > 0 || maxAttempts > 0 {
+		var sleepPtr, jitterPtr, maxAttemptsPtr *int
+		if sleep > 0 {
+			sleepPtr = &sleep
+		}
+		if jitter > 0 {
+			jitterPtr = &jitter
+		}
 		if maxAttempts > 0 {
 			maxAttemptsPtr = &maxAttempts
 		}
 		stealthConfig = &pentestfern.SprayStealthConfig{
-			Sleep:       sleep,
-			Jitter:      &jitter,
+			Sleep:       sleepPtr,
+			Jitter:      jitterPtr,
 			MaxAttempts: maxAttemptsPtr,
 		}
 	}
@@ -999,16 +1017,22 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 
 // getSprayUsernameConfig creates a configuration for username enumeration operations with the provided parameters.
 func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetService, usernameLists []pentestfern.WordlistType, usernames []string, usernameScheme *pentestfern.UsernameScheme, domain string, timeout int, sleep int, jitter int, maxAttempts int, successfulOnly bool) *pentestfern.PentestSprayConfig {
-	// Create stealth config if sleep, jitter, or maxAttempts is set
+	// Create stealth config if any stealth parameters are set
 	var stealthConfig *pentestfern.SprayStealthConfig
-	if sleep > 0 || maxAttempts > 0 {
-		var maxAttemptsPtr *int
+	if sleep > 0 || jitter > 0 || maxAttempts > 0 {
+		var sleepPtr, jitterPtr, maxAttemptsPtr *int
+		if sleep > 0 {
+			sleepPtr = &sleep
+		}
+		if jitter > 0 {
+			jitterPtr = &jitter
+		}
 		if maxAttempts > 0 {
 			maxAttemptsPtr = &maxAttempts
 		}
 		stealthConfig = &pentestfern.SprayStealthConfig{
-			Sleep:       sleep,
-			Jitter:      &jitter,
+			Sleep:       sleepPtr,
+			Jitter:      jitterPtr,
 			MaxAttempts: maxAttemptsPtr,
 		}
 	}

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -389,6 +389,12 @@ Additional actions can be specified to layer more functionality on top.`,
 	ldapCmd.Flags().Bool("stop-first-success", false, "Stop after first successful auth")
 	ldapCmd.Flags().Bool("successful-only", false, "Show only successful results")
 
+	// Stealth flags for domain dump operations
+	ldapCmd.Flags().Int("sleep", 0, "Delay in seconds between LDAP queries for stealth mode")
+	ldapCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delays")
+	ldapCmd.Flags().Int("max-queries", 0, "Maximum total LDAP queries to perform (0 = unlimited)")
+	ldapCmd.Flags().Bool("minimal-queries", false, "Use minimal query sets and essential attributes only")
+
 	parent.AddCommand(ldapCmd)
 }
 
@@ -677,6 +683,12 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
 	successfulOnly, _ := cmd.Flags().GetBool("successful-only")
 
+	// Parse stealth options
+	sleep, _ := cmd.Flags().GetInt("sleep")
+	jitter, _ := cmd.Flags().GetInt("jitter")
+	maxQueries, _ := cmd.Flags().GetInt("max-queries")
+	minimalQueries, _ := cmd.Flags().GetBool("minimal-queries")
+
 	// Load credentials from files if specified
 	if usernameFile != "" {
 		fileUsernames, err := utils.GetEntriesFromTXTFiles([]string{usernameFile})
@@ -706,7 +718,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash)
+	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, sleep, jitter, maxQueries, minimalQueries)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -1074,13 +1086,51 @@ func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnet
 }
 
 // getLDAPPentestConfig creates a configuration for LDAP pentest operations with the provided parameters.
-func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *ldapfern.PentestLdapConfig {
+func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, sleep int, jitter int, maxQueries int, minimalQueries bool) *ldapfern.PentestLdapConfig {
 	var domainPtr, ntlmHashPtr *string
 	if domain != "" {
 		domainPtr = &domain
 	}
 	if ntlmHash != "" {
 		ntlmHashPtr = &ntlmHash
+	}
+
+	// Create stealth config if any stealth parameters are set
+	var stealthConfig *ldapfern.DomainDumpStealthConfig
+	if sleep > 0 || jitter > 0 || maxQueries > 0 || minimalQueries {
+		var sleepPtr, jitterPtr, maxQueriesPtr *int
+		var minimalQueriesPtr *bool
+
+		if sleep > 0 {
+			sleepPtr = &sleep
+		}
+		if jitter > 0 {
+			jitterPtr = &jitter
+		}
+		if maxQueries > 0 {
+			maxQueriesPtr = &maxQueries
+		}
+		if minimalQueries {
+			minimalQueriesPtr = &minimalQueries
+		}
+
+		stealthConfig = &ldapfern.DomainDumpStealthConfig{
+			Sleep:          sleepPtr,
+			Jitter:         jitterPtr,
+			MaxQueries:     maxQueriesPtr,
+			MinimalQueries: minimalQueriesPtr,
+		}
+	}
+
+	// Create domain dump config if needed (for DOMAINDUMP action)
+	var domainDumpConfig *ldapfern.DomainDumpConfig
+	for _, action := range actions {
+		if action == ldapfern.PentestLdapActionDomaindump {
+			domainDumpConfig = &ldapfern.DomainDumpConfig{
+				Stealth: stealthConfig,
+			}
+			break
+		}
 	}
 
 	return &ldapfern.PentestLdapConfig{
@@ -1093,5 +1143,6 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 		Timeout:          timeout,
 		StopFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:   &successfulOnly,
+		DomaindumpConfig: domainDumpConfig,
 	}
 }

--- a/fern/definition/discover/host.yml
+++ b/fern/definition/discover/host.yml
@@ -10,7 +10,7 @@ types:
   # Stealth config
   HostStealthConfig:
     properties:
-      sleep: integer # Sleep delay in seconds between hosts
+      sleep: optional<integer> # Sleep delay in seconds between hosts
       jitter: optional<integer>         # Jitter percentage (0-100) to randomize sleep
       reverseLookup: optional<boolean>  # Perform reverse DNS lookup sweep first
   # Report structs

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -9,7 +9,7 @@ types:
   # Stealth config
   PortStealthConfig:
     properties:
-      sleep: integer # Sleep delay in seconds between ports
+      sleep: optional<integer> # Sleep delay in seconds between ports
       jitter: optional<integer> # Jitter percentage (0-100) to randomize sleep
   # Report structs
   PortDetails:

--- a/fern/definition/pentest/ldap/domaindump.yml
+++ b/fern/definition/pentest/ldap/domaindump.yml
@@ -3,6 +3,14 @@ imports:
 
 types:
   # ENUMs for Domain Dumping
+  
+  # Stealth config for domain dumping
+  DomainDumpStealthConfig:
+    properties:
+      sleep: optional<integer> # Delay in seconds between LDAP queries
+      jitter: optional<integer> # Jitter percentage (0-100) for randomizing delays
+      maxQueries: optional<integer> # Maximum total LDAP queries to perform
+      minimalQueries: optional<boolean> # Use minimal query sets and essential attributes only
 
   # Collection Methods - only the ones we currently implement
   CollectionMethod:
@@ -169,3 +177,4 @@ types:
     properties:
       collectionMethods: optional<list<CollectionMethod>>
       maxResults: optional<integer>
+      stealth: optional<DomainDumpStealthConfig>

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -40,6 +40,7 @@ types:
     properties:
       sleep: integer # Sleep delay in seconds between attempts
       jitter: optional<integer> # Jitter percentage (0-100) to randomize sleep
+      maxAttempts: optional<integer> # Maximum number of attempts to make (limits both username and password attempts)
 
   # Core Types
   Credential:

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -38,7 +38,7 @@ types:
   # Stealth config
   SprayStealthConfig:
     properties:
-      sleep: integer # Sleep delay in seconds between attempts
+      sleep: optional<integer> # Sleep delay in seconds between attempts
       jitter: optional<integer> # Jitter percentage (0-100) to randomize sleep
       maxAttempts: optional<integer> # Maximum number of attempts to make (limits both username and password attempts)
 

--- a/internal/discover/host/stealth.go
+++ b/internal/discover/host/stealth.go
@@ -55,7 +55,7 @@ func getStealthHostDiscovery(ctx context.Context, config discoverfern.DiscoverHo
 	// Get stealth delay configuration (but don't calculate delay yet - do it per attempt)
 	var sleepPtr, jitterPtr *int
 	if config.Stealth != nil {
-		sleepPtr = &config.Stealth.Sleep
+		sleepPtr = config.Stealth.Sleep
 		jitterPtr = config.Stealth.Jitter
 	}
 

--- a/internal/discover/port/stealth.go
+++ b/internal/discover/port/stealth.go
@@ -48,7 +48,7 @@ func getStealthPortScan(ctx context.Context, config discoverfern.DiscoverPortCon
 	// Get stealth delay configuration (but don't calculate delay yet - do it per attempt)
 	var sleepPtr, jitterPtr *int
 	if config.Stealth != nil {
-		sleepPtr = &config.Stealth.Sleep
+		sleepPtr = config.Stealth.Sleep
 		jitterPtr = config.Stealth.Jitter
 	}
 

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -1090,7 +1090,7 @@ func (l *LibraryPentestLdap) enumerateDomainTrusts(ctx context.Context, conn *ld
 		sizeLimit = *maxResults
 	}
 
-	// TODO: Implement minimal queries mode for domain trust enumeration  
+	// TODO: Implement minimal queries mode for domain trust enumeration
 	// Current: 5 attributes, Minimal should be: ~2 attributes (name, trustDirection)
 	attributes := []string{"name", "trustDirection", "trustType", "trustAttributes", "flatName"}
 

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -14,6 +14,8 @@ import (
 
 	// Internal
 	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	"github.com/Method-Security/networkscan/utils"
+
 	// External
 	"github.com/go-ldap/ldap/v3"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -23,6 +25,40 @@ import (
 func stringPtr(s string) *string { return &s }
 func intPtr(i int) *int          { return &i }
 func boolPtr(b bool) *bool       { return &b }
+
+// StealthContext tracks stealth parameters and query count
+type StealthContext struct {
+	QueryCount     int
+	MaxQueries     int
+	SleepPtr       *int
+	JitterPtr      *int
+	MinimalQueries bool
+	Logger         svc1log.Logger
+}
+
+// ShouldContinue checks if more queries are allowed
+func (sc *StealthContext) ShouldContinue() bool {
+	if sc.MaxQueries > 0 && sc.QueryCount >= sc.MaxQueries {
+		sc.Logger.Info("Stopping due to max queries limit reached",
+			svc1log.SafeParam("queries_made", sc.QueryCount),
+			svc1log.SafeParam("max_queries", sc.MaxQueries))
+		return false
+	}
+	return true
+}
+
+// IncrementQuery increments query count and applies stealth delay
+func (sc *StealthContext) IncrementQuery() {
+	sc.QueryCount++
+
+	// Apply stealth delay using existing utility
+	delay := utils.CalculateStealthDelay(sc.SleepPtr, sc.JitterPtr)
+	if delay > 0 {
+		sc.Logger.Debug("Applying stealth delay",
+			svc1log.SafeParam("duration_ms", delay.Milliseconds()))
+		time.Sleep(delay)
+	}
+}
 
 type LibraryPentestLdap struct{}
 
@@ -219,7 +255,7 @@ func (l *LibraryPentestLdap) getBaseDN(conn *ldap.Conn, target string) (string, 
 	return "", fmt.Errorf("no domain naming context found in: %v", namingContexts)
 }
 
-func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int) (*[]*ldapfern.DomainUser, []string) {
+func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.DomainUser, []string) {
 	var errors []string
 	var users []*ldapfern.DomainUser
 
@@ -232,6 +268,20 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 	domain := l.extractDomainFromBaseDN(baseDN)
 	domainSID := l.extractDomainSID(conn, baseDN)
 
+	// Use minimal attributes in stealth mode
+	attributes := []string{
+		"distinguishedName", "sAMAccountName", "userPrincipalName", "displayName",
+		"description", "objectSid", "userAccountControl", "sAMAccountType",
+		"lastLogon", "lastLogonTimestamp", "pwdLastSet", "adminCount", "servicePrincipalName",
+		"primaryGroupID", "isDeleted", "sIDHistory", "objectClass",
+	}
+	if stealthCtx.MinimalQueries {
+		// Only essential attributes for stealth mode
+		attributes = []string{
+			"distinguishedName", "sAMAccountName", "objectSid", "userAccountControl",
+		}
+	}
+
 	searchRequest := ldap.NewSearchRequest(
 		baseDN,
 		ldap.ScopeWholeSubtree,
@@ -240,14 +290,12 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 		0,
 		false,
 		"(|(&(objectCategory=person)(objectClass=user))(objectClass=msDS-GroupManagedServiceAccount)(objectClass=msDS-ManagedServiceAccount))",
-		[]string{
-			"distinguishedName", "sAMAccountName", "userPrincipalName", "displayName",
-			"description", "objectSid", "userAccountControl", "sAMAccountType",
-			"lastLogon", "lastLogonTimestamp", "pwdLastSet", "adminCount", "servicePrincipalName",
-			"primaryGroupID", "isDeleted", "sIDHistory", "objectClass",
-		},
+		attributes,
 		nil,
 	)
+
+	// Track query and apply stealth delay
+	stealthCtx.IncrementQuery()
 
 	sr, err := conn.Search(searchRequest)
 	if err != nil {
@@ -387,7 +435,7 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 	return &users, errors
 }
 
-func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int) (*[]*ldapfern.DomainGroup, []string) {
+func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.DomainGroup, []string) {
 	var errors []string
 	var groups []*ldapfern.DomainGroup
 
@@ -400,6 +448,18 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 	domain := l.extractDomainFromBaseDN(baseDN)
 	domainSID := l.extractDomainSID(conn, baseDN)
 
+	// Use minimal attributes in stealth mode
+	attributes := []string{
+		"distinguishedName", "sAMAccountName", "sAMAccountType", "description", "objectSid",
+		"groupType", "member", "memberOf", "adminCount", "isDeleted", "whenCreated",
+	}
+	if stealthCtx.MinimalQueries {
+		// Only essential attributes for stealth mode
+		attributes = []string{
+			"distinguishedName", "sAMAccountName", "objectSid", "member",
+		}
+	}
+
 	searchRequest := ldap.NewSearchRequest(
 		baseDN,
 		ldap.ScopeWholeSubtree,
@@ -408,12 +468,12 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 		0,
 		false,
 		"(objectClass=group)",
-		[]string{
-			"distinguishedName", "sAMAccountName", "sAMAccountType", "description", "objectSid",
-			"groupType", "member", "memberOf", "adminCount", "isDeleted", "whenCreated",
-		},
+		attributes,
 		nil,
 	)
+
+	// Track query and apply stealth delay
+	stealthCtx.IncrementQuery()
 
 	sr, err := conn.Search(searchRequest)
 	if err != nil {
@@ -460,12 +520,24 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 		var members []*ldapfern.GroupMember
 		memberDNS := entry.GetAttributeValues("member")
 		for _, memberDN := range memberDNS {
+			// Check query limit before each member lookup
+			if !stealthCtx.ShouldContinue() {
+				break
+			}
+
 			// Get the member's SID by doing a lookup
-			memberSID := l.getMemberSID(ctx, conn, memberDN)
+			memberSID := l.getMemberSID(ctx, conn, memberDN, stealthCtx)
 			if memberSID != "" {
+				var memberType string
+				if !stealthCtx.MinimalQueries {
+					memberType = l.determineMemberType(ctx, conn, memberDN, stealthCtx)
+				} else {
+					memberType = "Unknown" // Skip expensive type determination in stealth mode
+				}
+
 				member := &ldapfern.GroupMember{
 					ObjectIdentifier: stringPtr(memberSID),
-					ObjectType:       stringPtr(l.determineMemberType(ctx, conn, memberDN)),
+					ObjectType:       stringPtr(memberType),
 				}
 				members = append(members, member)
 			}
@@ -540,7 +612,7 @@ func (l *LibraryPentestLdap) isHighValueGroupBySID(objectSID string) bool {
 }
 
 // getMemberSID gets the SID of a member by DN
-func (l *LibraryPentestLdap) getMemberSID(ctx context.Context, conn *ldap.Conn, memberDN string) string {
+func (l *LibraryPentestLdap) getMemberSID(ctx context.Context, conn *ldap.Conn, memberDN string, stealthCtx *StealthContext) string {
 	searchRequest := ldap.NewSearchRequest(
 		memberDN,
 		ldap.ScopeBaseObject,
@@ -550,6 +622,9 @@ func (l *LibraryPentestLdap) getMemberSID(ctx context.Context, conn *ldap.Conn, 
 		[]string{"objectSid"},
 		nil,
 	)
+
+	// Track query and apply stealth delay
+	stealthCtx.IncrementQuery()
 
 	sr, err := conn.Search(searchRequest)
 	if err != nil || len(sr.Entries) == 0 {
@@ -564,7 +639,7 @@ func (l *LibraryPentestLdap) getMemberSID(ctx context.Context, conn *ldap.Conn, 
 
 // determineMemberType determines if a member is a User or Group using sAMAccountType
 // and objectClass, following Active Directory best practices
-func (l *LibraryPentestLdap) determineMemberType(ctx context.Context, conn *ldap.Conn, memberDN string) string {
+func (l *LibraryPentestLdap) determineMemberType(ctx context.Context, conn *ldap.Conn, memberDN string, stealthCtx *StealthContext) string {
 	// Query the object to get sAMAccountType and objectClass attributes
 	searchRequest := ldap.NewSearchRequest(
 		memberDN,
@@ -575,6 +650,9 @@ func (l *LibraryPentestLdap) determineMemberType(ctx context.Context, conn *ldap
 		[]string{"sAMAccountType", "objectClass"},
 		nil,
 	)
+
+	// Track query and apply stealth delay
+	stealthCtx.IncrementQuery()
 
 	sr, err := conn.Search(searchRequest)
 	if err != nil || len(sr.Entries) == 0 {
@@ -624,13 +702,21 @@ func (l *LibraryPentestLdap) determineMemberType(ctx context.Context, conn *ldap
 	return "Unknown"
 }
 
-func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int) (*[]*ldapfern.DomainComputer, []string) {
+func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.DomainComputer, []string) {
 	var errors []string
 	var computers []*ldapfern.DomainComputer
 
 	sizeLimit := 0
 	if maxResults != nil {
 		sizeLimit = *maxResults
+	}
+
+	// TODO: Implement minimal queries mode for computer enumeration
+	// Current: 10 attributes, Minimal should be: ~4 attributes (distinguishedName, sAMAccountName, objectSid, dNSHostName)
+	attributes := []string{
+		"distinguishedName", "sAMAccountName", "dNSHostName", "description",
+		"objectSid", "sAMAccountType", "operatingSystem", "operatingSystemVersion", "userAccountControl",
+		"lastLogon", "lastLogonTimestamp", "pwdLastSet", "servicePrincipalName", "isDeleted", "whenCreated",
 	}
 
 	searchRequest := ldap.NewSearchRequest(
@@ -641,11 +727,7 @@ func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.
 		0,
 		false,
 		"(&(sAMAccountType=805306369)(!(objectClass=msDS-GroupManagedServiceAccount))(!(objectClass=msDS-ManagedServiceAccount)))",
-		[]string{
-			"distinguishedName", "sAMAccountName", "dNSHostName", "description",
-			"objectSid", "sAMAccountType", "operatingSystem", "operatingSystemVersion", "userAccountControl",
-			"lastLogon", "lastLogonTimestamp", "pwdLastSet", "servicePrincipalName", "isDeleted", "whenCreated",
-		},
+		attributes,
 		nil,
 	)
 
@@ -707,13 +789,20 @@ func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.
 	return &computers, errors
 }
 
-func (l *LibraryPentestLdap) enumerateDomainControllers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int) (*[]*ldapfern.DomainController, []string) {
+func (l *LibraryPentestLdap) enumerateDomainControllers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.DomainController, []string) {
 	var errors []string
 	var dcs []*ldapfern.DomainController
 
 	sizeLimit := 0
 	if maxResults != nil {
 		sizeLimit = *maxResults
+	}
+
+	// TODO: Implement minimal queries mode for domain controller enumeration
+	// Current: 8 attributes, Minimal should be: ~3 attributes (distinguishedName, sAMAccountName, dNSHostName)
+	attributes := []string{
+		"distinguishedName", "sAMAccountName", "dNSHostName", "siteName",
+		"operatingSystem", "operatingSystemVersion", "userAccountControl", "serverReferenceBL",
 	}
 
 	searchRequest := ldap.NewSearchRequest(
@@ -724,10 +813,7 @@ func (l *LibraryPentestLdap) enumerateDomainControllers(ctx context.Context, con
 		0,
 		false,
 		"(&(sAMAccountType=805306369)(userAccountControl:1.2.840.113556.1.4.803:=8192))",
-		[]string{
-			"distinguishedName", "sAMAccountName", "dNSHostName", "siteName",
-			"operatingSystem", "operatingSystemVersion", "userAccountControl", "serverReferenceBL",
-		},
+		attributes,
 		nil,
 	)
 
@@ -767,13 +853,19 @@ func (l *LibraryPentestLdap) enumerateDomainControllers(ctx context.Context, con
 	return &dcs, errors
 }
 
-func (l *LibraryPentestLdap) enumerateOrganizationalUnits(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int) (*[]*ldapfern.OrganizationalUnit, []string) {
+func (l *LibraryPentestLdap) enumerateOrganizationalUnits(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.OrganizationalUnit, []string) {
 	var errors []string
 	var ous []*ldapfern.OrganizationalUnit
 
 	sizeLimit := 0
 	if maxResults != nil {
 		sizeLimit = *maxResults
+	}
+
+	// TODO: Implement minimal queries mode for organizational unit enumeration
+	// Current: 4 attributes, Minimal should be: ~2 attributes (distinguishedName, name)
+	attributes := []string{
+		"distinguishedName", "name", "description", "gPLink",
 	}
 
 	searchRequest := ldap.NewSearchRequest(
@@ -784,9 +876,7 @@ func (l *LibraryPentestLdap) enumerateOrganizationalUnits(ctx context.Context, c
 		0,
 		false,
 		"(objectClass=organizationalUnit)",
-		[]string{
-			"distinguishedName", "name", "description", "gPLink",
-		},
+		attributes,
 		nil,
 	)
 
@@ -819,13 +909,19 @@ func (l *LibraryPentestLdap) enumerateOrganizationalUnits(ctx context.Context, c
 	return &ous, errors
 }
 
-func (l *LibraryPentestLdap) enumerateGroupPolicyObjects(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int) (*[]*ldapfern.GroupPolicyObject, []string) {
+func (l *LibraryPentestLdap) enumerateGroupPolicyObjects(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.GroupPolicyObject, []string) {
 	var errors []string
 	var gpos []*ldapfern.GroupPolicyObject
 
 	sizeLimit := 0
 	if maxResults != nil {
 		sizeLimit = *maxResults
+	}
+
+	// TODO: Implement minimal queries mode for group policy object enumeration
+	// Current: 5 attributes, Minimal should be: ~2 attributes (distinguishedName, displayName)
+	attributes := []string{
+		"distinguishedName", "displayName", "description", "gPCFileSysPath", "versionNumber",
 	}
 
 	searchRequest := ldap.NewSearchRequest(
@@ -836,9 +932,7 @@ func (l *LibraryPentestLdap) enumerateGroupPolicyObjects(ctx context.Context, co
 		0,
 		false,
 		"(objectClass=groupPolicyContainer)",
-		[]string{
-			"distinguishedName", "displayName", "description", "gPCFileSysPath", "versionNumber",
-		},
+		attributes,
 		nil,
 	)
 
@@ -988,7 +1082,7 @@ func (l *LibraryPentestLdap) convertFileTime(fileTimeStr string) string {
 	return fileTimeStr
 }
 
-func (l *LibraryPentestLdap) enumerateDomainTrusts(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int) (*[]*ldapfern.DomainTrust, []string) {
+func (l *LibraryPentestLdap) enumerateDomainTrusts(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.DomainTrust, []string) {
 	var errors []string
 	var trusts []*ldapfern.DomainTrust
 	sizeLimit := 0
@@ -996,12 +1090,16 @@ func (l *LibraryPentestLdap) enumerateDomainTrusts(ctx context.Context, conn *ld
 		sizeLimit = *maxResults
 	}
 
+	// TODO: Implement minimal queries mode for domain trust enumeration  
+	// Current: 5 attributes, Minimal should be: ~2 attributes (name, trustDirection)
+	attributes := []string{"name", "trustDirection", "trustType", "trustAttributes", "flatName"}
+
 	// Search for domain trust objects
 	searchRequest := ldap.NewSearchRequest(
 		fmt.Sprintf("CN=System,%s", baseDN),
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, sizeLimit, 0, false,
 		"(objectClass=trustedDomain)",
-		[]string{"name", "trustDirection", "trustType", "trustAttributes", "flatName"},
+		attributes,
 		nil,
 	)
 
@@ -1081,6 +1179,9 @@ func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn 
 		TotalObjects: intPtr(0),
 	}
 
+	// Create stealth context from config
+	stealthCtx := l.createStealthContext(ctx, config)
+
 	// Process each action
 	for _, action := range config.Actions {
 		if action == ldapfern.PentestLdapActionDomaindump {
@@ -1088,12 +1189,54 @@ func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn 
 			maxResults := l.getMaxResults(config)
 
 			for _, method := range collectionMethods {
-				l.processCollectionMethod(ctx, conn, baseDN, method, maxResults, domainResult, &errors)
+				if !stealthCtx.ShouldContinue() {
+					break
+				}
+				l.processCollectionMethod(ctx, conn, baseDN, method, maxResults, stealthCtx, domainResult, &errors)
 			}
 		}
 	}
 
+	// Log final query count
+	stealthCtx.Logger.Info("Domain dump completed",
+		svc1log.SafeParam("total_queries", stealthCtx.QueryCount))
+
 	return domainResult, errors
+}
+
+// createStealthContext creates a stealth context from the config
+func (l *LibraryPentestLdap) createStealthContext(ctx context.Context, config ldapfern.PentestLdapConfig) *StealthContext {
+	logger := svc1log.FromContext(ctx)
+	stealthCtx := &StealthContext{
+		QueryCount:     0,
+		MaxQueries:     0,
+		MinimalQueries: false,
+		Logger:         logger,
+	}
+
+	// Extract stealth config if present
+	if config.DomaindumpConfig != nil && config.DomaindumpConfig.Stealth != nil {
+		stealth := config.DomaindumpConfig.Stealth
+
+		stealthCtx.SleepPtr = stealth.Sleep
+		stealthCtx.JitterPtr = stealth.Jitter
+
+		if stealth.MaxQueries != nil {
+			stealthCtx.MaxQueries = *stealth.MaxQueries
+		}
+		if stealth.MinimalQueries != nil {
+			stealthCtx.MinimalQueries = *stealth.MinimalQueries
+		}
+
+		if stealthCtx.MaxQueries > 0 || stealthCtx.SleepPtr != nil || stealthCtx.MinimalQueries {
+			logger.Info("Stealth mode enabled for domain dump",
+				svc1log.SafeParam("max_queries", stealthCtx.MaxQueries),
+				svc1log.SafeParam("sleep", stealthCtx.SleepPtr),
+				svc1log.SafeParam("minimal_queries", stealthCtx.MinimalQueries))
+		}
+	}
+
+	return stealthCtx
 }
 
 // getCollectionMethods extracts collection methods from config with sensible defaults
@@ -1113,16 +1256,16 @@ func (l *LibraryPentestLdap) getMaxResults(config ldapfern.PentestLdapConfig) *i
 }
 
 // processCollectionMethod processes a single collection method
-func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *ldap.Conn, baseDN string, method ldapfern.CollectionMethod, maxResults *int, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *ldap.Conn, baseDN string, method ldapfern.CollectionMethod, maxResults *int, stealthCtx *StealthContext, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
 	switch method {
 	case ldapfern.CollectionMethodGroup:
-		l.processGroupCollection(ctx, conn, baseDN, maxResults, domainResult, errors)
+		l.processGroupCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
 	case ldapfern.CollectionMethodTrusts:
-		l.processTrustsCollection(ctx, conn, baseDN, maxResults, domainResult, errors)
+		l.processTrustsCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
 	case ldapfern.CollectionMethodObjectprops:
-		l.processObjectPropsCollection(ctx, conn, baseDN, maxResults, domainResult, errors)
+		l.processObjectPropsCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
 	case ldapfern.CollectionMethodContainer:
-		l.processContainerCollection(ctx, conn, baseDN, maxResults, domainResult, errors)
+		l.processContainerCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
 	default:
 		logger := svc1log.FromContext(ctx)
 		logger.Info("Collection method not yet implemented", svc1log.SafeParam("method", string(method)))
@@ -1130,45 +1273,49 @@ func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *
 }
 
 // processGroupCollection handles group and user enumeration
-func (l *LibraryPentestLdap) processGroupCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+func (l *LibraryPentestLdap) processGroupCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
 	// Enumerate groups
-	groups, errs := l.enumerateGroups(ctx, conn, baseDN, maxResults)
-	if groups != nil {
-		groupsResult := &ldapfern.DomainGroupsResult{
-			Data: *groups,
-			Meta: &ldapfern.DomainDataMeta{
-				Methods: intPtr(0),
-				Type:    stringPtr("groups"),
-				Count:   intPtr(len(*groups)),
-				Version: intPtr(5),
-			},
+	if stealthCtx.ShouldContinue() {
+		groups, errs := l.enumerateGroups(ctx, conn, baseDN, maxResults, stealthCtx)
+		if groups != nil {
+			groupsResult := &ldapfern.DomainGroupsResult{
+				Data: *groups,
+				Meta: &ldapfern.DomainDataMeta{
+					Methods: intPtr(0),
+					Type:    stringPtr("groups"),
+					Count:   intPtr(len(*groups)),
+					Version: intPtr(5),
+				},
+			}
+			domainResult.Groups = groupsResult
+			*domainResult.TotalObjects += len(*groups)
 		}
-		domainResult.Groups = groupsResult
-		*domainResult.TotalObjects += len(*groups)
+		*errors = append(*errors, errs...)
 	}
-	*errors = append(*errors, errs...)
 
 	// Enumerate users
-	users, errs := l.enumerateUsers(ctx, conn, baseDN, maxResults)
-	if users != nil {
-		usersResult := &ldapfern.DomainUsersResult{
-			Data: *users,
-			Meta: &ldapfern.DomainDataMeta{
-				Methods: intPtr(0),
-				Type:    stringPtr("users"),
-				Count:   intPtr(len(*users)),
-				Version: intPtr(5),
-			},
+	if stealthCtx.ShouldContinue() {
+		users, errs := l.enumerateUsers(ctx, conn, baseDN, maxResults, stealthCtx)
+		if users != nil {
+			usersResult := &ldapfern.DomainUsersResult{
+				Data: *users,
+				Meta: &ldapfern.DomainDataMeta{
+					Methods: intPtr(0),
+					Type:    stringPtr("users"),
+					Count:   intPtr(len(*users)),
+					Version: intPtr(5),
+				},
+			}
+			domainResult.Users = usersResult
+			*domainResult.TotalObjects += len(*users)
 		}
-		domainResult.Users = usersResult
-		*domainResult.TotalObjects += len(*users)
+		*errors = append(*errors, errs...)
 	}
-	*errors = append(*errors, errs...)
 }
 
 // processTrustsCollection handles domain trust enumeration
-func (l *LibraryPentestLdap) processTrustsCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
-	trusts, errs := l.enumerateDomainTrusts(ctx, conn, baseDN, maxResults)
+func (l *LibraryPentestLdap) processTrustsCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+	trusts, errs := l.enumerateDomainTrusts(ctx, conn, baseDN, maxResults, stealthCtx)
 	if trusts != nil {
 		domainResult.DomainTrusts = *trusts
 		*domainResult.TotalObjects += len(*trusts)
@@ -1177,9 +1324,9 @@ func (l *LibraryPentestLdap) processTrustsCollection(ctx context.Context, conn *
 }
 
 // processObjectPropsCollection handles organizational units and GPO enumeration
-func (l *LibraryPentestLdap) processObjectPropsCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+func (l *LibraryPentestLdap) processObjectPropsCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
 	// Enumerate organizational units
-	ous, errs := l.enumerateOrganizationalUnits(ctx, conn, baseDN, maxResults)
+	ous, errs := l.enumerateOrganizationalUnits(ctx, conn, baseDN, maxResults, stealthCtx)
 	if ous != nil {
 		domainResult.OrganizationalUnits = *ous
 		*domainResult.TotalObjects += len(*ous)
@@ -1187,7 +1334,7 @@ func (l *LibraryPentestLdap) processObjectPropsCollection(ctx context.Context, c
 	*errors = append(*errors, errs...)
 
 	// Enumerate group policy objects
-	gpos, errs := l.enumerateGroupPolicyObjects(ctx, conn, baseDN, maxResults)
+	gpos, errs := l.enumerateGroupPolicyObjects(ctx, conn, baseDN, maxResults, stealthCtx)
 	if gpos != nil {
 		domainResult.GroupPolicyObjects = *gpos
 		*domainResult.TotalObjects += len(*gpos)
@@ -1196,9 +1343,9 @@ func (l *LibraryPentestLdap) processObjectPropsCollection(ctx context.Context, c
 }
 
 // processContainerCollection handles computer and domain controller enumeration
-func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
 	// Enumerate computers
-	computers, errs := l.enumerateComputers(ctx, conn, baseDN, maxResults)
+	computers, errs := l.enumerateComputers(ctx, conn, baseDN, maxResults, stealthCtx)
 	if computers != nil {
 		domainResult.Computers = *computers
 		*domainResult.TotalObjects += len(*computers)
@@ -1206,7 +1353,7 @@ func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, con
 	*errors = append(*errors, errs...)
 
 	// Enumerate domain controllers
-	dcs, errs := l.enumerateDomainControllers(ctx, conn, baseDN, maxResults)
+	dcs, errs := l.enumerateDomainControllers(ctx, conn, baseDN, maxResults, stealthCtx)
 	if dcs != nil {
 		domainResult.DomainControllers = *dcs
 		*domainResult.TotalObjects += len(*dcs)

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -109,6 +109,47 @@ func (l *LibraryPentestLdap) performLdapActions(ctx context.Context, config ldap
 	return result, errors
 }
 
+// calculateAdjustedTimeout adjusts the connection timeout when stealth mode is enabled
+// to account for potential sleep delays between queries
+func (l *LibraryPentestLdap) calculateAdjustedTimeout(config ldapfern.PentestLdapConfig) int {
+	baseTimeout := config.Timeout / 1000 // Convert ms to seconds
+
+	// Check if stealth mode is enabled
+	if config.DomaindumpConfig != nil && config.DomaindumpConfig.Stealth != nil {
+		stealth := config.DomaindumpConfig.Stealth
+
+		// If sleep is configured, add buffer time for stealth operations
+		if stealth.Sleep != nil && *stealth.Sleep > 0 {
+			sleepSeconds := *stealth.Sleep
+
+			// Add buffer: base sleep time + potential jitter (max 100% = 2x sleep time)
+			// Plus some additional buffer for query processing
+			maxDelayPerQuery := sleepSeconds * 2 // Account for maximum jitter
+			estimatedQueries := 10               // Conservative estimate for typical domain dump
+
+			// If max queries is set, use that as estimate
+			if stealth.MaxQueries != nil && *stealth.MaxQueries > 0 {
+				estimatedQueries = *stealth.MaxQueries
+			}
+
+			// Calculate additional timeout needed: max delay per query * estimated queries
+			additionalTimeout := maxDelayPerQuery * estimatedQueries
+
+			// Add the additional timeout to base, with a reasonable maximum
+			adjustedTimeout := baseTimeout + additionalTimeout
+
+			// Cap at 10 minutes (600 seconds) to prevent extremely long timeouts
+			if adjustedTimeout > 600 {
+				adjustedTimeout = 600
+			}
+
+			return adjustedTimeout
+		}
+	}
+
+	return baseTimeout
+}
+
 func (l *LibraryPentestLdap) connectToLDAP(ctx context.Context, config ldapfern.PentestLdapConfig) (*ldap.Conn, error) {
 	// Parse target to get host, port, and SSL settings
 	target, err := ParseTarget(config.Targets[0])
@@ -122,8 +163,8 @@ func (l *LibraryPentestLdap) connectToLDAP(ctx context.Context, config ldapfern.
 		return nil, err
 	}
 
-	// Configure connection timeout
-	timeout := config.Timeout / 1000 // Convert ms to seconds
+	// Configure connection timeout, adjusting for stealth mode if enabled
+	timeout := l.calculateAdjustedTimeout(config)
 	conn.SetTimeout(time.Duration(timeout) * time.Second)
 
 	// Authenticate

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -113,6 +113,18 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 
 	log.Info("Starting username enumeration", svc1log.SafeParam("count", len(usernames)))
 
+	// Check max attempts limit
+	var maxAttempts int
+	if config.Stealth != nil && config.Stealth.MaxAttempts != nil {
+		maxAttempts = *config.Stealth.MaxAttempts
+		if maxAttempts > 0 && len(usernames) > maxAttempts {
+			log.Info("Limiting username attempts due to max-attempts setting",
+				svc1log.SafeParam("total_usernames", len(usernames)),
+				svc1log.SafeParam("max_attempts", maxAttempts))
+			usernames = usernames[:maxAttempts]
+		}
+	}
+
 	// Perform username enumeration (currently only supported for Kerberos)
 	if config.Service == pentestfern.SprayTargetServiceKerberos {
 		// Ensure timeout has proper default
@@ -282,6 +294,27 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 	// Ensure timeout has proper default
 	timeoutMs := ensureTimeoutDefaults(config.Timeout)
 	config.Timeout = timeoutMs
+
+	// Check max attempts limit and limit password list if needed
+	if config.Stealth != nil && config.Stealth.MaxAttempts != nil {
+		maxAttempts := *config.Stealth.MaxAttempts
+		totalCombinations := len(usernames) * len(passwords)
+		if maxAttempts > 0 && totalCombinations > maxAttempts {
+			// Calculate how many passwords we can test with all usernames
+			maxPasswords := maxAttempts / len(usernames)
+			if maxPasswords == 0 {
+				maxPasswords = 1 // Always allow at least one password
+			}
+			if len(passwords) > maxPasswords {
+				log.Info("Limiting password attempts due to max-attempts setting",
+					svc1log.SafeParam("total_passwords", len(passwords)),
+					svc1log.SafeParam("max_passwords", maxPasswords),
+					svc1log.SafeParam("total_combinations_before", totalCombinations),
+					svc1log.SafeParam("max_attempts", maxAttempts))
+				passwords = passwords[:maxPasswords]
+			}
+		}
+	}
 
 	log.Info("Starting password spray",
 		svc1log.SafeParam("usernames", len(usernames)),

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -155,17 +155,17 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 			}
 
 			// Apply delay with jitter between username attempts (except after last username)
-			if config.Stealth != nil && config.Stealth.Sleep > 0 && i < len(usernames)-1 {
+			if config.Stealth != nil && config.Stealth.Sleep != nil && *config.Stealth.Sleep > 0 && i < len(usernames)-1 {
 				var jitterPercent int
 				if config.Stealth.Jitter != nil {
 					jitterPercent = *config.Stealth.Jitter
 				}
 
-				delay := utils.CalculateDelayWithJitter(config.Stealth.Sleep, jitterPercent)
+				delay := utils.CalculateDelayWithJitter(*config.Stealth.Sleep, jitterPercent)
 
 				if delay > 0 {
 					log.Info("Sleeping between username attempts",
-						svc1log.SafeParam("base_sleep_seconds", config.Stealth.Sleep),
+						svc1log.SafeParam("base_sleep_seconds", *config.Stealth.Sleep),
 						svc1log.SafeParam("actual_delay_ms", delay.Milliseconds()),
 						svc1log.SafeParam("jitter_percent", jitterPercent))
 					time.Sleep(delay)
@@ -368,17 +368,17 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 		}
 
 		// Apply delay with jitter between password attempts (after testing password against all users)
-		if config.Stealth != nil && config.Stealth.Sleep > 0 && password != passwords[len(passwords)-1] { // Don't sleep after last password
+		if config.Stealth != nil && config.Stealth.Sleep != nil && *config.Stealth.Sleep > 0 && password != passwords[len(passwords)-1] { // Don't sleep after last password
 			var jitterPercent int
 			if config.Stealth.Jitter != nil {
 				jitterPercent = *config.Stealth.Jitter
 			}
 
-			delay := utils.CalculateDelayWithJitter(config.Stealth.Sleep, jitterPercent)
+			delay := utils.CalculateDelayWithJitter(*config.Stealth.Sleep, jitterPercent)
 
 			if delay > 0 {
 				log.Info("Sleeping between password attempts",
-					svc1log.SafeParam("base_sleep_seconds", config.Stealth.Sleep),
+					svc1log.SafeParam("base_sleep_seconds", *config.Stealth.Sleep),
 					svc1log.SafeParam("actual_delay_ms", delay.Milliseconds()),
 					svc1log.SafeParam("jitter_percent", jitterPercent))
 				time.Sleep(delay)


### PR DESCRIPTION
# Simplify Stealth Mode and Add Rate Limiting Controls

This PR simplifies the stealth scanning approach across the tool by:

- Removing the explicit `--stealth` flag in favor of enabling stealth mode automatically when delay parameters are specified
- Setting sensible defaults for scan types (ICMP_ECHO for host discovery)
- Adding rate limiting controls with `--max-attempts` parameter for credential spraying operations
- Adding stealth controls for LDAP domain enumeration with sleep, jitter, and query limiting options
- Improving timeout handling for operations with stealth delays
- Fixing validation to ensure jitter is only used when sleep is also specified

These changes make the tool more intuitive to use while maintaining all stealth capabilities, and add better control over operation intensity for both credential spraying and domain enumeration.