### PR TITLE
Preserve original hostnames in port scan results

### DIFF
--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -76,8 +76,8 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 	// Hide OS args from Naabu
 	hideOsArgsFromNaabu()
 
-	// Expand target hosts (handles CIDR ranges, IP ranges, and single hosts)
-	targetHosts, err := utils.ParseTargetHosts(config.Target)
+	// Parse target hosts and create IP-to-hostname mapping
+	targetHosts, ipToHostname, err := utils.ParseTargetHostsWithMapping(config.Target)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse target hosts: %w", err)
 	}
@@ -93,13 +93,13 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 		Retries:           runner.DefaultRetriesConnectScan,
 		Threads:           config.Threads,
 		Timeout:           runner.DefaultPortTimeoutConnectScan,
-		Host:              goflags.StringSlice(targetHosts), // Use expanded hosts
+		Host:              goflags.StringSlice(targetHosts), // Use resolved IPs
 		SkipHostDiscovery: true,
 		WarmUpTime:        2,
 		InputReadTimeout:  180000000000, // This is their default
 		OnResult: func(hr *result.HostResult) {
 			output = *hr
-			hosts = append(hosts, parsePortScanResult(&output))
+			hosts = append(hosts, parsePortScanResult(&output, ipToHostname))
 		},
 	}
 
@@ -136,7 +136,8 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 
 // parsePortScanResult converts a Naabu port scan result into our internal SocketDetails format.
 // It extracts host information and open ports from the scan result.
