### PR TITLE
Add support for multiple NTLM hashes in password spray

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -75,7 +75,7 @@ func (a *NetworkScan) createPasswordSprayCommand(parent *cobra.Command) {
 	passwordCmd.Flags().StringSlice("username-lists", []string{}, "Built-in username lists (SYSTEM_USERNAMES, DOMAIN_USERNAMES, SERVICE_USERNAMES)")
 	passwordCmd.Flags().StringSlice("password-lists", []string{}, "Built-in password lists (SYSTEM_PASSWORDS, DOMAIN_PASSWORDS, SERVICE_PASSWORDS)")
 	passwordCmd.Flags().StringP("domain", "d", "", "Domain for SMB/LDAP/KERBEROS authentication")
-	passwordCmd.Flags().String("ntlm-hash", "", "NT hash for pass-the-hash authentication (32 hex chars, LM hash auto-added)")
+	passwordCmd.Flags().StringSlice("ntlm-hashes", nil, "NTLM hashes for pass-the-hash authentication (32 hex chars each)")
 	passwordCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
 	passwordCmd.Flags().Int("sleep", 0, "Delay between password attempts in seconds")
 	passwordCmd.Flags().Int("jitter", 0, "Random jitter percentage (0-100) to apply to sleep delays")
@@ -808,9 +808,14 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 		return nil, fmt.Errorf("failed to get domain: %v", err)
 	}
 
-	ntlmHash, err := cmd.Flags().GetString("ntlm-hash")
+	ntlmHashes, err := cmd.Flags().GetStringSlice("ntlm-hashes")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ntlm-hash: %v", err)
+		return nil, fmt.Errorf("failed to get ntlm-hashes: %v", err)
+	}
+
+	// Validate NTLM hashes are not used with Kerberos
+	if len(ntlmHashes) > 0 && service == pentestfern.SprayTargetServiceKerberos {
+		return nil, fmt.Errorf("NTLM hashes cannot be used with Kerberos authentication")
 	}
 
 	// Behavior flags
@@ -860,7 +865,7 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 	}
 
 	// Set Config
-	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, ntlmHash, timeout, sleep, jitter, maxAttempts, stopFirstSuccess, successfulOnly)
+	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, ntlmHashes, timeout, sleep, jitter, maxAttempts, stopFirstSuccess, successfulOnly)
 
 	return config, nil
 }
@@ -959,7 +964,7 @@ func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []st
 }
 
 // getSprayPasswordConfig creates a configuration for password spray operations with the provided parameters.
