### PR TITLE
Fix stealth mode scan type handling and standardize target formatting

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -485,10 +485,12 @@ func getDiscoverHostConfig(target string, scanType *discoverfern.HostScanType, s
 	config := discoverfern.DiscoverHostConfig{
 		Target: target,
 	}
-	if scanType != nil {
-		config.ScanType = scanType
-	}
-	if sleep > 0 || jitter > 0 || reverseLookup {
+
+	// Check if stealth mode is enabled
+	stealthEnabled := sleep > 0 || jitter > 0 || reverseLookup
+
+	if stealthEnabled {
+		// In stealth mode, configure stealth settings and don't set scanType
 		stealthConfig := &discoverfern.HostStealthConfig{
 			ReverseLookup: &reverseLookup,
 		}
@@ -499,6 +501,11 @@ func getDiscoverHostConfig(target string, scanType *discoverfern.HostScanType, s
 			stealthConfig.Jitter = &jitter
 		}
 		config.Stealth = stealthConfig
+	} else {
+		// In non-stealth mode, set scanType if provided
+		if scanType != nil {
+			config.ScanType = scanType
+		}
 	}
 
 	return config

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -42,7 +42,6 @@ type Fingerprinter interface {
 // List the modules you want to run after fingerprintx fails.
 var customFingerprintModules = []Fingerprinter{
 	&localPlugins.GrpcFingerprinter{},
-	&localPlugins.KerberosFingerprinter{},
 }
 
 // RunServiceFingerprint fingerprints the service at target:port.

--- a/internal/enumerate/engine.go
+++ b/internal/enumerate/engine.go
@@ -5,7 +5,6 @@ import (
 	// Standard
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -18,6 +17,9 @@ import (
 	smb "github.com/Method-Security/networkscan/internal/enumerate/smb"
 	smtp "github.com/Method-Security/networkscan/internal/enumerate/smtp"
 	ssh "github.com/Method-Security/networkscan/internal/enumerate/ssh"
+
+	// External
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // NetworkApplicationLibrary defines the interface for service-specific enumeration implementations.
@@ -36,7 +38,10 @@ type NetworkApplicationEngine struct {
 // It manages timeouts, error handling, and result collection for each target.
 // Returns a report containing enumeration details and any errors encountered.
 func RunServiceEnumerate(ctx context.Context, config enumeratefern.EnumerateServiceConfig) (enumeratefern.EnumerateServiceReport, error) {
-	log.Printf("[INFO] Starting enumeration for %d targets with a timeout of %ds", len(config.Targets), config.Timeout)
+	log := svc1log.FromContext(ctx)
+	log.Info("Starting enumeration for targets",
+		svc1log.SafeParam("targets", len(config.Targets)),
+		svc1log.SafeParam("timeout", config.Timeout))
 	resource := enumeratefern.EnumerateServiceReport{Config: &config}
 
 	engine, err := getEngine(config.Service)
@@ -79,16 +84,18 @@ func RunServiceEnumerate(ctx context.Context, config enumeratefern.EnumerateServ
 				if targetCtx.Err() == context.DeadlineExceeded {
 					errMsg := fmt.Sprintf("Timeout (%ds) while enumerating %s", config.Timeout, target)
 					errorsChan <- errMsg
-					log.Printf("[ERROR] %s", errMsg)
+					log.Error("Enumeration timeout",
+						svc1log.SafeParam("target", target),
+						svc1log.SafeParam("timeout", config.Timeout))
 				}
 			case result := <-resultChan:
 				if result.detail != nil {
 					detailsChan <- result.detail
-					log.Printf("[INFO] Collected enumeration details for target %s", target)
+					log.Info("Collected enumeration details for target", svc1log.SafeParam("target", target))
 				}
 				for _, err := range result.errs {
 					errorsChan <- err
-					log.Printf("[ERROR] %s", err)
+					log.Error("Enumeration error", svc1log.SafeParam("error", err))
 				}
 			}
 		}(target)
@@ -112,7 +119,9 @@ func RunServiceEnumerate(ctx context.Context, config enumeratefern.EnumerateServ
 		errors = append(errors, err)
 	}
 
-	log.Printf("[INFO] Enumeration complete. Processed %d targets with %d errors", len(config.Targets), len(errors))
+	log.Info("Enumeration complete",
+		svc1log.SafeParam("targets", len(config.Targets)),
+		svc1log.SafeParam("errors", len(errors)))
 	resource.Result = &enumeratefern.EnumerateServiceResult{Details: details}
 	resource.Errors = errors
 	return resource, nil

--- a/internal/enumerate/ftp/ftp.go
+++ b/internal/enumerate/ftp/ftp.go
@@ -4,11 +4,13 @@ import (
 	// Standard
 	"context"
 	"fmt"
-	"log"
 
 	// Generated
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	ftp "github.com/Method-Security/networkscan/generated/go/enumerate/ftp"
+
+	// External
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 var bufferSize = 2048
@@ -45,17 +47,22 @@ type LibraryEnumerateFTP struct{}
 // EnumerateTarget connects to the target and extracts FTP details.
 func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string) (*enumeratefern.EnumerateServiceDetails, []string) {
 	var details ftp.EnumerateFtpDetails
+	// Set the actual connection target (the target parameter is already in host:port format for FTP)
 	details.Target = target
 	errors := []string{}
-	log.Printf("[INFO] Enumerating target: %s", target)
+
+	log := svc1log.FromContext(ctx)
+	log.Info("Starting FTP enumeration for target", svc1log.SafeParam("target", target))
 
 	// Attempt to connect to the target
 	conn, err := attemptConnection(ctx, target)
 	if err != nil {
-		log.Printf("[ERROR] Failed to connect to %s: %v", target, err)
+		log.Error("Failed to connect to FTP target", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
 		errors = append(errors, fmt.Sprintf("Failed to connect to %s: %v", target, err))
 		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
 	}
+
+	log.Debug("FTP connection established", svc1log.SafeParam("target", target))
 
 	// Grab the FTP banner
 	bannerStr, err := grabBanner(ctx, conn)
@@ -66,6 +73,8 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 	details.Banner = &bannerStr
 	successFulConnection := true
 	details.SuccessfulConnection = &successFulConnection
+
+	log.Debug("FTP banner retrieved", svc1log.SafeParam("target", target), svc1log.SafeParam("banner", bannerStr))
 
 	// Check TLS implemented
 	if err := checkTLSImplemented(ctx, conn, &details); err != nil {
@@ -95,5 +104,6 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 		errors = append(errors, fmt.Sprintf("failed to close connection: %v", err))
 	}
 
+	log.Info("FTP enumeration completed", svc1log.SafeParam("target", target))
 	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
 }

--- a/internal/enumerate/ftp/helpers.go
+++ b/internal/enumerate/ftp/helpers.go
@@ -25,7 +25,7 @@ func attemptConnection(ctx context.Context, target string) (net.Conn, error) {
 		log.Error("Initial connection failed", svc1log.SafeParam("error", err.Error()))
 		// Retry once if it was a broken pipe error
 		if strings.Contains(err.Error(), "broken pipe") {
-			log.Info("Retrying connection to %s", svc1log.SafeParam("target", target))
+			log.Info("Retrying connection due to broken pipe", svc1log.SafeParam("target", target))
 			conn, err = dialer.DialContext(ctx, "tcp", target)
 		}
 	}
@@ -197,7 +197,7 @@ readLoop: // Label for the outer loop
 		}
 	}
 
-	fmt.Println("[DEBUG] featResponse: ", featResponse) // Ensure this is outside the loop
+	log.Debug("FEAT response received", svc1log.SafeParam("response", featResponse))
 
 	// RFC 2228 and 4217 both enable TLS commands
 	if strings.Contains(featResponse, "TLS") || strings.Contains(featResponse, "SSL") || (strings.Contains(featResponse, "RFC") && (strings.Contains(featResponse, "2228") || strings.Contains(featResponse, "4217"))) {

--- a/internal/enumerate/ldap/ldap.go
+++ b/internal/enumerate/ldap/ldap.go
@@ -315,13 +315,14 @@ func (l *LibraryEnumerateLDAP) assembleResponse(details *ldapfern.EnumerateLdapD
 // EnumerateTarget performs LDAP enumeration for the given target
 func (l *LibraryEnumerateLDAP) EnumerateTarget(ctx context.Context, target string) (*enumeratefern.EnumerateServiceDetails, []string) {
 	var details ldapfern.EnumerateLdapDetails
-	details.Target = target
 	var errors []string
 
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting LDAP enumeration for target", svc1log.SafeParam("target", target))
 
 	host, port := utils.ParseHostPort(target, 389)
+	// Set the actual connection target (ip:port)
+	details.Target = fmt.Sprintf("%s:%d", host, port)
 
 	// Perform all authentication tests
 	authState := l.performAuthentication(ctx, host, port, target)

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -264,13 +264,13 @@ func (s *LibraryEnumerateSMB) assembleResponse(details *smb.EnumerateSmbDetails,
 // EnumerateTarget performs comprehensive SMB enumeration using the shared SMB protocol library
 func (s *LibraryEnumerateSMB) EnumerateTarget(ctx context.Context, target string) (*enumeratefern.EnumerateServiceDetails, []string) {
 	var details smb.EnumerateSmbDetails
-	details.Target = target
 	var errors []string
 
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting SMB enumeration for target", svc1log.SafeParam("target", target))
 
 	host, port := utils.ParseHostPort(target, 445)
+	details.Target = fmt.Sprintf("%s:%d", host, port)
 
 	// Create SMB client using shared protocol library
 	client := smbclient.NewClient(host, port)

--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -104,11 +104,12 @@ func (e *Engine) runSMBPentestForTargetPhased(ctx context.Context, target string
 			return results, errors // Fail fast - don't continue to AUTH/ACTION stages
 		}
 
-		// Check if probe result indicates failure
-		if probeResult.Errors != nil && len(probeResult.Errors) > 0 {
+		// Check if probe result indicates complete failure (no server info extracted)
+		// PROBE is considered successful if server info was extracted, even if there were connection errors
+		if (probeResult.Errors != nil && len(probeResult.Errors) > 0) && probeResult.ServerInfo == nil {
 			results = append(results, smbfern.NewPentestSmbResultFromProbeResult(probeResult))
 			errors = append(errors, "PROBE stage failed - cannot continue to AUTH/ACTION stages")
-			return results, errors // Fail fast - probe failed
+			return results, errors // Fail fast - probe failed completely
 		}
 
 		results = append(results, smbfern.NewPentestSmbResultFromProbeResult(probeResult))
@@ -521,11 +522,12 @@ func (e *Engine) runLDAPPentestForTargetPhased(ctx context.Context, target strin
 			return results, errors // Fail fast - don't continue to AUTH/ACTION stages
 		}
 
-		// Check if probe result indicates failure
-		if probeResult.Errors != nil && len(probeResult.Errors) > 0 {
+		// Check if probe result indicates complete failure (no server info extracted)
+		// PROBE is considered successful if server info was extracted, even if there were connection errors
+		if (probeResult.Errors != nil && len(probeResult.Errors) > 0) && probeResult.ServerInfo == nil {
 			results = append(results, ldapfern.NewPentestLdapResultFromProbeResult(probeResult))
 			errors = append(errors, "PROBE stage failed - cannot continue to AUTH/ACTION stages")
-			return results, errors // Fail fast - probe failed
+			return results, errors // Fail fast - probe failed completely
 		}
 
 		results = append(results, ldapfern.NewPentestLdapResultFromProbeResult(probeResult))

--- a/internal/pentest/ldap/auth.go
+++ b/internal/pentest/ldap/auth.go
@@ -400,16 +400,19 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting LDAP authentication testing", svc1log.SafeParam("target", target))
 
-	result := &pentestfern.AuthResult{
-		Target: target,
-	}
-
 	var errors []string
 
 	// Parse the target
 	ldapTarget, err := ParseTarget(target)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse target: %v", err)
+	}
+
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", ldapTarget.Host, ldapTarget.Port)
+
+	result := &pentestfern.AuthResult{
+		Target: connectionTarget,
 	}
 
 	// Override domain with config domain if provided (instead of deriving from target IP)

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -1406,12 +1406,19 @@ func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, con
 func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapfern.PentestLdapConfig) (*ldapfern.PentestLdapResult, []string) {
 	var errors []string
 
-	// Check that auth config exists
+	// Parse target to get the actual connection details
+	connectionTarget := config.Targets[0] // default fallback
+	if len(config.Targets) > 0 {
+		if target, parseErr := ParseTarget(config.Targets[0]); parseErr == nil {
+			connectionTarget = fmt.Sprintf("%s:%d", target.Host, target.Port)
+		}
+	}
 
+	// Check that auth config exists
 	if len(config.Usernames) == 0 {
 		err := fmt.Errorf("at least one username is required for authentication")
 		authResult := &pentestfern.AuthResult{
-			Target: config.Targets[0],
+			Target: connectionTarget,
 			Errors: []string{err.Error()},
 		}
 		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
@@ -1425,7 +1432,7 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 	if !hasPasswords && !hasNtlmHash {
 		err := fmt.Errorf("at least one password or NTLM hash is required for authentication")
 		authResult := &pentestfern.AuthResult{
-			Target: config.Targets[0],
+			Target: connectionTarget,
 			Errors: []string{err.Error()},
 		}
 		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
@@ -1460,7 +1467,7 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 		}
 
 		authResult := &pentestfern.AuthResult{
-			Target:       config.Targets[0],
+			Target:       connectionTarget,
 			AuthAttempts: []*pentestfern.AuthAttempt{authAttempt},
 			Errors:       []string{err.Error()},
 		}
@@ -1492,7 +1499,7 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 	}
 
 	authResult := &pentestfern.AuthResult{
-		Target:       config.Targets[0],
+		Target:       connectionTarget,
 		AuthAttempts: []*pentestfern.AuthAttempt{authAttempt},
 		Errors:       nil,
 	}

--- a/internal/pentest/ldap/probe.go
+++ b/internal/pentest/ldap/probe.go
@@ -17,17 +17,22 @@ func PerformProbe(ctx context.Context, target string, config *ldapfern.PentestLd
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting LDAP probe operation", svc1log.SafeParam("target", target))
 
-	result := &ldapfern.ProbeResult{
-		Target: target,
-	}
-
 	// Parse the target
 	ldapTarget, err := ParseTarget(target)
 	if err != nil {
-		errorMsg := "Failed to parse target: " + err.Error()
-		result.Errors = []string{errorMsg}
+		result := &ldapfern.ProbeResult{
+			Target: target, // Use original if parse fails
+			Errors: []string{"Failed to parse target: " + err.Error()},
+		}
 		log.Debug("LDAP probe failed - target parse error", svc1log.SafeParam("error", err))
 		return result, nil // Return result with error, don't fail the whole operation
+	}
+
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", ldapTarget.Host, ldapTarget.Port)
+
+	result := &ldapfern.ProbeResult{
+		Target: connectionTarget,
 	}
 
 	// Create LDAP connection for probing

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -37,13 +37,15 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 		return nil, fmt.Errorf("no target provided")
 	}
 
-	result := &smbfern.AuthResult{
-		Target: target,
-	}
-
 	var errors []string
 
 	host, port := utils.ParseHostPort(target, 445)
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+
+	result := &smbfern.AuthResult{
+		Target: connectionTarget,
+	}
 
 	// Always attempt to extract server info from NTLM challenge, regardless of auth requirements
 	log := svc1log.FromContext(ctx)

--- a/internal/pentest/smb/probe.go
+++ b/internal/pentest/smb/probe.go
@@ -25,11 +25,12 @@ func PerformProbe(ctx context.Context, target string, config *smbfern.PentestSmb
 		Target: connectionTarget,
 	}
 
-	// Create SMB client for probing (no authentication)
+	// Create SMB client for probing (challenge-only mode - no authentication)
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(config.Timeout) * time.Millisecond
+	client.SetChallengeOnly() // Only extract NTLM challenge, don't authenticate
 
-	// Perform connection and extract server info from NTLM challenge
+	// Perform connection and extract server info from NTLM challenge only
 	err := client.ConnectWithContext(ctx)
 	if err != nil {
 		errorMsg := "Failed to connect to SMB server: " + err.Error()

--- a/internal/pentest/smb/probe.go
+++ b/internal/pentest/smb/probe.go
@@ -2,6 +2,7 @@ package smb
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
@@ -16,11 +17,13 @@ func PerformProbe(ctx context.Context, target string, config *smbfern.PentestSmb
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting SMB probe operation", svc1log.SafeParam("target", target))
 
-	result := &smbfern.ProbeResult{
-		Target: target,
-	}
-
 	host, port := utils.ParseHostPort(target, 445)
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+
+	result := &smbfern.ProbeResult{
+		Target: connectionTarget,
+	}
 
 	// Create SMB client for probing (no authentication)
 	client := smbclient.NewClient(host, port)

--- a/internal/pentest/smb/shares.go
+++ b/internal/pentest/smb/shares.go
@@ -20,8 +20,12 @@ func PerformShares(ctx context.Context, target string, config *smbfern.PentestSm
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting SMB share enumeration using authenticated session", svc1log.SafeParam("target", target))
 
+	host, port := utils.ParseHostPort(target, 445)
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+
 	result := &smbfern.SharesResult{
-		Target: target,
+		Target: connectionTarget,
 	}
 
 	var errors []string

--- a/internal/pentest/ssh/auth.go
+++ b/internal/pentest/ssh/auth.go
@@ -22,13 +22,15 @@ func PerformAuthentication(target string, config *sshfern.PentestSshConfig) (*ss
 // Returns auth results
 func PerformAuthenticationWithContext(ctx context.Context, target string, config *sshfern.PentestSshConfig) (*sshfern.AuthResult, error) {
 
-	result := &sshfern.AuthResult{
-		Target: target,
-	}
-
 	var errors []string
 
 	host, port := utils.ParseHostPort(target, 22)
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+
+	result := &sshfern.AuthResult{
+		Target: connectionTarget,
+	}
 
 	// Perform auth attempts
 	authAttempts, authErrors := performAuthAttemptsWithContext(ctx, host, port, config)

--- a/internal/pentest/telnet/auth.go
+++ b/internal/pentest/telnet/auth.go
@@ -24,13 +24,15 @@ func PerformAuthentication(target string, config *telnetfern.PentestTelnetConfig
 // Returns both base server info and auth results
 func PerformAuthenticationWithContext(ctx context.Context, target string, config *telnetfern.PentestTelnetConfig) (*telnetfern.AuthResult, error) {
 
-	result := &telnetfern.AuthResult{
-		Target: target,
-	}
-
 	var errors []string
 
 	host, port := utils.ParseHostPort(target, 23)
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+
+	result := &telnetfern.AuthResult{
+		Target: connectionTarget,
+	}
 
 	// Only perform auth attempts if we have auth config
 	if config != nil {


### PR DESCRIPTION
# Improve stealth mode handling in host discovery and standardize target formatting

This PR makes two key improvements:

1. Enhances the host discovery logic to properly handle stealth mode:
   - Adds explicit stealth mode detection
   - Prevents scanType from being set when in stealth mode
   - Improves code readability with clear conditional blocks

2. Standardizes target formatting across all modules:
   - Ensures consistent target representation as "host:port" in results
   - Updates LDAP, SMB, SSH, and Telnet modules to use proper connection targets
   - Fixes target parsing in authentication and probe operations

Additional changes:
- Replaces basic logging with structured logging using svc1log
- Removes Kerberos fingerprinter from custom modules
- Improves error handling and logging in FTP enumeration

## Testing

Tested host discovery with both stealth and non-stealth modes to verify proper configuration.
Verified target formatting consistency across all service modules.