### PR TITLE
Reuse authenticated connections for SMB and LDAP actions

### DIFF
--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -2,7 +2,9 @@ package pentest
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"strings"
 	"time"
 
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
@@ -10,12 +12,14 @@ import (
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
 	telnetfern "github.com/Method-Security/networkscan/generated/go/pentest/telnet"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	ldappentest "github.com/Method-Security/networkscan/internal/pentest/ldap"
 	smbpentest "github.com/Method-Security/networkscan/internal/pentest/smb"
 	sshpentest "github.com/Method-Security/networkscan/internal/pentest/ssh"
 	telnetpentest "github.com/Method-Security/networkscan/internal/pentest/telnet"
 	smbclient "github.com/Method-Security/networkscan/internal/protocol/smb"
 	"github.com/Method-Security/networkscan/utils"
+	"github.com/go-ldap/ldap/v3"
 	gosmb "github.com/jfjallid/go-smb/smb"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -121,13 +125,17 @@ func (e *Engine) runSMBPentestForTargetPhased(ctx context.Context, target string
 	}
 
 	// STAGE 2: AUTH - Authentication testing with credentials
+	var authenticatedClient *smbclient.Client
 	if needsAuth || needsOtherAction {
 		log.Info("Stage 2: AUTH - Authentication testing", svc1log.SafeParam("target", target))
-		authResult, err := smbpentest.PerformAuthenticationWithContext(ctx, target, config)
+		authResult, authClient, err := smbpentest.PerformAuthenticationWithContextAndConnection(ctx, target, config)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("AUTH stage failed: %v", err))
 			return results, errors // Fail fast - don't continue to ACTION stage
 		}
+
+		// Store the authenticated client for ACTION stage
+		authenticatedClient = authClient
 
 		// Check if auth result indicates failure (no successful auth attempts)
 		successfulAuths := make([]*pentestfern.AuthAttempt, 0)
@@ -147,14 +155,17 @@ func (e *Engine) runSMBPentestForTargetPhased(ctx context.Context, target string
 			return results, errors // Fail fast - auth failed, can't do actions
 		}
 
-		// If only AUTH was requested, return early
+		// If only AUTH was requested, return early (but close the client if we have one)
 		if !needsOtherAction {
+			if authenticatedClient != nil {
+				// Don't explicitly close to avoid panic - let GC handle it
+			}
 			return results, errors
 		}
 
 		// STAGE 3: ACTION - Execute specific actions with authenticated context
 		if needsOtherAction {
-			actionResults, actionErrors := e.executeSMBActionsWithAuth(ctx, target, config, authResult, otherActions)
+			actionResults, actionErrors := e.executeSMBActionsWithAuthenticatedClient(ctx, target, config, authenticatedClient, otherActions)
 			results = append(results, actionResults...)
 			errors = append(errors, actionErrors...)
 		}
@@ -163,7 +174,68 @@ func (e *Engine) runSMBPentestForTargetPhased(ctx context.Context, target string
 	return results, errors
 }
 
