### PR TITLE
Implement minimal queries mode for LDAP computer and DC enumeration

### DIFF
--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -852,38 +852,51 @@ func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.
 	var errors []string
 	var computers []*ldapfern.DomainComputer
 
-	sizeLimit := 0
-	if maxResults != nil {
-		sizeLimit = *maxResults
+	// Use minimal attributes in stealth mode to reduce query size
+	var attributes []string
+	if stealthCtx.MinimalQueries {
+		attributes = []string{
+			"distinguishedName", "sAMAccountName", "objectSid", "dNSHostName",
+		}
+	} else {
+		attributes = []string{
+			"distinguishedName", "sAMAccountName", "dNSHostName", "description",
+			"objectSid", "sAMAccountType", "operatingSystem", "operatingSystemVersion", "userAccountControl",
+			"lastLogon", "lastLogonTimestamp", "pwdLastSet", "servicePrincipalName", "isDeleted", "whenCreated",
+		}
 	}
 
-	// TODO: Implement minimal queries mode for computer enumeration
-	// Current: 10 attributes, Minimal should be: ~4 attributes (distinguishedName, sAMAccountName, objectSid, dNSHostName)
-	attributes := []string{
-		"distinguishedName", "sAMAccountName", "dNSHostName", "description",
-		"objectSid", "sAMAccountType", "operatingSystem", "operatingSystemVersion", "userAccountControl",
-		"lastLogon", "lastLogonTimestamp", "pwdLastSet", "servicePrincipalName", "isDeleted", "whenCreated",
-	}
+	// Use pagination for large domains (1000 results per page)
+	const pageSize = 1000
+	var totalProcessed int
 
 	searchRequest := ldap.NewSearchRequest(
 		baseDN,
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
-		sizeLimit,
-		0,
+		0, // No size limit - we'll use pagination
+		0, // No time limit
 		false,
 		"(&(sAMAccountType=805306369)(!(objectClass=msDS-GroupManagedServiceAccount))(!(objectClass=msDS-ManagedServiceAccount)))",
 		attributes,
 		nil,
 	)
 
-	sr, err := conn.Search(searchRequest)
+	// Track query and apply stealth delay
+	stealthCtx.IncrementQuery()
+
+	sr, err := l.executeSearchWithRetry(conn, searchRequest, pageSize, stealthCtx)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to search computers: %v", err))
 		return nil, errors
 	}
 
 	for _, entry := range sr.Entries {
+		// Check if we've reached max results limit
+		if maxResults != nil && totalProcessed >= *maxResults {
+			break
+		}
+		totalProcessed++
 		computer := &ldapfern.DomainComputer{
 			DistinguishedName: stringPtr(entry.DN),
 			SamAccountName:    stringPtr(l.getAttributeValue(entry, "sAMAccountName")),
@@ -939,37 +952,50 @@ func (l *LibraryPentestLdap) enumerateDomainControllers(ctx context.Context, con
 	var errors []string
 	var dcs []*ldapfern.DomainController
 
-	sizeLimit := 0
-	if maxResults != nil {
-		sizeLimit = *maxResults
+	// Use minimal attributes in stealth mode to reduce query size
+	var attributes []string
+	if stealthCtx.MinimalQueries {
+		attributes = []string{
+			"distinguishedName", "sAMAccountName", "dNSHostName",
+		}
+	} else {
+		attributes = []string{
+			"distinguishedName", "sAMAccountName", "dNSHostName", "siteName",
+			"operatingSystem", "operatingSystemVersion", "userAccountControl", "serverReferenceBL",
+		}
 	}
 
-	// TODO: Implement minimal queries mode for domain controller enumeration
-	// Current: 8 attributes, Minimal should be: ~3 attributes (distinguishedName, sAMAccountName, dNSHostName)
-	attributes := []string{
-		"distinguishedName", "sAMAccountName", "dNSHostName", "siteName",
-		"operatingSystem", "operatingSystemVersion", "userAccountControl", "serverReferenceBL",
-	}
+	// Use pagination for consistency (though DCs are typically few)
+	const pageSize = 1000
+	var totalProcessed int
 
 	searchRequest := ldap.NewSearchRequest(
 		baseDN,
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
-		sizeLimit,
-		0,
+		0, // No size limit - we'll use pagination
+		0, // No time limit
 		false,
 		"(&(sAMAccountType=805306369)(userAccountControl:1.2.840.113556.1.4.803:=8192))",
 		attributes,
 		nil,
 	)
 
-	sr, err := conn.Search(searchRequest)
+	// Track query and apply stealth delay
+	stealthCtx.IncrementQuery()
+
+	sr, err := l.executeSearchWithRetry(conn, searchRequest, pageSize, stealthCtx)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to search domain controllers: %v", err))
 		return nil, errors
 	}
 
 	for _, entry := range sr.Entries {
+		// Check if we've reached max results limit
+		if maxResults != nil && totalProcessed >= *maxResults {
+			break
+		}
+		totalProcessed++
 		dc := &ldapfern.DomainController{
 			DistinguishedName: stringPtr(entry.DN),
 			SamAccountName:    stringPtr(l.getAttributeValue(entry, "sAMAccountName")),


### PR DESCRIPTION
### TL;DR

Implemented stealth mode for computer and domain controller enumeration by reducing attribute queries and adding pagination support.

### What changed?

- Added support for minimal attribute queries in stealth mode for computer enumeration, reducing from 10 attributes to 4 essential ones
- Added similar minimal attribute support for domain controller enumeration, reducing from 8 attributes to 3
- Implemented pagination (1000 results per page) for both computer and domain controller searches
- Added proper handling of max results limits with pagination
- Integrated stealth context tracking and query delays
- Replaced direct LDAP searches with the executeSearchWithRetry method

### How to test?

1. Run domain enumeration with stealth mode enabled and verify fewer attributes are queried
2. Test against a large domain to confirm pagination works correctly
3. Verify max results limits are properly enforced
4. Check that stealth delays are applied between queries

### Why make this change?

This change reduces the network footprint and query size when operating in stealth mode, making the tool less likely to trigger security alerts. The pagination support also improves reliability when working with large domains by preventing potential timeout issues or incomplete results.