-func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentestfern.WordlistType, passwordLists []pentestfern.WordlistType, domain string, ntlmHash string, timeout int, sleep int, jitter int, maxAttempts int, stopFirstSuccess bool, successfulOnly bool) *pentestfern.PentestSprayConfig {
+func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentestfern.WordlistType, passwordLists []pentestfern.WordlistType, domain string, ntlmHashes []string, timeout int, sleep int, jitter int, maxAttempts int, stopFirstSuccess bool, successfulOnly bool) *pentestfern.PentestSprayConfig {
 	// Create config
 	var usernameFilePtr, passwordFilePtr, domainPtr *string
 	if usernameFile != "" {
@@ -971,8 +976,8 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 	if domain != "" {
 		domainPtr = &domain
 	}
-	// TODO: Add NTLM hash support to spray functionality
-	_ = ntlmHash // Temporarily suppress unused warning
+
+	// NTLM hashes are already passed as a slice, no conversion needed
 
 	// Create stealth config if any stealth parameters are set
 	var stealthConfig *pentestfern.SprayStealthConfig
@@ -1001,6 +1006,7 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 			Service:            service,
 			Usernames:          usernames,
 			Passwords:          passwords,
+			NtlmHashes:         ntlmHashes,
 			UsernameFile:       usernameFilePtr,
 			PasswordFile:       passwordFilePtr,
 			UsernameLists:      usernameLists,

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -46,7 +46,8 @@ types:
   Credential:
     properties:
       username: string
-      password: string
+      password: optional<string> # Optional when using NTLM hash authentication
+      ntlmHash: optional<string> # NTLM hash for pass-the-hash authentication (SMB/LDAP only)
       domain: optional<string>
       target: optional<string> # host:port where authentication succeeded
       service: optional<SprayTargetService> # service where authentication succeeded
@@ -103,6 +104,7 @@ types:
       # Credential configuration
       usernames: optional<list<string>>
       passwords: optional<list<string>>
+      ntlmHashes: optional<list<string>> # NTLM hashes for pass-the-hash (SMB/LDAP only)
       usernameFile: optional<string>
       passwordFile: optional<string>
       usernameLists: optional<list<WordlistType>>

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -28,6 +28,44 @@ func ensureTimeoutDefaults(timeout int) int {
 	return timeout
 }
 
+// applyStealth applies stealth delay between attempts if configured
+func applyStealth(ctx context.Context, stealth *pentestfern.SprayStealthConfig, attemptType string) {
+	if stealth == nil || stealth.Sleep == nil {
+		return
+	}
+
+	log := svc1log.FromContext(ctx)
+	jitterPercent := 0
+	if stealth.Jitter != nil {
+		jitterPercent = *stealth.Jitter
+	}
+
+	delay := utils.CalculateDelayWithJitter(*stealth.Sleep, jitterPercent)
+	if delay > 0 {
+		log.Info(fmt.Sprintf("Sleeping between %s attempts", attemptType),
+			svc1log.SafeParam("base_sleep_seconds", *stealth.Sleep),
+			svc1log.SafeParam("actual_delay_ms", delay.Milliseconds()),
+			svc1log.SafeParam("jitter_percent", jitterPercent))
+		time.Sleep(delay)
+	}
+}
+
+// validatePasswordRequired checks if a service requires a password (no NTLM hash support)
+func validatePasswordRequired(cred *pentestfern.Credential, serviceName string) (bool, string) {
+	if cred.Password == nil {
+		return false, fmt.Sprintf("%s authentication requires a password", serviceName)
+	}
+	return true, ""
+}
+
+// getPasswordForAuth returns password string for authentication (handles optional password)
+func getPasswordForAuth(cred *pentestfern.Credential) string {
+	if cred.Password != nil {
+		return *cred.Password
+	}
+	return "" // Empty password for hash auth
+}
+
 // RunSprayPassword executes password spraying attacks against specified targets
 func (e *Engine) RunSprayPassword(ctx context.Context, config *pentestfern.PentestSprayConfig) (*pentestfern.PentestSprayReport, error) {
 	log := svc1log.FromContext(ctx)
@@ -155,21 +193,8 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 			}
 
 			// Apply delay with jitter between username attempts (except after last username)
-			if config.Stealth != nil && config.Stealth.Sleep != nil && *config.Stealth.Sleep > 0 && i < len(usernames)-1 {
-				var jitterPercent int
-				if config.Stealth.Jitter != nil {
-					jitterPercent = *config.Stealth.Jitter
-				}
-
-				delay := utils.CalculateDelayWithJitter(*config.Stealth.Sleep, jitterPercent)
-
-				if delay > 0 {
-					log.Info("Sleeping between username attempts",
-						svc1log.SafeParam("base_sleep_seconds", *config.Stealth.Sleep),
-						svc1log.SafeParam("actual_delay_ms", delay.Milliseconds()),
-						svc1log.SafeParam("jitter_percent", jitterPercent))
-					time.Sleep(delay)
-				}
+			if i < len(usernames)-1 {
+				applyStealth(ctx, config.Stealth, "username")
 			}
 
 			attemptNumber++
@@ -285,8 +310,8 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 	// Parse target host and port
 	host, port := utils.ParseHostPort(target, utils.GetDefaultPortForService(config.Service))
 
-	// Load usernames and passwords from config and wordlists
-	usernames, passwords, err := loadCredentialsFromConfig(config)
+	// Load usernames, passwords, and NTLM hashes from config and wordlists
+	usernames, passwords, ntlmHashes, err := loadCredentialsFromConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load credentials: %v", err)
 	}
@@ -319,17 +344,20 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 	log.Info("Starting password spray",
 		svc1log.SafeParam("usernames", len(usernames)),
 		svc1log.SafeParam("passwords", len(passwords)),
+		svc1log.SafeParam("ntlm_hashes", len(ntlmHashes)),
 		svc1log.SafeParam("timeout_ms", timeoutMs))
 
 	// Perform password spraying: iterate passwords first, then users
 	attemptNumber := 1
+
+	// Try passwords first
 	for _, password := range passwords {
 		log.Info("Testing password against all users", svc1log.SafeParam("password_length", len(password)))
 
 		for _, username := range usernames {
 			cred := &pentestfern.Credential{
 				Username: username,
-				Password: password,
+				Password: &password,
 				Domain:   config.Domain,
 			}
 
@@ -368,27 +396,67 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 		}
 
 		// Apply delay with jitter between password attempts (after testing password against all users)
-		if config.Stealth != nil && config.Stealth.Sleep != nil && *config.Stealth.Sleep > 0 && password != passwords[len(passwords)-1] { // Don't sleep after last password
-			var jitterPercent int
-			if config.Stealth.Jitter != nil {
-				jitterPercent = *config.Stealth.Jitter
+		if password != passwords[len(passwords)-1] { // Don't sleep after last password
+			applyStealth(ctx, config.Stealth, "password")
+		}
+	}
+
+	// Try NTLM hashes next
+	for _, ntlmHash := range ntlmHashes {
+		log.Info("Testing NTLM hash against all users", svc1log.SafeParam("hash", "[REDACTED]"))
+
+		for _, username := range usernames {
+			cred := &pentestfern.Credential{
+				Username: username,
+				Password: nil, // No password for hash auth
+				NtlmHash: &ntlmHash,
+				Domain:   config.Domain,
 			}
 
-			delay := utils.CalculateDelayWithJitter(*config.Stealth.Sleep, jitterPercent)
-
-			if delay > 0 {
-				log.Info("Sleeping between password attempts",
-					svc1log.SafeParam("base_sleep_seconds", *config.Stealth.Sleep),
-					svc1log.SafeParam("actual_delay_ms", delay.Milliseconds()),
-					svc1log.SafeParam("jitter_percent", jitterPercent))
-				time.Sleep(delay)
+			// Single attempt - retries have been removed
+			attempt, err := e.performSprayAttempt(ctx, target, config.Service, cred, attemptNumber, config)
+			if err != nil {
+				errors = append(errors, err.Error())
 			}
+
+			// Only include attempt in output if not filtering to successful only, or if attempt was successful
+			if !config.SuccessfulOnly || attempt.Response.Success {
+				attempts = append(attempts, attempt)
+			}
+
+			if attempt.Response.Success {
+				targetWithPort := fmt.Sprintf("%s:%d", host, port)
+				credWithTarget := &pentestfern.Credential{
+					Username: cred.Username,
+					Password: cred.Password,
+					NtlmHash: cred.NtlmHash,
+					Domain:   cred.Domain,
+					Target:   &targetWithPort,
+					Service:  &config.Service,
+				}
+				successfulCredentials = append(successfulCredentials, credWithTarget)
+				log.Info("Successful NTLM hash authentication",
+					svc1log.SafeParam("target", target),
+					svc1log.SafeParam("username", cred.Username),
+					svc1log.SafeParam("hash", "[REDACTED]"))
+
+				if config.StopOnFirstSuccess {
+					goto done
+				}
+			}
+
+			attemptNumber++
+		}
+
+		// Apply delay with jitter between hash attempts (after testing hash against all users)
+		if ntlmHash != ntlmHashes[len(ntlmHashes)-1] { // Don't sleep after last hash
+			applyStealth(ctx, config.Stealth, "NTLM hash")
 		}
 	}
 
 done:
 	endTime := time.Now()
-	statistics := generateStatistics(attempts, len(usernames), len(passwords), startTime, endTime)
+	statistics := generateStatistics(attempts, len(usernames), len(passwords)+len(ntlmHashes), startTime, endTime)
 
 	return &pentestfern.SprayTargetResult{
 		Target:                fmt.Sprintf("%s:%d", host, port),
@@ -463,8 +531,13 @@ func (e *Engine) performKerberosSpray(ctx context.Context, target string, cred *
 		kerberosTarget.Domain = strings.ToUpper(*config.Domain)
 	}
 
+	// Validate password required
+	if valid, msg := validatePasswordRequired(cred, "Kerberos"); !valid {
+		return false, msg
+	}
+
 	// Attempt authentication
-	success, message, err := kerberospentest.AuthenticateUser(ctx, kerberosTarget, cred.Username, cred.Password, config.Timeout)
+	success, message, err := kerberospentest.AuthenticateUser(ctx, kerberosTarget, cred.Username, getPasswordForAuth(cred), config.Timeout)
 	if err != nil {
 		return false, fmt.Sprintf("Kerberos error: %v", err)
 	}
@@ -474,10 +547,15 @@ func (e *Engine) performKerberosSpray(ctx context.Context, target string, cred *
 
 // performSSHSpray uses existing SSH auth functionality
 func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {
+	// Validate password required
+	if valid, msg := validatePasswordRequired(cred, "SSH"); !valid {
+		return false, msg
+	}
+
 	sshConfig := &sshfern.PentestSshConfig{
 		Targets:   []string{target},
 		Usernames: []string{cred.Username},
-		Passwords: []string{cred.Password},
+		Passwords: []string{getPasswordForAuth(cred)},
 		Timeout:   config.Timeout,
 	}
 
@@ -503,8 +581,13 @@ func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pente
 
 // performFTPSpray uses FTP auth functionality
 func (e *Engine) performFTPSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {
+	// Validate password required
+	if valid, msg := validatePasswordRequired(cred, "FTP"); !valid {
+		return false, msg
+	}
+
 	// Use the FTP authentication function
-	success, message, err := ftppentest.AuthenticateUser(ctx, target, cred.Username, cred.Password, config.Timeout)
+	success, message, err := ftppentest.AuthenticateUser(ctx, target, cred.Username, getPasswordForAuth(cred), config.Timeout)
 	if err != nil {
 		return false, fmt.Sprintf("FTP error: %v", err)
 	}
@@ -514,10 +597,19 @@ func (e *Engine) performFTPSpray(ctx context.Context, target string, cred *pente
 
 // performSMBSpray uses existing SMB auth functionality
 func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {
+	// Build passwords array (either password or empty for hash auth)
+	var passwords []string
+	if cred.Password != nil {
+		passwords = []string{*cred.Password}
+	} else {
+		passwords = []string{""} // Empty password for hash auth
+	}
+
 	smbConfig := &smbfern.PentestSmbConfig{
 		Targets:   []string{target},
 		Usernames: []string{cred.Username},
-		Passwords: []string{cred.Password},
+		Passwords: passwords,
+		NtlmHash:  cred.NtlmHash, // Pass NTLM hash for pass-the-hash authentication
 		Domain:    cred.Domain,
 		Timeout:   config.Timeout,
 	}
@@ -544,10 +636,15 @@ func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pente
 
 // performTelnetSpray uses existing Telnet auth functionality
 func (e *Engine) performTelnetSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {
+	// Validate password required
+	if valid, msg := validatePasswordRequired(cred, "Telnet"); !valid {
+		return false, msg
+	}
+
 	telnetConfig := &telnetfern.PentestTelnetConfig{
 		Targets:   []string{target},
 		Usernames: []string{cred.Username},
-		Passwords: []string{cred.Password},
+		Passwords: []string{getPasswordForAuth(cred)},
 		Timeout:   config.Timeout,
 	}
 
@@ -591,8 +688,8 @@ func (e *Engine) performLDAPSpray(ctx context.Context, target string, cred *pent
 		ldapTarget.BaseDN = strings.Join(dcParts, ",")
 	}
 
-	// Attempt authentication
-	success, message, err := ldappentest.AuthenticateUser(ctx, ldapTarget, cred.Username, cred.Password, config.Timeout)
+	// Attempt authentication (LDAP supports both password and NTLM hash auth)
+	success, message, err := ldappentest.AuthenticateUser(ctx, ldapTarget, cred.Username, getPasswordForAuth(cred), config.Timeout)
 	if err != nil {
 		return false, fmt.Sprintf("LDAP error: %v", err)
 	}
@@ -678,23 +775,26 @@ func generateUsernameEnumStatistics(attempts []*pentestfern.SprayAttempt, userna
 	}
 }
 
-// loadCredentialsFromConfig loads usernames and passwords from config including built-in wordlists
-func loadCredentialsFromConfig(config *pentestfern.SprayPasswordConfig) ([]string, []string, error) {
+// loadCredentialsFromConfig loads usernames, passwords, and NTLM hashes from config including built-in wordlists
+func loadCredentialsFromConfig(config *pentestfern.SprayPasswordConfig) ([]string, []string, []string, error) {
 	// Initialize wordlist resolver
 	resolver := utils.GetDefaultWordlistResolver()
 
-	// Start with explicitly provided usernames and passwords
+	// Start with explicitly provided usernames, passwords, and NTLM hashes
 	usernames := make([]string, len(config.Usernames))
 	copy(usernames, config.Usernames)
 
 	passwords := make([]string, len(config.Passwords))
 	copy(passwords, config.Passwords)
 
+	ntlmHashes := make([]string, len(config.NtlmHashes))
+	copy(ntlmHashes, config.NtlmHashes)
+
 	// Load usernames from built-in wordlists if specified
 	if len(config.UsernameLists) > 0 {
 		wordlistUsernames, err := resolver.GetUsernameWordlists(config.UsernameLists)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to load username wordlists: %v", err)
+			return nil, nil, nil, fmt.Errorf("failed to load username wordlists: %v", err)
 		}
 		usernames = append(usernames, wordlistUsernames...)
 	}
@@ -703,12 +803,12 @@ func loadCredentialsFromConfig(config *pentestfern.SprayPasswordConfig) ([]strin
 	if len(config.PasswordLists) > 0 {
 		wordlistPasswords, err := resolver.GetPasswordWordlists(config.PasswordLists)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to load password wordlists: %v", err)
+			return nil, nil, nil, fmt.Errorf("failed to load password wordlists: %v", err)
 		}
 		passwords = append(passwords, wordlistPasswords...)
 	}
 
-	return usernames, passwords, nil
+	return usernames, passwords, ntlmHashes, nil
 }
 
 // loadUsernamesFromConfig loads usernames from config including built-in wordlists and generated schemes


### PR DESCRIPTION
### TL;DR

Added support for multiple NTLM hashes in password spray attacks, replacing the single hash parameter with a list.

### What changed?

- Changed the `ntlm-hash` flag to `ntlm-hashes` in the password spray command, allowing multiple hashes to be provided
- Updated the `Credential` type to make password optional when using NTLM hash authentication
- Added validation to prevent using NTLM hashes with Kerberos authentication
- Modified the spray functionality to support both password-based and hash-based authentication
- Added proper handling of authentication attempts with NTLM hashes against all users
- Refactored code to improve stealth delay functionality and credential handling

### How to test?

1. Run a password spray attack with NTLM hashes:
   ```
   ./pentest network password-spray smb --targets 192.168.1.100 --usernames admin,user1 --ntlm-hashes aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0
   ```

2. Try using multiple NTLM hashes:
   ```
   ./pentest network password-spray smb --targets 192.168.1.100 --usernames admin,user1 --ntlm-hashes hash1,hash2,hash3
   ```

3. Verify that attempting to use NTLM hashes with Kerberos authentication fails with an appropriate error message:
   ```
   ./pentest network password-spray kerberos --targets 192.168.1.100 --usernames admin --ntlm-hashes hash1
   ```

### Why make this change?

This change enhances the password spray functionality by supporting multiple NTLM hashes for pass-the-hash attacks against SMB and LDAP services. This is particularly useful in penetration testing scenarios where multiple hashes have been obtained and need to be tested against a range of targets. The implementation properly handles both password-based and hash-based authentication methods, with appropriate validation to ensure hashes are only used with compatible services.