-// executeSMBActionsWithAuth executes specific SMB actions using authenticated context
+// executeSMBActionsWithAuthenticatedClient executes specific SMB actions using pre-authenticated client
+func (e *Engine) executeSMBActionsWithAuthenticatedClient(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authenticatedClient *smbclient.Client, actions []smbfern.PentestSmbAction) ([]*smbfern.PentestSmbResult, []string) {
+	var results []*smbfern.PentestSmbResult
+	var errors []string
+
+	log := svc1log.FromContext(ctx)
+	log.Info("Stage 3: ACTION - Executing specific actions with pre-authenticated client", svc1log.SafeParam("target", target))
+
+	if authenticatedClient == nil {
+		errors = append(errors, "No authenticated client available for ACTION stage")
+		return results, errors
+	}
+
+	// Get the authenticated session directly from the client
+	authenticatedSession, sessionErr := authenticatedClient.GetSMBSession()
+	if sessionErr != nil {
+		errors = append(errors, fmt.Sprintf("Failed to get SMB session from authenticated client: %v", sessionErr))
+		return results, errors
+	}
+
+	defer func() {
+		if authenticatedClient != nil {
+			// Don't explicitly close to avoid panic - let GC handle it
+		}
+	}()
+
+	// Execute each requested action using the pre-authenticated client and session
+	for _, action := range actions {
+		switch action {
+		case smbfern.PentestSmbActionSamdump:
+			log.Debug("Performing " + string(smbfern.PentestSmbActionSamdump))
+			samdumpResult, err := smbpentest.PerformSamdump(ctx, target, config, authenticatedSession)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionSamdump), err))
+			} else {
+				results = append(results, smbfern.NewPentestSmbResultFromSamdumpResult(samdumpResult))
+			}
+		case smbfern.PentestSmbActionLsadump:
+			log.Debug("Performing " + string(smbfern.PentestSmbActionLsadump))
+			lsadumpResult, err := smbpentest.PerformLsadump(ctx, target, config, authenticatedSession)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionLsadump), err))
+			} else {
+				results = append(results, smbfern.NewPentestSmbResultFromLsadumpResult(lsadumpResult))
+			}
+		case smbfern.PentestSmbActionShares:
+			log.Debug("Performing " + string(smbfern.PentestSmbActionShares))
+			sharesResult, err := smbpentest.PerformShares(ctx, target, config, authenticatedSession)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionShares), err))
+			} else {
+				results = append(results, smbfern.NewPentestSmbResultFromSharesResult(sharesResult))
+			}
+		default:
+			errors = append(errors, fmt.Sprintf("unsupported action: %s", string(action)))
+		}
+	}
+
+	return results, errors
+}
+
+// executeSMBActionsWithAuth executes specific SMB actions using authenticated context (DEPRECATED - use executeSMBActionsWithAuthenticatedClient)
 func (e *Engine) executeSMBActionsWithAuth(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authResult *smbfern.AuthResult, actions []smbfern.PentestSmbAction) ([]*smbfern.PentestSmbResult, []string) {
 	var results []*smbfern.PentestSmbResult
 	var errors []string
@@ -263,6 +335,148 @@ func (e *Engine) createAuthenticatedSMBSession(ctx context.Context, target strin
 
 	authenticatedSession, err := tempClient.GetSMBSession()
 	return authenticatedSession, tempClient, err
+}
+
+// createAuthenticatedLDAPSession creates an authenticated LDAP connection for action execution
+func (e *Engine) createAuthenticatedLDAPSession(ctx context.Context, target string, config *ldapfern.PentestLdapConfig, successfulAuth *pentestfern.AuthAttempt) (*ldap.Conn, string, error) {
+	// Parse target to get connection details
+	parsedTarget, err := ldappentest.ParseTarget(target)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to parse target: %v", err)
+	}
+
+	// Establish connection
+	address := fmt.Sprintf("%s:%d", parsedTarget.Host, parsedTarget.Port)
+	var conn *ldap.Conn
+
+	if parsedTarget.UseSSL {
+		conn, err = ldap.DialTLS("tcp", address, &tls.Config{
+			InsecureSkipVerify: true,
+		})
+	} else {
+		conn, err = ldap.Dial("tcp", address)
+	}
+
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to connect to LDAP server: %v", err)
+	}
+
+	// Set timeout
+	timeout := time.Duration(config.Timeout) * time.Millisecond
+	conn.SetTimeout(timeout)
+
+	// Authenticate using the successful auth attempt
+	username := successfulAuth.Username
+	authDomain := ""
+	if successfulAuth.Domain != nil {
+		authDomain = *successfulAuth.Domain
+	}
+
+	// Check if we should use hash or password authentication
+	if config.NtlmHash != nil && *config.NtlmHash != "" {
+		// Use NTLM hash authentication
+		ntlmHash := *config.NtlmHash
+		processor := ntlm.NewHashProcessor()
+		fullHash := processor.ProcessHashForLDAP(ntlmHash)
+
+		err = conn.NTLMBindWithHash(authDomain, username, fullHash)
+		if err != nil {
+			_ = conn.Close()
+			return nil, "", fmt.Errorf("NTLM hash bind failed: %v", err)
+		}
+	} else {
+		// Use password authentication
+		var bindUsername string
+		var password string
+
+		if successfulAuth.Password != nil {
+			password = *successfulAuth.Password
+		}
+
+		if authDomain != "" {
+			bindUsername = fmt.Sprintf("%s@%s", username, authDomain)
+		} else {
+			bindUsername = username
+		}
+
+		err = conn.Bind(bindUsername, password)
+		if err != nil {
+			_ = conn.Close()
+			return nil, "", fmt.Errorf("password bind failed: %v", err)
+		}
+	}
+
+	// Get base DN
+	searchRequest := ldap.NewSearchRequest(
+		"", // Empty base DN for root DSE
+		ldap.ScopeBaseObject,
+		ldap.NeverDerefAliases,
+		0, 0, false,
+		"(objectclass=*)",
+		[]string{"namingContexts"},
+		nil,
+	)
+
+	sr, err := conn.Search(searchRequest)
+	if err != nil {
+		_ = conn.Close()
+		return nil, "", fmt.Errorf("failed to query root DSE: %v", err)
+	}
+
+	if len(sr.Entries) == 0 {
+		_ = conn.Close()
+		return nil, "", fmt.Errorf("no naming contexts found in root DSE")
+	}
+
+	// Find the domain context
+	namingContexts := sr.Entries[0].GetAttributeValues("namingContexts")
+	var baseDN string
+	for _, context := range namingContexts {
+		if strings.Contains(context, "DC=") {
+			baseDN = context
+			break
+		}
+	}
+
+	if baseDN == "" {
+		_ = conn.Close()
+		return nil, "", fmt.Errorf("no domain naming context found")
+	}
+
+	return conn, baseDN, nil
+}
+
+// getBaseDNFromConnection queries the base DN from an existing authenticated LDAP connection
+func (e *Engine) getBaseDNFromConnection(conn *ldap.Conn) (string, error) {
+	// Get base DN
+	searchRequest := ldap.NewSearchRequest(
+		"", // Empty base DN for root DSE
+		ldap.ScopeBaseObject,
+		ldap.NeverDerefAliases,
+		0, 0, false,
+		"(objectclass=*)",
+		[]string{"namingContexts"},
+		nil,
+	)
+
+	sr, err := conn.Search(searchRequest)
+	if err != nil {
+		return "", fmt.Errorf("failed to query root DSE: %v", err)
+	}
+
+	if len(sr.Entries) == 0 {
+		return "", fmt.Errorf("no naming contexts found in root DSE")
+	}
+
+	// Find the domain context
+	namingContexts := sr.Entries[0].GetAttributeValues("namingContexts")
+	for _, context := range namingContexts {
+		if strings.Contains(context, "DC=") {
+			return context, nil
+		}
+	}
+
+	return "", fmt.Errorf("no domain naming context found")
 }
 
 // RunSSHPentest performs SSH pentest operations for multiple targets
@@ -541,10 +755,19 @@ func (e *Engine) runLDAPPentestForTargetPhased(ctx context.Context, target strin
 	// STAGE 2: AUTH - Authentication testing with credentials
 	if needsAuth || needsOtherAction {
 		log.Info("Stage 2: AUTH - Authentication testing", svc1log.SafeParam("target", target))
-		authResult, err := ldappentest.PerformAuthenticationWithContext(ctx, target, config)
+		authResult, authenticatedConn, err := ldappentest.PerformAuthenticationWithContextAndConnection(ctx, target, config)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("AUTH stage failed: %v", err))
 			return results, errors // Fail fast - don't continue to ACTION stage
+		}
+
+		// Defer closing the authenticated connection if we have one
+		if authenticatedConn != nil {
+			defer func() {
+				if err := authenticatedConn.Close(); err != nil {
+					log.Error("Failed to close authenticated LDAP connection", svc1log.SafeParam("error", err))
+				}
+			}()
 		}
 
 		// Check if auth result indicates failure (no successful auth attempts)
