### PR TITLE
Update build workflow and add Docker AMD64 image support

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -254,12 +254,6 @@ jobs:
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash
 
-      - name: Copy AMD64 binary to Docker context
-        run: cp output/build-linux_amd64/networkscan ./networkscan
-
-      - name: Build Docker Image (AMD64)
-        run: docker buildx build . --platform linux/amd64 --tag methodsecurity/networkscan:latest-amd64
-
       - name: View Output
         run: ls -al output output/*
 
@@ -273,4 +267,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          COSIGN_EXPERIMENTAL: "true" 
+          COSIGN_EXPERIMENTAL: "true"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -20,6 +20,8 @@ jobs:
     name: Prepare Linux (arm64)
     runs-on: ubuntu-22.04-arm
     steps:
+      - name: Install Dependencies
+        run: sudo apt update && sudo apt install -y libpcap-dev
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev
+        run: sudo apt update && sudo apt install -y libpcap-dev
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
@@ -248,10 +248,10 @@ jobs:
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64_v8.0/* output/build-linux_arm64/
-          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v7/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v7/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
-          mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
+          mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v7/* output/build-darwin_arm64/
         shell: bash
 
       - name: View Output

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev
+        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev libsystemd-dev
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev libsystemd-dev
+        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev pkg-config
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libpcap-dev
+        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libpcap-dev libdbus-1-dev pkg-config
+        run: sudo apt update && sudo apt install -y libpcap-dev pkg-config
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
@@ -247,7 +247,6 @@ jobs:
           mkdir -p output/build-linux_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
-          mkdir -p output/build-linux_amd64/
           mkdir -p output/build-windows_amd64/
           mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v8.0/* output/build-linux_arm64/
           mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -20,8 +20,6 @@ jobs:
     name: Prepare Linux (arm64)
     runs-on: ubuntu-22.04-arm
     steps:
-      - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libpcap-dev
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
@@ -247,12 +245,19 @@ jobs:
           mkdir -p output/build-linux_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
+          mkdir -p output/build-linux_amd64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v7/* output/build-linux_arm64/
-          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v7/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v8.0/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
-          mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v7/* output/build-darwin_arm64/
+          mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash
+
+      - name: Copy AMD64 binary to Docker context
+        run: cp output/build-linux_amd64/networkscan ./networkscan
+
+      - name: Build Docker Image (AMD64)
+        run: docker buildx build . --platform linux/amd64 --tag methodsecurity/networkscan:latest-amd64
 
       - name: View Output
         run: ls -al output output/*

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -14,7 +14,7 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread'"
+      - "-extldflags '-static -lm -ldl -lpthread -ldbus-1'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -14,7 +14,7 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread -ldbus-1 -ludev'"
+      - "-extldflags '-static -lm -ldl -lpthread'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -14,7 +14,6 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -14,7 +14,7 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread -ldbus-1'"
+      - "-extldflags '-static -lm -ldl -lpthread -ldbus-1 -lsystemd'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -29,6 +29,7 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
+      - "-extldflags '-static -lm -ldl -lpthread'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1
@@ -43,6 +44,7 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
+      - "-extldflags '-static -lm -ldl -lpthread'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1
@@ -57,6 +59,7 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
+      - "-extldflags '-static -lm -ldl -lpthread'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -14,7 +14,7 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread -ldbus-1 -lsystemd'"
+      - "-extldflags '-static -lm -ldl -lpthread -ldbus-1 -ludev'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -9,22 +9,7 @@ partial:
   by: target
 
 builds:
-  - id: build-linux-amd64
-    main: .
-    binary: networkscan
-    ldflags:
-      - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread'"
-      - -X github.com/method-security/networkscan/main.version={{.Version}}
-    env:
-      - CGO_ENABLED=1
-    goos:
-      - linux
-    goarch:
-      - amd64
-    goarm:
-      - "7"
-  - id: build-linux-arm64
+  - id: build-linux
     main: .
     binary: networkscan
     ldflags:
@@ -37,6 +22,7 @@ builds:
       - linux
     goarch:
       - arm64
+      - amd64
     goarm:
       - "7"
   - id: build-macos
@@ -44,7 +30,6 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1
@@ -59,7 +44,6 @@ builds:
     binary: networkscan
     ldflags:
       - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread'"
       - -X github.com/method-security/networkscan/main.version={{.Version}}
     env:
       - CGO_ENABLED=1

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,7 @@ ARG CLI_NAME="networkscan"
 ARG TARGETARCH
 
 RUN \
-  apk add --no-cache git gcc musl-dev bash build-base libpcap-dev wget && \
+  apk add --no-cache git gcc musl-dev bash build-base libpcap-dev dbus-dev wget && \
   mkdir -p /app/${CLI_NAME} && \
   git config --global --add safe.directory /app/${CLI_NAME}
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,7 @@ ARG CLI_NAME="networkscan"
 ARG TARGETARCH
 
 RUN \
-  apk add --no-cache git gcc musl-dev bash build-base libpcap-dev dbus-dev eudev-dev wget && \
+  apk add --no-cache git gcc musl-dev bash libpcap-dev wget && \
   mkdir -p /app/${CLI_NAME} && \
   git config --global --add safe.directory /app/${CLI_NAME}
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,7 @@ ARG CLI_NAME="networkscan"
 ARG TARGETARCH
 
 RUN \
-  apk add --no-cache git gcc musl-dev bash && \
+  apk add --no-cache git gcc musl-dev bash build-base libpcap-dev wget && \
   mkdir -p /app/${CLI_NAME} && \
   git config --global --add safe.directory /app/${CLI_NAME}
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,7 @@ ARG CLI_NAME="networkscan"
 ARG TARGETARCH
 
 RUN \
-  apk add --no-cache git gcc musl-dev bash build-base libpcap-dev dbus-dev wget && \
+  apk add --no-cache git gcc musl-dev bash build-base libpcap-dev dbus-dev eudev-dev wget && \
   mkdir -p /app/${CLI_NAME} && \
   git config --global --add safe.directory /app/${CLI_NAME}
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,17 +1,17 @@
 # Dockerfile used for the compilation of the statically compiled networkscan binary
-FROM golang:1.24.2-alpine3.20 as base
+FROM golang:1.24.2-alpine3.20 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="networkscan"
 ARG TARGETARCH
 
 RUN \
-  apk add --no-cache git gcc build-base libpcap-dev bash wget && \
+  apk add --no-cache git gcc musl-dev bash && \
   mkdir -p /app/${CLI_NAME} && \
   git config --global --add safe.directory /app/${CLI_NAME}
 
 WORKDIR /app/${CLI_NAME}
 
-FROM base as amd64
+FROM base AS amd64
 ARG CLI_NAME
 ARG GORELEASER_VERSION
 RUN \
@@ -20,7 +20,7 @@ RUN \
   mv goreleaser /usr/local/bin/goreleaser && \
   rm -rf goreleaser-pro_Linux_x86_64.tar.gz LICENSE.md README.md completions manpages
 
-FROM base as arm64
+FROM base AS arm64
 ARG CLI_NAME
 RUN \
   wget https://github.com/goreleaser/goreleaser-pro/releases/download/${GORELEASER_VERSION}-pro/goreleaser-pro_Linux_arm64.tar.gz && \


### PR DESCRIPTION
# Docker Build Integration and Build Configuration Updates

## Changes

- **Consolidated Linux Builds**: Merged separate Linux AMD64 and ARM64 build configurations into a single `build-linux` configuration in goreleaser-build.yml
- **Docker Integration**: Added steps to build a Docker image for AMD64 platform in the CI workflow
- **Path Updates**: Fixed output paths in the reusable-build.yml workflow to match the new consolidated build configuration
- **Dependency Changes**: 
  - Replaced `libdbus-1-dev` with `pkg-config` in the Ubuntu dependencies
  - Refined Alpine dependencies in the builder Dockerfile

## Testing

1. Run the GitHub workflow to verify the build process completes successfully
2. Confirm the Docker image builds correctly with the AMD64 binary
3. Verify all artifacts are correctly placed in their expected output directories

These changes streamline the build process and add Docker image generation as part of the CI pipeline.