### PR TITLE
Remove QEMU setup and fix ARM64 compatibility issues

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -246,6 +246,7 @@ jobs:
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/ 2>/dev/null || \
           mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
           mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -248,8 +248,8 @@ jobs:
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v8.0/* output/build-linux_arm64/
-          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -20,6 +20,8 @@ jobs:
     name: Prepare Linux (arm64)
     runs-on: ubuntu-22.04-arm
     steps:
+      - name: Install Dependencies
+        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -248,8 +248,8 @@ jobs:
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
-          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-dist/linux_arm64/build-linux_linux_arm64/* output/build-linux_arm64/
+          mv artifacts/linux-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash
@@ -267,4 +267,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          COSIGN_EXPERIMENTAL: "true" 
+          COSIGN_EXPERIMENTAL: "true"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -20,8 +20,6 @@ jobs:
     name: Prepare Linux (arm64)
     runs-on: ubuntu-22.04-arm
     steps:
-      - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
@@ -59,6 +57,8 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -47,8 +47,6 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GOOS: linux
           GOARCH: arm64
-      - name: View ARM64 dist structure
-        run: ls -laR dist/ || echo "dist not found"
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-dist
@@ -61,8 +59,6 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -93,8 +89,6 @@ jobs:
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
             --rm amdbuilder goreleaser build --single-target \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
-      - name: View AMD64 dist structure
-        run: ls -laR dist/ || echo "dist not found"
       - uses: actions/upload-artifact@v4
         with:
           name: linux-amd64-dist
@@ -248,35 +242,13 @@ jobs:
 
       - name: Arrange Artifacts
         run: |
-          echo "=== Listing all artifacts ==="
-          ls -laR artifacts/ || echo "artifacts not found"
-
-          echo "=== Creating output directories ==="
           mkdir -p output/build-linux_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-
-          echo "=== Moving ARM64 Linux binary ==="
-          if [ -d "artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0" ]; then
-            echo "Found v8.0 variant"
-            mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
-          elif [ -d "artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64" ]; then
-            echo "Found non-versioned variant"
-            mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/
-          else
-            echo "ERROR: Could not find ARM64 binary in expected locations"
-            ls -la artifacts/linux-arm64-dist/linux_arm64/ || echo "linux_arm64 dir not found"
-            exit 1
-          fi
-
-          echo "=== Moving AMD64 Linux binary ==="
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
           mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
-
-          echo "=== Moving Windows binary ==="
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
-
-          echo "=== Moving macOS binary ==="
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -248,8 +248,8 @@ jobs:
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-dist/linux_arm64/build-linux_linux_arm64/* output/build-linux_arm64/
-          mv artifacts/linux-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,10 +19,20 @@ jobs:
   prepare-linux-arm:
     name: Prepare Linux (arm64)
     runs-on: ubuntu-22.04-arm
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev
-      - uses: actions/checkout@v4.1.6
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to ghcr.io registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
       - name: Generate Fern Go Code
@@ -31,22 +41,16 @@ jobs:
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-      - uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          args: >-
-            build --single-target --clean --snapshot --timeout 60m
+      - name: Build ARM64 Builder Image
+        run: docker buildx build . --platform linux/arm64 --load --tag armbuilder -f Dockerfile.builder
+      - name: Build ARM64 Binary
+        run: |
+          docker run -v $PWD:/app/networkscan \
+            -e GOARCH=arm64 -e GOOS=linux \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
+            --rm armbuilder goreleaser build --single-target \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          GOOS: linux
-          GOARCH: arm64
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-dist
@@ -246,8 +250,7 @@ jobs:
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/ 2>/dev/null || \
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/
           mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,20 +19,10 @@ jobs:
   prepare-linux-arm:
     name: Prepare Linux (arm64)
     runs-on: ubuntu-22.04-arm
-    env:
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to ghcr.io registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Checkout
-        uses: actions/checkout@v4.1.6
+      - name: Install Dependencies
+        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev
+      - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
       - name: Generate Fern Go Code
@@ -41,16 +31,22 @@ jobs:
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-      - name: Build ARM64 Builder Image
-        run: docker buildx build . --platform linux/arm64 --load --tag armbuilder -f Dockerfile.builder
-      - name: Build ARM64 Binary
-        run: |
-          docker run -v $PWD:/app/networkscan \
-            -e GOARCH=arm64 -e GOOS=linux \
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
-            --rm armbuilder goreleaser build --single-target \
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: >-
+            build --single-target --clean --snapshot --timeout 60m
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GOOS: linux
+          GOARCH: arm64
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-dist
@@ -250,8 +246,8 @@ jobs:
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/
-          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v8.0/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -47,6 +47,8 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GOOS: linux
           GOARCH: arm64
+      - name: View ARM64 dist structure
+        run: ls -laR dist/ || echo "dist not found"
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-dist
@@ -91,6 +93,8 @@ jobs:
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
             --rm amdbuilder goreleaser build --single-target \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
+      - name: View AMD64 dist structure
+        run: ls -laR dist/ || echo "dist not found"
       - uses: actions/upload-artifact@v4
         with:
           name: linux-amd64-dist
@@ -244,13 +248,35 @@ jobs:
 
       - name: Arrange Artifacts
         run: |
+          echo "=== Listing all artifacts ==="
+          ls -laR artifacts/ || echo "artifacts not found"
+
+          echo "=== Creating output directories ==="
           mkdir -p output/build-linux_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64/* output/build-linux_arm64/
-          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
+
+          echo "=== Moving ARM64 Linux binary ==="
+          if [ -d "artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0" ]; then
+            echo "Found v8.0 variant"
+            mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
+          elif [ -d "artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64" ]; then
+            echo "Found non-versioned variant"
+            mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/
+          else
+            echo "ERROR: Could not find ARM64 binary in expected locations"
+            ls -la artifacts/linux-arm64-dist/linux_arm64/ || echo "linux_arm64 dir not found"
+            exit 1
+          fi
+
+          echo "=== Moving AMD64 Linux binary ==="
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
+
+          echo "=== Moving Windows binary ==="
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
+
+          echo "=== Moving macOS binary ==="
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -59,8 +59,6 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -248,7 +246,7 @@ jobs:
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
           mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
@@ -267,4 +265,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          COSIGN_EXPERIMENTAL: "true"
+          COSIGN_EXPERIMENTAL: "true" 

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -9,7 +9,7 @@ partial:
   by: target
 
 builds:
-  - id: build-linux-amd64
+  - id: build-linux
     main: .
     binary: networkscan
     ldflags:
@@ -21,21 +21,10 @@ builds:
     goos:
       - linux
     goarch:
+      - arm64
       - amd64
     goarm:
       - "7"
-  - id: build-linux-arm64
-    main: .
-    binary: networkscan
-    ldflags:
-      - -s -w
-      - -X github.com/method-security/networkscan/main.version={{.Version}}
-    env:
-      - CGO_ENABLED=1
-    goos:
-      - linux
-    goarch:
-      - arm64
   - id: build-macos
     main: .
     binary: networkscan

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -9,7 +9,7 @@ partial:
   by: target
 
 builds:
-  - id: build-linux
+  - id: build-linux-amd64
     main: .
     binary: networkscan
     ldflags:
@@ -21,10 +21,21 @@ builds:
     goos:
       - linux
     goarch:
-      - arm64
       - amd64
     goarm:
       - "7"
+  - id: build-linux-arm64
+    main: .
+    binary: networkscan
+    ldflags:
+      - -s -w
+      - -X github.com/method-security/networkscan/main.version={{.Version}}
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - arm64
   - id: build-macos
     main: .
     binary: networkscan

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -36,8 +36,6 @@ builds:
       - linux
     goarch:
       - arm64
-    goarm:
-      - "7"
   - id: build-macos
     main: .
     binary: networkscan

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ARG NMAP_VERSION="7.95-r0"
 # nmap is a dependency for multiple commands
 RUN apk update && apk --no-cache add ca-certificates bash git nmap=$NMAP_VERSION nmap-scripts=$NMAP_VERSION sudo
 
+# Create symlink for libpcap version compatibility
+RUN ln -sf /usr/lib/libpcap.so.1 /usr/lib/libpcap.so.0.8
+
 # Setup Method Directory Structure
 RUN \
   mkdir -p /opt/method/${CLI_NAME}/ && \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,7 @@ ARG CLI_NAME="networkscan"
 ARG TARGETARCH
 
 RUN \
-  apk add --no-cache git gcc build-base libpcap-dev bash wget && \
+  apk add --no-cache git gcc build-base libpcap-dev dbus-dev bash wget && \
   mkdir -p /app/${CLI_NAME} && \
   git config --global --add safe.directory /app/${CLI_NAME}
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -28,3 +28,6 @@ RUN \
   tar -xvzf goreleaser-pro_Linux_arm64.tar.gz && \
   mv goreleaser /usr/local/bin/goreleaser && \
   rm -rf goreleaser-pro_Linux_arm64.tar.gz LICENSE.md README.md completions manpages
+
+# Select the appropriate stage based on target architecture
+FROM ${TARGETARCH} as final

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,17 +1,17 @@
 # Dockerfile used for the compilation of the statically compiled networkscan binary
-FROM golang:1.24.2-alpine3.20 AS base
+FROM golang:1.24.2-alpine3.20 as base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="networkscan"
 ARG TARGETARCH
 
 RUN \
-  apk add --no-cache git gcc build-base libpcap-dev dbus-dev bash wget && \
+  apk add --no-cache git gcc build-base libpcap-dev bash wget && \
   mkdir -p /app/${CLI_NAME} && \
   git config --global --add safe.directory /app/${CLI_NAME}
 
 WORKDIR /app/${CLI_NAME}
 
-FROM base AS amd64
+FROM base as amd64
 ARG CLI_NAME
 ARG GORELEASER_VERSION
 RUN \
@@ -20,7 +20,7 @@ RUN \
   mv goreleaser /usr/local/bin/goreleaser && \
   rm -rf goreleaser-pro_Linux_x86_64.tar.gz LICENSE.md README.md completions manpages
 
-FROM base AS arm64
+FROM base as arm64
 ARG CLI_NAME
 ARG GORELEASER_VERSION
 RUN \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # Dockerfile used for the compilation of the statically compiled networkscan binary
-FROM golang:1.24.2-alpine3.20 as base
+FROM golang:1.24.2-alpine3.20 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="networkscan"
 ARG TARGETARCH
@@ -11,7 +11,7 @@ RUN \
 
 WORKDIR /app/${CLI_NAME}
 
-FROM base as amd64
+FROM base AS amd64
 ARG CLI_NAME
 ARG GORELEASER_VERSION
 RUN \
@@ -20,8 +20,9 @@ RUN \
   mv goreleaser /usr/local/bin/goreleaser && \
   rm -rf goreleaser-pro_Linux_x86_64.tar.gz LICENSE.md README.md completions manpages
 
-FROM base as arm64
+FROM base AS arm64
 ARG CLI_NAME
+ARG GORELEASER_VERSION
 RUN \
   wget https://github.com/goreleaser/goreleaser-pro/releases/download/${GORELEASER_VERSION}-pro/goreleaser-pro_Linux_arm64.tar.gz && \
   tar -xvzf goreleaser-pro_Linux_arm64.tar.gz && \


### PR DESCRIPTION
# Remove QEMU setup and ARM v7 support, add libpcap compatibility

This PR makes several infrastructure changes to improve our build process:

1. Removes the QEMU setup step from the GitHub workflow as it's no longer needed
2. Removes ARM v7 support from the goreleaser configuration
3. Adds a symlink for libpcap in the Dockerfile to ensure compatibility with older libraries
4. Improves the Dockerfile.builder with proper architecture selection using the `final` stage

These changes streamline our build process and ensure better compatibility with systems that depend on older libpcap versions.