@@ -572,7 +795,20 @@ func (e *Engine) runLDAPPentestForTargetPhased(ctx context.Context, target strin
 
 		// STAGE 3: ACTION - Execute specific actions with authenticated context
 		if needsOtherAction {
-			actionResults, actionErrors := e.executeLDAPActionsWithAuth(ctx, target, config, authResult, otherActions)
+			if authenticatedConn == nil {
+				errors = append(errors, "No authenticated connection available for ACTION stage")
+				return results, errors
+			}
+
+			// Get base DN from the authenticated connection
+			baseDN, baseDNErr := e.getBaseDNFromConnection(authenticatedConn)
+			if baseDNErr != nil {
+				errors = append(errors, fmt.Sprintf("Failed to determine base DN: %v", baseDNErr))
+				return results, errors
+			}
+
+			// Execute actions with the pre-authenticated connection from AUTH stage
+			actionResults, actionErrors := e.executeLDAPActionsWithAuthenticatedConnection(ctx, authenticatedConn, baseDN, config, otherActions)
 			results = append(results, actionResults...)
 			errors = append(errors, actionErrors...)
 		}
@@ -581,34 +817,28 @@ func (e *Engine) runLDAPPentestForTargetPhased(ctx context.Context, target strin
 	return results, errors
 }
 
-// executeLDAPActionsWithAuth executes specific LDAP actions using authenticated context
-func (e *Engine) executeLDAPActionsWithAuth(ctx context.Context, target string, config *ldapfern.PentestLdapConfig, authResult *pentestfern.AuthResult, actions []ldapfern.PentestLdapAction) ([]*ldapfern.PentestLdapResult, []string) {
+// executeLDAPActionsWithAuthenticatedConnection executes specific LDAP actions using pre-authenticated connection
+func (e *Engine) executeLDAPActionsWithAuthenticatedConnection(ctx context.Context, conn *ldap.Conn, baseDN string, config *ldapfern.PentestLdapConfig, actions []ldapfern.PentestLdapAction) ([]*ldapfern.PentestLdapResult, []string) {
 	var results []*ldapfern.PentestLdapResult
 	var errors []string
 
 	log := svc1log.FromContext(ctx)
-	log.Info("Stage 3: ACTION - Executing specific actions with authenticated context", svc1log.SafeParam("target", target))
+	log.Info("Stage 3: ACTION - Executing specific actions with pre-authenticated connection", svc1log.SafeParam("baseDN", baseDN))
 
-	// Find successful auth attempts (we already validated there's at least one)
-	successfulAuths := make([]*pentestfern.AuthAttempt, 0)
-	for _, attempt := range authResult.AuthAttempts {
-		if attempt.Success {
-			successfulAuths = append(successfulAuths, attempt)
-		}
-	}
-
-	// Execute each requested action
+	// Execute each requested action with the pre-authenticated connection
 	for _, action := range actions {
 		switch action {
 		case ldapfern.PentestLdapActionDomaindump:
 			log.Debug("Performing " + string(ldapfern.PentestLdapActionDomaindump))
-			// Use the existing library for domain dump with authenticated context
+			// Use the pre-authenticated connection directly - no re-authentication!
 			library := &ldappentest.LibraryPentestLdap{}
-			domainDumpResult, err := library.DomainDump(ctx, *config)
-			if err != nil {
-				errors = append(errors, fmt.Sprintf("%s failed: %v", string(ldapfern.PentestLdapActionDomaindump), err))
-			} else if domainDumpResult != nil {
-				results = append(results, domainDumpResult)
+			domainResult, actionErrors := library.DomainDumpWithAuth(ctx, conn, baseDN, *config)
+			if len(actionErrors) > 0 {
+				errors = append(errors, actionErrors...)
+			}
+			if domainResult != nil {
+				result := ldapfern.NewPentestLdapResultFromDomainDumpResult(domainResult)
+				results = append(results, result)
 			}
 		}
 	}

--- a/internal/pentest/ldap/auth.go
+++ b/internal/pentest/ldap/auth.go
@@ -397,6 +397,12 @@ func createLDAPConnection(target *Target, timeout int) (*ldap.Conn, error) {
 
 // PerformAuthenticationWithContext performs LDAP authentication attempts with context
 func PerformAuthenticationWithContext(ctx context.Context, target string, config *ldapfern.PentestLdapConfig) (*pentestfern.AuthResult, error) {
+	result, _, err := PerformAuthenticationWithContextAndConnection(ctx, target, config)
+	return result, err
+}
+
+// PerformAuthenticationWithContextAndConnection performs LDAP authentication attempts and returns authenticated connection
+func PerformAuthenticationWithContextAndConnection(ctx context.Context, target string, config *ldapfern.PentestLdapConfig) (*pentestfern.AuthResult, *ldap.Conn, error) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting LDAP authentication testing", svc1log.SafeParam("target", target))
 
@@ -405,7 +411,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 	// Parse the target
 	ldapTarget, err := ParseTarget(target)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse target: %v", err)
+		return nil, nil, fmt.Errorf("failed to parse target: %v", err)
 	}
 
 	// Set the actual connection target (ip:port)
@@ -438,10 +444,14 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 		(config.NtlmHash != nil && *config.NtlmHash != ""))
 	shouldPerformAuth = hasCredentials
 
+	var authenticatedConnection *ldap.Conn
+
 	// If credentials are provided, perform authentication
 	if shouldPerformAuth {
-		authAttempts, authErrors := performLDAPAuthAttemptsWithContext(ctx, ldapTarget, config)
+		// Perform authentication with connection keeping to avoid double authentication
+		authAttempts, authConn, authErrors := performLDAPAuthAttemptsWithConnectionKeeping(ctx, ldapTarget, config)
 		result.AuthAttempts = authAttempts
+		authenticatedConnection = authConn
 		errors = append(errors, authErrors...)
 	}
 
@@ -449,17 +459,18 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 		result.Errors = errors
 	}
 
-	return result, nil
+	return result, authenticatedConnection, nil
 }
 
-// performLDAPAuthAttemptsWithContext performs credential-based authentication attempts with context
-func performLDAPAuthAttemptsWithContext(ctx context.Context, target *Target, config *ldapfern.PentestLdapConfig) ([]*pentestfern.AuthAttempt, []string) {
+// performLDAPAuthAttemptsWithConnectionKeeping performs credential-based authentication attempts with connection keeping
+func performLDAPAuthAttemptsWithConnectionKeeping(ctx context.Context, target *Target, config *ldapfern.PentestLdapConfig) ([]*pentestfern.AuthAttempt, *ldap.Conn, []string) {
 	var allAttempts []*pentestfern.AuthAttempt
 	var errors []string
+	var authenticatedConnection *ldap.Conn
 
 	// Check if credentials are available
 	if len(config.Usernames) == 0 {
-		return nil, []string{"no usernames provided"}
+		return nil, nil, []string{"no usernames provided"}
 	}
 
 	log := svc1log.FromContext(ctx)
@@ -472,19 +483,19 @@ func performLDAPAuthAttemptsWithContext(ctx context.Context, target *Target, con
 
 		for _, username := range config.Usernames {
 			timeout := config.Timeout
-			attempt, err := attemptLDAPHashAuthenticationWithContext(ctx, target, username, ntlmHash, timeout)
+			attempt, conn, err := attemptLDAPHashAuthenticationWithConnection(ctx, target, username, ntlmHash, timeout)
 			if err != nil {
 				errors = append(errors, err.Error())
 			}
 
 			allAttempts = append(allAttempts, attempt)
 
-			if attempt.Success {
+			if attempt.Success && conn != nil {
 				log.Info("Pass-the-hash authentication successful",
 					svc1log.SafeParam("username", username),
 					svc1log.SafeParam("hash", "[REDACTED]"))
 
-				// Stop on first success for pass-the-hash
+				authenticatedConnection = conn
 				break
 			}
 		}
@@ -493,20 +504,26 @@ func performLDAPAuthAttemptsWithContext(ctx context.Context, target *Target, con
 		for _, username := range config.Usernames {
 			for _, password := range config.Passwords {
 				timeout := config.Timeout
-				attempt, err := attemptLDAPAuthenticationWithContext(ctx, target, username, password, timeout)
+				attempt, conn, err := attemptLDAPAuthenticationWithConnection(ctx, target, username, password, timeout)
 				if err != nil {
 					errors = append(errors, err.Error())
 				}
 
 				allAttempts = append(allAttempts, attempt)
 
-				if attempt.Success {
+				if attempt.Success && conn != nil {
 					log.Info("Authentication successful",
 						svc1log.SafeParam("username", username),
 						svc1log.SafeParam("password", "[REDACTED]"))
 
-					// Continue with next password for traditional auth
+					authenticatedConnection = conn
+					// Stop on first success to avoid multiple connections
+					break
 				}
+			}
+			// If we found a successful connection, break out of username loop too
+			if authenticatedConnection != nil {
+				break
 			}
 		}
 	}
@@ -523,11 +540,74 @@ func performLDAPAuthAttemptsWithContext(ctx context.Context, target *Target, con
 		svc1log.SafeParam("successful", successfulCount),
 		svc1log.SafeParam("failed", len(allAttempts)-successfulCount))
 
-	return allAttempts, errors
+	return allAttempts, authenticatedConnection, errors
 }
 
-// attemptLDAPAuthenticationWithContext performs a single LDAP authentication attempt with context
-func attemptLDAPAuthenticationWithContext(ctx context.Context, target *Target, username, password string, timeout int) (*pentestfern.AuthAttempt, error) {
+// attemptLDAPHashAuthenticationWithConnection performs a single LDAP hash authentication attempt with connection keeping
+func attemptLDAPHashAuthenticationWithConnection(ctx context.Context, target *Target, username, ntlmHash string, timeout int) (*pentestfern.AuthAttempt, *ldap.Conn, error) {
+	timestamp := time.Now()
+	attempt := &pentestfern.AuthAttempt{
+		Username:  username,
+		Password:  &ntlmHash, // Store NTLM hash in password field for now
+		Domain:    &target.Domain,
+		Success:   false,
+		Message:   "Authentication in progress",
+		Timestamp: timestamp,
+	}
+
+	// Generate bind DNs based on target configuration
+	bindDNS := generateBindDNS(username, target.BaseDN, target.Domain)
+	if len(bindDNS) == 0 {
+		return attempt, nil, fmt.Errorf("no valid bind DN formats available")
+	}
+
+	log := svc1log.FromContext(ctx)
+
+	// Try each bind DN format
+	for _, bindDN := range bindDNS {
+		select {
+		case <-ctx.Done():
+			return attempt, nil, ctx.Err()
+		default:
+		}
+
+		log.Debug("Attempting LDAP hash authentication",
+			svc1log.SafeParam("bind_dn", bindDN),
+			svc1log.SafeParam("timeout", timeout))
+
+		// Create connection
+		conn, err := createLDAPConnection(target, timeout)
+		if err != nil {
+			log.Debug("Failed to create LDAP connection",
+				svc1log.SafeParam("error", err))
+			continue
+		}
+
+		// Attempt to bind with hash using SASL
+		err = conn.NTLMBind(target.Domain, username, ntlmHash)
+		if err != nil {
+			_ = conn.Close()
+			log.Debug("LDAP hash authentication failed",
+				svc1log.SafeParam("bind_dn", bindDN),
+				svc1log.SafeParam("error", err))
+			continue
+		}
+
+		// Authentication successful
+		attempt.Success = true
+		attempt.Message = "Authentication successful"
+		log.Info("LDAP hash authentication successful", svc1log.SafeParam("bind_dn", bindDN))
+
+		return attempt, conn, nil
+	}
+
+	// All bind attempts failed
+	attempt.Message = "Authentication failed for all bind DN formats"
+	return attempt, nil, nil
+}
+
+// attemptLDAPAuthenticationWithConnection performs a single LDAP authentication attempt and returns the connection
+func attemptLDAPAuthenticationWithConnection(ctx context.Context, target *Target, username, password string, timeout int) (*pentestfern.AuthAttempt, *ldap.Conn, error) {
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
 		Username:  username,
@@ -537,53 +617,37 @@ func attemptLDAPAuthenticationWithContext(ctx context.Context, target *Target, u
 		Timestamp: timestamp,
 	}
 
-	success, message, err := AuthenticateUser(ctx, target, username, password, timeout)
+	success, message, conn, err := AuthenticateUserKeepConnection(ctx, target, username, password, timeout)
 	if err != nil {
 		attempt.Message = err.Error()
-		return attempt, nil // Don't return error here, it's expected for failed auth
+		return attempt, nil, nil // Don't return error here, it's expected for failed auth
 	}
 
 	attempt.Success = success
 	attempt.Message = message
 
-	return attempt, nil
-}
-
-// attemptLDAPHashAuthenticationWithContext performs a single LDAP pass-the-hash authentication attempt with context
-func attemptLDAPHashAuthenticationWithContext(ctx context.Context, target *Target, username, ntlmHash string, timeout int) (*pentestfern.AuthAttempt, error) {
-	timestamp := time.Now()
-	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  nil, // No password for hash auth
-		Domain:    &target.Domain,
-		Success:   false,
-		Timestamp: timestamp,
-	}
-
-	success, message, err := AuthenticateUserWithHash(ctx, target, username, ntlmHash, timeout)
-	if err != nil {
-		attempt.Message = err.Error()
-		return attempt, nil // Don't return error here, it's expected for failed auth
-	}
-
-	attempt.Success = success
-	attempt.Message = message
-
-	return attempt, nil
+	return attempt, conn, nil
 }
 
 // generateBindDNS generates possible bind DN formats for a username
 func generateBindDNS(username, baseDN, domain string) []string {
 	var bindDNS []string
 
-	// Common bind DN formats
-	bindDNS = append(bindDNS, username)                                   // Direct username
-	bindDNS = append(bindDNS, fmt.Sprintf("%s@%s", username, domain))     // UPN format
+	// If domain is provided, prioritize domain-qualified formats first to avoid redundant attempts
+	if domain != "" {
+		bindDNS = append(bindDNS, fmt.Sprintf("%s@%s", username, domain))  // UPN format (most common for AD)
+		bindDNS = append(bindDNS, fmt.Sprintf("%s\\%s", domain, username)) // Domain\username format
+		bindDNS = append(bindDNS, username)                                // Direct username (fallback)
+	} else {
+		// If no domain provided, try direct username first
+		bindDNS = append(bindDNS, username) // Direct username
+	}
+
+	// LDAP DN formats (less common for modern AD but still supported)
 	bindDNS = append(bindDNS, fmt.Sprintf("cn=%s,%s", username, baseDN))  // CN format
 	bindDNS = append(bindDNS, fmt.Sprintf("uid=%s,%s", username, baseDN)) // UID format
-	bindDNS = append(bindDNS, fmt.Sprintf("%s\\%s", domain, username))    // Domain\username format
 
-	// Try with different organizational units
+	// Try with different organizational units (less common)
 	commonOUs := []string{"ou=users", "ou=people", "cn=users"}
 	for _, ou := range commonOUs {
 		bindDNS = append(bindDNS, fmt.Sprintf("cn=%s,%s,%s", username, ou, baseDN))
@@ -591,4 +655,42 @@ func generateBindDNS(username, baseDN, domain string) []string {
 	}
 
 	return bindDNS
+}
+
+// AuthenticateUserKeepConnection performs LDAP authentication and keeps the connection open on success
+func AuthenticateUserKeepConnection(ctx context.Context, target *Target, username, password string, timeout int) (bool, string, *ldap.Conn, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Create LDAP connection
+	conn, err := createLDAPConnection(target, timeout)
+	if err != nil {
+		return false, fmt.Sprintf("Connection failed: %v", err), nil, nil
+	}
+
+	// Try different bind DN formats
+	bindDNS := generateBindDNS(username, target.BaseDN, target.Domain)
+	var errorMessages []string
+
+	for _, bindDN := range bindDNS {
+		log.Debug("Attempting LDAP bind", svc1log.SafeParam("bindDN", bindDN))
+		err = conn.Bind(bindDN, password)
+		if err == nil {
+			log.Info("LDAP authentication successful",
+				svc1log.SafeParam("bindDN", bindDN),
+				svc1log.SafeParam("username", username))
+			return true, fmt.Sprintf("Authentication successful with bind DN: %s", bindDN), conn, nil
+		}
+
+		errorMessages = append(errorMessages, fmt.Sprintf("%s: %v", bindDN, err))
+		log.Debug("LDAP bind failed",
+			svc1log.SafeParam("bindDN", bindDN),
+			svc1log.SafeParam("error", err))
+	}
+
+	// If we get here, all authentication attempts failed - close the connection
+	if closeErr := conn.Close(); closeErr != nil {
+		log.Warn("Failed to close LDAP connection", svc1log.SafeParam("error", closeErr))
+	}
+
+	return false, fmt.Sprintf("All bind attempts failed: %s", strings.Join(errorMessages, "; ")), nil, nil
 }

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -36,6 +36,37 @@ type StealthContext struct {
 	Logger         svc1log.Logger
 }
 
+// executeSearchWithRetry performs LDAP search with retry logic for handling large domains
+func (l *LibraryPentestLdap) executeSearchWithRetry(conn *ldap.Conn, searchRequest *ldap.SearchRequest, pageSize uint32, stealthCtx *StealthContext) (*ldap.SearchResult, error) {
+	const maxRetries = 3
+	const retryDelaySeconds = 5
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		sr, err := conn.SearchWithPaging(searchRequest, pageSize)
+		if err != nil {
+			stealthCtx.Logger.Warn("LDAP search attempt failed",
+				svc1log.SafeParam("attempt", attempt),
+				svc1log.SafeParam("max_retries", maxRetries),
+				svc1log.SafeParam("error", err.Error()))
+
+			if attempt == maxRetries {
+				return nil, fmt.Errorf("search failed after %d attempts: %v", maxRetries, err)
+			}
+
+			// Wait before retry
+			time.Sleep(time.Duration(retryDelaySeconds) * time.Second)
+			continue
+		}
+
+		stealthCtx.Logger.Debug("LDAP search succeeded",
+			svc1log.SafeParam("attempt", attempt),
+			svc1log.SafeParam("results", len(sr.Entries)))
+		return sr, nil
+	}
+
+	return nil, fmt.Errorf("search failed after %d attempts", maxRetries)
+}
+
 // ShouldContinue checks if more queries are allowed
 func (sc *StealthContext) ShouldContinue() bool {
 	if sc.MaxQueries > 0 && sc.QueryCount >= sc.MaxQueries {
@@ -66,6 +97,22 @@ func (l *LibraryPentestLdap) DomainDump(ctx context.Context, config ldapfern.Pen
 	return l.performLdapActions(ctx, config)
 }
 
+// DomainDumpWithAuth performs domain dump using an authenticated LDAP connection
+// This is called from the engine's executeLDAPActionsWithAuth to avoid re-authentication
+func (l *LibraryPentestLdap) DomainDumpWithAuth(ctx context.Context, conn *ldap.Conn, baseDN string, config ldapfern.PentestLdapConfig) (*ldapfern.DomainDumpResult, []string) {
+	// Create stealth context from config
+	stealthCtx := l.createStealthContext(ctx, config)
+
+	// Process domain dump actions with the authenticated connection
+	domainResult, errors := l.processDomainDumpActions(ctx, conn, baseDN, config)
+
+	// Log final query count
+	stealthCtx.Logger.Info("Domain dump completed",
+		svc1log.SafeParam("total_queries", stealthCtx.QueryCount))
+
+	return domainResult, errors
+}
+
 // PentestLdap performs LDAP penetration testing based on the provided configuration
 func (l *LibraryPentestLdap) PentestLdap(ctx context.Context, config ldapfern.PentestLdapConfig) (*ldapfern.PentestLdapResult, []string) {
 	return l.performLdapActions(ctx, config)
@@ -74,14 +121,25 @@ func (l *LibraryPentestLdap) PentestLdap(ctx context.Context, config ldapfern.Pe
 func (l *LibraryPentestLdap) performLdapActions(ctx context.Context, config ldapfern.PentestLdapConfig) (*ldapfern.PentestLdapResult, []string) {
 	var errors []string
 
-	// Handle AUTH action separately - just test authentication
+	// Check if we only have AUTH action - if so, just test authentication
+	hasAuthOnly := false
+	hasDomainDump := false
+
 	for _, action := range config.Actions {
 		if action == ldapfern.PentestLdapActionAuth {
-			return l.performAuthAction(ctx, config)
+			hasAuthOnly = true
+		}
+		if action == ldapfern.PentestLdapActionDomaindump {
+			hasDomainDump = true
 		}
 	}
 
-	// For DOMAINDUMP action, we need a connection
+	// If only AUTH action is specified, just test authentication
+	if hasAuthOnly && !hasDomainDump {
+		return l.performAuthAction(ctx, config)
+	}
+
+	// For DOMAINDUMP action (with or without AUTH), establish connection and authenticate once
 	conn, err := l.connectToLDAP(ctx, config)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to connect to LDAP: %v", err))
@@ -110,9 +168,15 @@ func (l *LibraryPentestLdap) performLdapActions(ctx context.Context, config ldap
 }
 
 // calculateAdjustedTimeout adjusts the connection timeout when stealth mode is enabled
-// to account for potential sleep delays between queries
+// to account for potential sleep delays between queries and large result processing
 func (l *LibraryPentestLdap) calculateAdjustedTimeout(config ldapfern.PentestLdapConfig) int {
 	baseTimeout := config.Timeout / 1000 // Convert ms to seconds
+
+	// Minimum timeout for large domains (5 minutes)
+	const minLargeTimeout = 300
+	if baseTimeout < minLargeTimeout {
+		baseTimeout = minLargeTimeout
+	}
 
 	// Check if stealth mode is enabled
 	if config.DomaindumpConfig != nil && config.DomaindumpConfig.Stealth != nil {
@@ -138,13 +202,19 @@ func (l *LibraryPentestLdap) calculateAdjustedTimeout(config ldapfern.PentestLda
 			// Add the additional timeout to base, with a reasonable maximum
 			adjustedTimeout := baseTimeout + additionalTimeout
 
-			// Cap at 10 minutes (600 seconds) to prevent extremely long timeouts
-			if adjustedTimeout > 600 {
-				adjustedTimeout = 600
+			// Cap at 15 minutes (900 seconds) to handle very large domains
+			if adjustedTimeout > 900 {
+				adjustedTimeout = 900
 			}
 
 			return adjustedTimeout
 		}
+	}
+
+	// For large domains without stealth mode, still increase timeout
+	// Cap at 10 minutes (600 seconds) for non-stealth operations
+	if baseTimeout > 600 {
+		baseTimeout = 600
 	}
 
 	return baseTimeout
@@ -300,11 +370,6 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 	var errors []string
 	var users []*ldapfern.DomainUser
 
-	sizeLimit := 0
-	if maxResults != nil {
-		sizeLimit = *maxResults
-	}
-
 	// Extract domain information
 	domain := l.extractDomainFromBaseDN(baseDN)
 	domainSID := l.extractDomainSID(conn, baseDN)
@@ -323,12 +388,16 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 		}
 	}
 
+	// Use pagination for large domains (1000 results per page)
+	const pageSize = 1000
+	var totalProcessed int
+
 	searchRequest := ldap.NewSearchRequest(
 		baseDN,
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
-		sizeLimit,
-		0,
+		0, // No size limit - we'll use pagination
+		0, // No time limit
 		false,
 		"(|(&(objectCategory=person)(objectClass=user))(objectClass=msDS-GroupManagedServiceAccount)(objectClass=msDS-ManagedServiceAccount))",
 		attributes,
@@ -338,13 +407,19 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 	// Track query and apply stealth delay
 	stealthCtx.IncrementQuery()
 
-	sr, err := conn.Search(searchRequest)
+	sr, err := l.executeSearchWithRetry(conn, searchRequest, pageSize, stealthCtx)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to search users: %v", err))
 		return nil, errors
 	}
 
 	for _, entry := range sr.Entries {
+		// Check if we've reached max results limit
+		if maxResults != nil && totalProcessed >= *maxResults {
+			break
+		}
+		totalProcessed++
+
 		user := &ldapfern.DomainUser{}
 
 		// Extract and convert binary SID to readable format
@@ -480,11 +555,6 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 	var errors []string
 	var groups []*ldapfern.DomainGroup
 
-	sizeLimit := 0
-	if maxResults != nil {
-		sizeLimit = *maxResults
-	}
-
 	// Extract domain information
 	domain := l.extractDomainFromBaseDN(baseDN)
 	domainSID := l.extractDomainSID(conn, baseDN)
@@ -501,12 +571,16 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 		}
 	}
 
+	// Use pagination for large domains (1000 results per page)
+	const pageSize = 1000
+	var totalProcessed int
+
 	searchRequest := ldap.NewSearchRequest(
 		baseDN,
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
-		sizeLimit,
-		0,
+		0, // No size limit - we'll use pagination
+		0, // No time limit
 		false,
 		"(objectClass=group)",
 		attributes,
@@ -516,13 +590,19 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 	// Track query and apply stealth delay
 	stealthCtx.IncrementQuery()
 
-	sr, err := conn.Search(searchRequest)
+	sr, err := l.executeSearchWithRetry(conn, searchRequest, pageSize, stealthCtx)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to search groups: %v", err))
 		return nil, errors
 	}
 
 	for _, entry := range sr.Entries {
+		// Check if we've reached max results limit
+		if maxResults != nil && totalProcessed >= *maxResults {
+			break
+		}
+		totalProcessed++
+
 		group := &ldapfern.DomainGroup{}
 
 		// Extract and convert binary SID to readable format
@@ -557,33 +637,45 @@ func (l *LibraryPentestLdap) enumerateGroups(ctx context.Context, conn *ldap.Con
 
 		group.Properties = properties
 
-		// Process members to create Members array with ObjectIdentifier/ObjectType format
+		// Process members - skip individual member lookups in stealth mode or limit them
 		var members []*ldapfern.GroupMember
 		memberDNS := entry.GetAttributeValues("member")
-		for _, memberDN := range memberDNS {
-			// Check query limit before each member lookup
-			if !stealthCtx.ShouldContinue() {
-				break
+
+		if stealthCtx.MinimalQueries {
+			// In stealth mode, only store member count to avoid excessive queries
+			group.Members = make([]*ldapfern.GroupMember, 0)
+		} else {
+			// Limit member lookups to prevent excessive queries in large groups
+			const maxMemberLookups = 100
+			memberCount := len(memberDNS)
+			if memberCount > maxMemberLookups {
+				memberDNS = memberDNS[:maxMemberLookups]
+				stealthCtx.Logger.Debug("Limiting member lookups for large group",
+					svc1log.SafeParam("group", entry.GetAttributeValue("sAMAccountName")),
+					svc1log.SafeParam("total_members", memberCount),
+					svc1log.SafeParam("processing", maxMemberLookups))
 			}
 
-			// Get the member's SID by doing a lookup
-			memberSID := l.getMemberSID(ctx, conn, memberDN, stealthCtx)
-			if memberSID != "" {
-				var memberType string
-				if !stealthCtx.MinimalQueries {
-					memberType = l.determineMemberType(ctx, conn, memberDN, stealthCtx)
-				} else {
-					memberType = "Unknown" // Skip expensive type determination in stealth mode
+			for _, memberDN := range memberDNS {
+				// Check query limit before each member lookup
+				if !stealthCtx.ShouldContinue() {
+					break
 				}
 
-				member := &ldapfern.GroupMember{
-					ObjectIdentifier: stringPtr(memberSID),
-					ObjectType:       stringPtr(memberType),
+				// Get the member's SID by doing a lookup
+				memberSID := l.getMemberSID(ctx, conn, memberDN, stealthCtx)
+				if memberSID != "" {
+					memberType := l.determineMemberType(ctx, conn, memberDN, stealthCtx)
+
+					member := &ldapfern.GroupMember{
+						ObjectIdentifier: stringPtr(memberSID),
+						ObjectType:       stringPtr(memberType),
+					}
+					members = append(members, member)
 				}
-				members = append(members, member)
 			}
+			group.Members = members
 		}
-		group.Members = members
 
 		// Check if object is deleted (important for accurate enumeration)
 		isDeleted := false
@@ -652,7 +744,7 @@ func (l *LibraryPentestLdap) isHighValueGroupBySID(objectSID string) bool {
 	return false
 }
 
-// getMemberSID gets the SID of a member by DN
+// getMemberSID gets the SID of a member by DN with retry logic
 func (l *LibraryPentestLdap) getMemberSID(ctx context.Context, conn *ldap.Conn, memberDN string, stealthCtx *StealthContext) string {
 	searchRequest := ldap.NewSearchRequest(
 		memberDN,
@@ -667,14 +759,27 @@ func (l *LibraryPentestLdap) getMemberSID(ctx context.Context, conn *ldap.Conn, 
 	// Track query and apply stealth delay
 	stealthCtx.IncrementQuery()
 
-	sr, err := conn.Search(searchRequest)
-	if err != nil || len(sr.Entries) == 0 {
-		return ""
+	// Use simple retry for member lookup (2 attempts max to avoid excessive queries)
+	const maxRetries = 2
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		sr, err := conn.Search(searchRequest)
+		if err == nil && len(sr.Entries) > 0 {
+			if sidBytes := sr.Entries[0].GetRawAttributeValue("objectSid"); len(sidBytes) > 0 {
+				return l.convertSIDToString(string(sidBytes))
+			}
+		}
+
+		if attempt < maxRetries {
+			stealthCtx.Logger.Debug("Member SID lookup failed, retrying",
+				svc1log.SafeParam("member_dn", memberDN),
+				svc1log.SafeParam("attempt", attempt),
+				svc1log.SafeParam("error", err))
+			time.Sleep(time.Duration(1) * time.Second) // Short retry delay
+		}
 	}
 
-	if sidBytes := sr.Entries[0].GetRawAttributeValue("objectSid"); len(sidBytes) > 0 {
-		return l.convertSIDToString(string(sidBytes))
-	}
+	stealthCtx.Logger.Debug("Failed to get member SID after retries",
+		svc1log.SafeParam("member_dn", memberDN))
 	return ""
 }
 

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -30,6 +30,57 @@ func PerformAuthentication(target string, config *smbfern.PentestSmbConfig) (*sm
 	return PerformAuthenticationWithContext(context.Background(), target, config)
 }
 
+// PerformAuthenticationWithContextAndConnection performs authentication attempts against SMB service with context
+// Returns both auth results and authenticated client (if successful)
+func PerformAuthenticationWithContextAndConnection(ctx context.Context, target string, config *smbfern.PentestSmbConfig) (*smbfern.AuthResult, *smbclient.Client, error) {
+	if target == "" {
+		return nil, nil, fmt.Errorf("no target provided")
+	}
+
+	var errors []string
+
+	host, port := utils.ParseHostPort(target, 445)
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+
+	result := &smbfern.AuthResult{
+		Target: connectionTarget,
+	}
+
+	// Always attempt to extract server info from NTLM challenge, regardless of auth requirements
+	log := svc1log.FromContext(ctx)
+	log.Debug("Extracting SMB server info", svc1log.SafeParam("target", target))
+
+	// Check if auth should be performed based on credentials or explicit actions
+	shouldPerformAuth := false
+	// Check if credentials are available directly on config
+	hasCredentials := len(config.Usernames) > 0 && (len(config.Passwords) > 0 ||
+		(config.NtlmHash != nil && *config.NtlmHash != ""))
+	shouldPerformAuth = hasCredentials
+	for _, action := range config.Actions {
+		if action == smbfern.PentestSmbActionAuth {
+			shouldPerformAuth = true
+			break
+		}
+	}
+
+	var authenticatedClient *smbclient.Client
+
+	// If credentials are provided, perform authentication
+	if shouldPerformAuth {
+		authAttempts, authClient, authErrors := performAuthAttemptsWithConnectionKeeping(ctx, host, port, config)
+		result.AuthAttempts = authAttempts
+		authenticatedClient = authClient
+		errors = append(errors, authErrors...)
+	}
+
+	if len(errors) > 0 {
+		result.Errors = errors
+	}
+
+	return result, authenticatedClient, nil
+}
+
 // PerformAuthenticationWithContext performs authentication attempts against SMB service with context
 // Returns both base server info and auth results
 func PerformAuthenticationWithContext(ctx context.Context, target string, config *smbfern.PentestSmbConfig) (*smbfern.AuthResult, error) {
@@ -198,6 +249,114 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 		svc1log.SafeParam("failed", len(credPairs)-successfulCount))
 
 	return allAttempts, errors
+}
+
+// performAuthAttemptsWithConnectionKeeping performs credential-based authentication attempts with connection keeping
+func performAuthAttemptsWithConnectionKeeping(ctx context.Context, host string, port int, config *smbfern.PentestSmbConfig) (
+	[]*pentestfern.AuthAttempt, *smbclient.Client, []string) {
+
+	var allAttempts []*pentestfern.AuthAttempt
+	var errors []string
+	var authenticatedClient *smbclient.Client
+
+	// Check if credentials are available
+	if len(config.Usernames) == 0 {
+		return nil, nil, []string{"no usernames provided"}
+	}
+
+	log := svc1log.FromContext(ctx)
+
+	// For hash authentication, we only need usernames (not passwords)
+	var credPairs []credentialPair
+	if config.NtlmHash != nil && *config.NtlmHash != "" {
+		// For hash auth, generate pairs with usernames only (empty passwords)
+		for _, username := range config.Usernames {
+			credPairs = append(credPairs, credentialPair{
+				username: username,
+				password: "", // Not used for hash auth
+			})
+		}
+		log.Info("Starting hash authentication attempts",
+			svc1log.SafeParam("credentialPairs", len(credPairs)),
+			svc1log.SafeParam("usernames", config.Usernames),
+			svc1log.SafeParam("hash", "[REDACTED]"))
+	} else {
+		// For password auth, generate all username/password combinations
+		credPairs = generateCredentialPairs(config.Usernames, config.Passwords)
+		log.Info("Starting authentication attempts",
+			svc1log.SafeParam("credentialPairs", len(credPairs)),
+			svc1log.SafeParam("usernames", config.Usernames),
+			svc1log.SafeParam("passwords", len(config.Passwords)))
+	}
+
+	// Get domain from config
+	domain := ""
+	if config.Domain != nil {
+		domain = *config.Domain
+	}
+
+	// If no domain provided, attempt to discover it from server info using NTLM challenge
+	if domain == "" {
+		discoveredDomain := discoverDomainFromServerChallenge(ctx, host, port, config.Timeout)
+		if discoveredDomain != "" {
+			domain = discoveredDomain
+			log.Info("Using discovered domain from NTLM challenge for authentication", svc1log.SafeParam("domain", domain))
+
+			// Update the config to reflect the discovered domain
+			config.Domain = &domain
+		}
+	}
+
+	// Process each credential pair
+	for _, cred := range credPairs {
+		select {
+		case <-ctx.Done():
+			return allAttempts, authenticatedClient, []string{ctx.Err().Error()}
+		default:
+		}
+
+		var attempt *pentestfern.AuthAttempt
+		var client *smbclient.Client
+		var err error
+
+		if config.NtlmHash != nil && *config.NtlmHash != "" {
+			// Use pass-the-hash authentication
+			attempt, client, err = attemptSMBHashAuthenticationWithConnection(ctx, host, port, cred.username, *config.NtlmHash, domain, config.Timeout)
+		} else {
+			// Use password authentication
+			attempt, client, err = attemptSMBAuthenticationWithConnection(ctx, host, port, cred.username, cred.password, domain, config.Timeout)
+		}
+
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
+
+		allAttempts = append(allAttempts, attempt)
+
+		// If authentication is successful and we don't have an authenticated client yet, keep this one
+		if attempt.Success && authenticatedClient == nil && client != nil {
+			authenticatedClient = client
+			log.Info("Authentication successful - keeping connection",
+				svc1log.SafeParam("username", cred.username))
+		} else if client != nil && client != authenticatedClient {
+			// Close additional successful connections we don't need
+			// Don't explicitly close to avoid panic - let GC handle it
+		}
+	}
+
+	// Count successful attempts
+	successfulCount := 0
+	for _, attempt := range allAttempts {
+		if attempt.Success {
+			successfulCount++
+		}
+	}
+
+	log.Info("SMB Authentication completed",
+		svc1log.SafeParam("successful", successfulCount),
+		svc1log.SafeParam("failed", len(allAttempts)-successfulCount))
+
+	return allAttempts, authenticatedClient, errors
 }
 
 // credentialPair represents a username/password combination
@@ -369,6 +528,106 @@ func attemptHashAuthenticationWithContext(ctx context.Context, host string, port
 	}
 
 	return attempt, nil
+}
+
+// attemptSMBAuthenticationWithConnection performs a single SMB authentication attempt with connection keeping
+func attemptSMBAuthenticationWithConnection(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*pentestfern.AuthAttempt, *smbclient.Client, error) {
+	client := smbclient.NewClient(host, port)
+	client.Timeout = time.Duration(timeout) * time.Millisecond
+	// Skip server info extraction since it's done in PROBE stage
+	client.SkipServerInfoExtraction(true)
+	// Use provided domain or empty string for local authentication
+	client.SetCredentials(username, password, domain)
+	timestamp := time.Now()
+	attempt := &pentestfern.AuthAttempt{
+		Username:  username,
+		Password:  &password,
+		Domain:    &domain,
+		Success:   false,
+		Timestamp: timestamp,
+	}
+	err := client.ConnectWithContext(ctx)
+	if err != nil {
+		attempt.Message = err.Error()
+		return attempt, nil, nil // Don't return error here, it's expected for failed auth
+	}
+
+	if client.IsAuthenticated() {
+		attempt.Success = true
+		// Extract actual domain from SMB server info after successful authentication
+		serverInfo := client.GetServerInfo()
+		actualDomain := domain // Use provided domain as fallback
+		if extractedDomain := ntlm.GetSMBDomainName(serverInfo); extractedDomain != "" {
+			actualDomain = extractedDomain
+			log := svc1log.FromContext(ctx)
+			log.Debug("Extracted domain from SMB server info", svc1log.SafeParam("domain", actualDomain))
+		}
+
+		// Update attempt with actual domain
+		attempt.Domain = &actualDomain
+
+		// Check for administrative privileges
+		isAdmin := checkAdminPrivileges(ctx, client)
+		attempt.IsAdmin = &isAdmin
+
+		attempt.Message = "Authentication successful"
+		return attempt, client, nil // Return the authenticated client
+	}
+
+	// Authentication failed - close the client
+	_ = client.Close()
+	attempt.Message = "Authentication failed"
+	return attempt, nil, nil
+}
+
+// attemptSMBHashAuthenticationWithConnection performs a single SMB hash authentication attempt with connection keeping
+func attemptSMBHashAuthenticationWithConnection(ctx context.Context, host string, port int, username, ntlmHash, domain string, timeout int) (*pentestfern.AuthAttempt, *smbclient.Client, error) {
+	client := smbclient.NewClient(host, port)
+	client.Timeout = time.Duration(timeout) * time.Millisecond
+	// Skip server info extraction since it's done in PROBE stage
+	client.SkipServerInfoExtraction(true)
+	// Use provided domain or empty string for local authentication
+	client.SetCredentialsWithHash(username, ntlmHash, domain)
+	timestamp := time.Now()
+	attempt := &pentestfern.AuthAttempt{
+		Username:  username,
+		Password:  nil, // No password for hash auth
+		Domain:    &domain,
+		Success:   false,
+		Timestamp: timestamp,
+	}
+	err := client.ConnectWithContext(ctx)
+	if err != nil {
+		attempt.Message = err.Error()
+		return attempt, nil, nil // Don't return error here, it's expected for failed auth
+	}
+
+	if client.IsAuthenticated() {
+		attempt.Success = true
+		// Extract actual domain from SMB server info after successful authentication
+		serverInfo := client.GetServerInfo()
+		actualDomain := domain // Use provided domain as fallback
+		if extractedDomain := ntlm.GetSMBDomainName(serverInfo); extractedDomain != "" {
+			actualDomain = extractedDomain
+			log := svc1log.FromContext(ctx)
+			log.Debug("Extracted domain from SMB server info", svc1log.SafeParam("domain", actualDomain))
+		}
+
+		// Update attempt with actual domain
+		attempt.Domain = &actualDomain
+
+		// Check for administrative privileges
+		isAdmin := checkAdminPrivileges(ctx, client)
+		attempt.IsAdmin = &isAdmin
+
+		attempt.Message = "Hash authentication successful"
+		return attempt, client, nil // Return the authenticated client
+	}
+
+	// Authentication failed - close the client
+	_ = client.Close()
+	attempt.Message = "Hash authentication failed"
+	return attempt, nil, nil
 }
 
 // checkAdminPrivileges tests administrative privileges by attempting to access the ADMIN$ share


### PR DESCRIPTION
### TL;DR

Improved SMB and LDAP authentication handling to maintain connections between authentication and action stages, reducing redundant authentication attempts and improving reliability.

### What changed?

- Added connection reuse between authentication and action stages for both SMB and LDAP protocols
- Implemented `PerformAuthenticationWithContextAndConnection` for both SMB and LDAP to return authenticated connections
- Created new methods to execute actions with pre-authenticated clients instead of re-authenticating
- Added pagination support for LDAP searches to handle large domains more effectively
- Implemented retry logic for LDAP searches to improve reliability
- Enhanced timeout calculations for large domain operations
- Added proper connection cleanup to prevent resource leaks
- Improved domain name discovery and handling in authentication attempts
- Added NTLM hash authentication support for LDAP connections

### How to test?

1. Run SMB pentests with both authentication and action stages (e.g., shares, samdump, lsadump)
2. Run LDAP pentests with domain dump action against large domains
3. Test with various authentication methods (password, NTLM hash)
4. Verify that connections are maintained between authentication and action stages
5. Test against domains with large numbers of users/groups to verify pagination works

### Why make this change?

The previous implementation re-authenticated for each action stage, which was inefficient and could lead to authentication failures between stages. This change maintains authenticated connections across stages, improving reliability and performance. It also adds better handling for large domains with pagination and retry logic, making the tool more robust when dealing with enterprise environments.