### PR TITLE
Improve machine account secret display with hostname formatting

### DIFF
--- a/internal/protocol/smb/lsa.go
+++ b/internal/protocol/smb/lsa.go
@@ -381,11 +381,18 @@ func parseSecret(rpccon *msrrp.RPCCon, base []byte, name string, secretItem []by
 	} else if strings.HasPrefix(upperName, "$MACHINE.ACC") {
 		h := md4.New()
 		h.Write(secretItem)
-		printname := "$MACHINE.ACC"
-		secret = fmt.Sprintf("$MACHINE.ACC (NT Hash): %x", h.Sum(nil))
+		// Get hostname and format as HOSTNAME$ instead of $MACHINE.ACC
+		hostname, domain, err := GetHostnameAndDomain(rpccon, base)
+		var printname string
+		if err != nil || hostname == "" {
+			// Fallback to original format if hostname retrieval fails
+			printname = "$MACHINE.ACC"
+		} else {
+			printname = strings.ToUpper(hostname) + "$"
+		}
+		secret = fmt.Sprintf("%s (NT Hash): %x", printname, h.Sum(nil))
 		result.secrets = append(result.secrets, secret)
 		// Calculate AES128 and AES256 keys from plaintext passwords
-		hostname, domain, err := GetHostnameAndDomain(rpccon, base)
 		if err != nil {
 			// Skip calculation of AES Keys if request failed or if domain is empty
 		} else if domain != "" {


### PR DESCRIPTION
### TL;DR

Improved the display format of machine account secrets to show the actual hostname instead of the generic `$MACHINE.ACC` label.

### What changed?

Modified the `parseSecret` function to retrieve the hostname when processing machine account secrets (`$MACHINE.ACC`). When available, the code now displays the secret using the actual machine name in the format `HOSTNAME$` instead of the generic `$MACHINE.ACC` label. If hostname retrieval fails, it falls back to the original format.

### How to test?

1. Run a secret dump against a domain-joined machine
2. Verify that machine account secrets are displayed with the actual hostname (e.g., `SERVER01$`) instead of `$MACHINE.ACC`
3. Test the fallback mechanism by simulating a hostname retrieval failure

### Why make this change?

This change makes machine account secrets more identifiable by using the actual hostname in the output. This improves readability and makes it easier to associate the secret with the specific machine it belongs to, especially when working with multiple machine accounts.