-func parsePortScanResult(result *result.HostResult) *discoverfern.SocketDetails {
+// If the IP was resolved from a hostname, it uses the original hostname as the host field.
+func parsePortScanResult(result *result.HostResult, ipToHostname map[string]string) *discoverfern.SocketDetails {
 	ports := []*discoverfern.PortDetails{}
 	for _, p := range result.Ports {
 		ports = append(ports, &discoverfern.PortDetails{
@@ -144,8 +145,15 @@ func parsePortScanResult(result *result.HostResult) *discoverfern.SocketDetails 
 			Protocol: common.TransportType(p.Protocol.String()),
 		})
 	}
+
+	// Use original hostname if available, otherwise use the IP as host
+	hostField := result.IP
+	if originalHostname, exists := ipToHostname[result.IP]; exists {
+		hostField = originalHostname
+	}
+
 	host := discoverfern.SocketDetails{
-		Host:  result.Host,
+		Host:  hostField,
 		Ip:    result.IP,
 		Ports: ports,
 	}

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -101,58 +101,117 @@ func GenerateRandomString(length int) string {
 	return string(b)
 }
 
-// ParseTargetHosts expands CIDR ranges and hostnames into individual IP addresses
-func ParseTargetHosts(target string) ([]string, error) {
-	var hosts []string
-
-	if strings.Contains(target, "/") {
-		// Must be a valid CIDR - no smart parsing
-		ip, ipnet, err := net.ParseCIDR(target)
-		if err != nil {
-			return nil, fmt.Errorf("invalid CIDR: %s", target)
-		}
-
-		// Verify the IP is actually the network address
-		if !ip.Equal(ipnet.IP) {
-			return nil, fmt.Errorf("invalid CIDR: %s is not a network address", target)
-		}
-
-		// Generate all IPs in the CIDR range
-		for ip := ipnet.IP.Mask(ipnet.Mask); ipnet.Contains(ip); IncIP(ip) {
-			hosts = append(hosts, ip.String())
-		}
-
-		// Remove network and broadcast addresses for /24 and smaller
-		ones, _ := ipnet.Mask.Size()
-		if ones >= 24 && len(hosts) > 2 {
-			hosts = hosts[1 : len(hosts)-1]
-		}
-	} else if strings.Contains(target, "-") {
-		// IP range like 192.168.1.1-192.168.1.10
-		parts := strings.Split(target, "-")
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid IP range: %s", target)
-		}
-
-		startIP := net.ParseIP(strings.TrimSpace(parts[0]))
-		endIP := net.ParseIP(strings.TrimSpace(parts[1]))
-		if startIP == nil || endIP == nil {
-			return nil, fmt.Errorf("invalid IP range: %s", target)
-		}
-
-		// Generate IPs in range
-		for ip := make(net.IP, len(startIP)); copy(ip, startIP) > 0; IncIP(ip) {
-			hosts = append(hosts, ip.String())
-			if ip.Equal(endIP) {
-				break
-			}
-		}
-	} else {
-		// Single host or hostname
-		hosts = append(hosts, target)
+// parseTargetInternal is the core logic for parsing different target formats
+func parseTargetInternal(target string, trackMapping bool) ([]string, map[string]string, error) {
+	var ipToHostname map[string]string
+	if trackMapping {
+		ipToHostname = make(map[string]string)
 	}
 
-	return hosts, nil
+	if strings.Contains(target, "/") {
+		// CIDR range (e.g., 192.168.1.0/24)
+		return expandCIDR(target)
+	} else if isIPRange(target) {
+		// IP range (e.g., 192.168.1.1-192.168.1.10)
+		return expandIPRange(target)
+	} else {
+		// Single IP or hostname
+		return parseSingleTarget(target, trackMapping, ipToHostname)
+	}
+}
+
+// expandCIDR handles CIDR notation like 192.168.1.0/24
+func expandCIDR(target string) ([]string, map[string]string, error) {
+	ip, ipnet, err := net.ParseCIDR(target)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid CIDR: %s", target)
+	}
+
+	// Verify the IP is actually the network address
+	if !ip.Equal(ipnet.IP) {
+		return nil, nil, fmt.Errorf("invalid CIDR: %s is not a network address", target)
+	}
+
+	var hosts []string
+	// Generate all IPs in the CIDR range
+	for ip := ipnet.IP.Mask(ipnet.Mask); ipnet.Contains(ip); IncIP(ip) {
+		hosts = append(hosts, ip.String())
+	}
+
+	// Remove network and broadcast addresses for /24 and smaller
+	ones, _ := ipnet.Mask.Size()
+	if ones >= 24 && len(hosts) > 2 {
+		hosts = hosts[1 : len(hosts)-1]
+	}
+
+	return hosts, nil, nil
+}
+
+// isIPRange checks if target is an IP range like 192.168.1.1-192.168.1.10
+func isIPRange(target string) bool {
+	if !strings.Contains(target, "-") {
+		return false
+	}
+	parts := strings.Split(target, "-")
+	if len(parts) != 2 {
+		return false
+	}
+	startIP := net.ParseIP(strings.TrimSpace(parts[0]))
+	endIP := net.ParseIP(strings.TrimSpace(parts[1]))
+	return startIP != nil && endIP != nil
+}
+
+// expandIPRange handles IP ranges like 192.168.1.1-192.168.1.10
+func expandIPRange(target string) ([]string, map[string]string, error) {
+	parts := strings.Split(target, "-")
+	startIP := net.ParseIP(strings.TrimSpace(parts[0]))
+	endIP := net.ParseIP(strings.TrimSpace(parts[1]))
+
+	var hosts []string
+	for ip := make(net.IP, len(startIP)); copy(ip, startIP) > 0; IncIP(ip) {
+		hosts = append(hosts, ip.String())
+		if ip.Equal(endIP) {
+			break
+		}
+	}
+	return hosts, nil, nil
+}
+
+// parseSingleTarget handles single IPs or hostnames
+func parseSingleTarget(target string, trackMapping bool, ipToHostname map[string]string) ([]string, map[string]string, error) {
+	if ip := net.ParseIP(target); ip != nil {
+		// Already an IP address
+		return []string{target}, ipToHostname, nil
+	}
+
+	// It's a hostname/FQDN, resolve to IP addresses
+	ips, err := GetIPs(target)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve hostname %s: %v", target, err)
+	}
+
+	var hosts []string
+	for _, ip := range ips {
+		ipStr := ip.String()
+		hosts = append(hosts, ipStr)
+		if trackMapping {
+			ipToHostname[ipStr] = target
+		}
+	}
+
+	return hosts, ipToHostname, nil
+}
+
+// ParseTargetHosts expands CIDR ranges and hostnames into individual IP addresses
+func ParseTargetHosts(target string) ([]string, error) {
+	hosts, _, err := parseTargetInternal(target, false)
+	return hosts, err
+}
+
+// ParseTargetHostsWithMapping expands CIDR ranges and hostnames into individual IP addresses
+// and returns a mapping from IP addresses back to their original hostnames (if resolved from FQDNs)
+func ParseTargetHostsWithMapping(target string) ([]string, map[string]string, error) {
+	return parseTargetInternal(target, true)
 }
 
 // IncIP increments an IP address


### PR DESCRIPTION
### TL;DR

Improved hostname handling in port scanning to preserve original hostnames in scan results.

### What changed?

- Added a new `ParseTargetHostsWithMapping` function that tracks the mapping between resolved IP addresses and their original hostnames
- Modified the port scanning logic to use this mapping to display the original hostname in scan results instead of just the IP address
- Refactored target parsing logic into smaller, more focused functions for better maintainability:
  - `parseTargetInternal`: Core logic for parsing different target formats
  - `expandCIDR`: Handles CIDR notation (e.g., 192.168.1.0/24)
  - `isIPRange`: Checks if a target is an IP range
  - `expandIPRange`: Handles IP ranges (e.g., 192.168.1.1-192.168.1.10)
  - `parseSingleTarget`: Handles single IPs or hostnames

### How to test?

1. Run a port scan against a hostname (e.g., `example.com`) instead of an IP address
2. Verify that the scan results show the original hostname in the `Host` field rather than just the resolved IP address
3. Test with different target formats (single hostname, IP address, CIDR range, IP range) to ensure all work correctly

### Why make this change?

When scanning hostnames, the original hostname was being lost in the results, which only showed the resolved IP address. This made it difficult to correlate scan results back to the original target, especially when scanning multiple hostnames that might resolve to the same IP. This change preserves the context of the original scan target, making results more useful and easier to interpret.