### PR TITLE
Improve domain trust enumeration with human-readable attributes

### DIFF
--- a/fern/definition/pentest/ldap/domaindump.yml
+++ b/fern/definition/pentest/ldap/domaindump.yml
@@ -136,8 +136,8 @@ types:
   # Domain Trust Objects
   DomainTrust:
     properties:
-      sourceDomain: optional<string>
-      targetDomain: optional<string>
+      targetDomainFQDN: optional<string>        # Trusted domain's fully qualified domain name (from 'name' attribute)
+      targetDomainNetBIOS: optional<string>     # Trusted domain's NetBIOS name (from 'flatName' attribute)
       trustDirection: optional<string>
       trustType: optional<string>
       trustAttributes: optional<string>

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -1284,27 +1284,123 @@ func (l *LibraryPentestLdap) enumerateDomainTrusts(ctx context.Context, conn *ld
 	for _, entry := range sr.Entries {
 		trust := &ldapfern.DomainTrust{}
 
-		// Extract trust information
-		if name := entry.GetAttributeValue("name"); name != "" {
-			trust.TargetDomain = stringPtr(name)
+		// Extract trust information directly from LDAP attributes
+		// The 'name' attribute is the trusted domain's FQDN
+		// The 'flatName' attribute is the trusted domain's NetBIOS name
+		if trustedDomainFQDN := entry.GetAttributeValue("name"); trustedDomainFQDN != "" {
+			trust.TargetDomainFqdn = stringPtr(trustedDomainFQDN)
 		}
-		if flatName := entry.GetAttributeValue("flatName"); flatName != "" {
-			trust.SourceDomain = stringPtr(flatName)
+		if trustedDomainNetBIOS := entry.GetAttributeValue("flatName"); trustedDomainNetBIOS != "" {
+			trust.TargetDomainNetBios = stringPtr(trustedDomainNetBIOS)
 		}
 		if trustDirection := entry.GetAttributeValue("trustDirection"); trustDirection != "" {
-			trust.TrustDirection = stringPtr(trustDirection)
+			parsedDirection := l.parseTrustDirection(trustDirection)
+			trust.TrustDirection = stringPtr(parsedDirection)
 		}
 		if trustType := entry.GetAttributeValue("trustType"); trustType != "" {
-			trust.TrustType = stringPtr(trustType)
+			parsedType := l.parseTrustType(trustType)
+			trust.TrustType = stringPtr(parsedType)
 		}
 		if trustAttributes := entry.GetAttributeValue("trustAttributes"); trustAttributes != "" {
-			trust.TrustAttributes = stringPtr(trustAttributes)
+			parsedAttributes := l.parseTrustAttributes(trustAttributes)
+			trust.TrustAttributes = stringPtr(parsedAttributes)
 		}
 
 		trusts = append(trusts, trust)
 	}
 
 	return &trusts, errors
+}
+
+// parseTrustDirection converts numeric trust direction to human-readable string
+func (l *LibraryPentestLdap) parseTrustDirection(direction string) string {
+	if direction == "" {
+		return ""
+	}
+
+	switch direction {
+	case "1":
+		return "INBOUND"
+	case "2":
+		return "OUTBOUND"
+	case "3":
+		return "BIDIRECTIONAL"
+	default:
+		return fmt.Sprintf("UNKNOWN (%s)", direction)
+	}
+}
+
+// parseTrustType converts numeric trust type to human-readable string
+func (l *LibraryPentestLdap) parseTrustType(trustType string) string {
+	if trustType == "" {
+		return ""
+	}
+
+	switch trustType {
+	case "1":
+		return "MIT"
+	case "2":
+		return "WINDOWS_ACTIVE_DIRECTORY"
+	case "3":
+		return "DCE"
+	default:
+		return fmt.Sprintf("UNKNOWN (%s)", trustType)
+	}
+}
+
+// parseTrustAttributes converts numeric trust attributes to human-readable strings
+func (l *LibraryPentestLdap) parseTrustAttributes(attributes string) string {
+	if attributes == "" {
+		return ""
+	}
+
+	attr, err := strconv.Atoi(attributes)
+	if err != nil {
+		return fmt.Sprintf("INVALID (%s)", attributes)
+	}
+
+	var flags []string
+
+	// Trust attribute flags (from Microsoft documentation)
+	if attr&0x0001 != 0 {
+		flags = append(flags, "NON_TRANSITIVE")
+	}
+	if attr&0x0002 != 0 {
+		flags = append(flags, "UPLEVEL_ONLY")
+	}
+	if attr&0x0004 != 0 {
+		flags = append(flags, "FILTER_SIDS")
+	}
+	if attr&0x0008 != 0 {
+		flags = append(flags, "FOREST_TRANSITIVE")
+	}
+	if attr&0x0010 != 0 {
+		flags = append(flags, "CROSS_ORGANIZATION")
+	}
+	if attr&0x0020 != 0 {
+		flags = append(flags, "WITHIN_FOREST")
+	}
+	if attr&0x0040 != 0 {
+		flags = append(flags, "TREAT_AS_EXTERNAL")
+	}
+	if attr&0x0080 != 0 {
+		flags = append(flags, "TRUST_USES_RC4_ENCRYPTION")
+	}
+	if attr&0x0100 != 0 {
+		flags = append(flags, "TRUST_USES_AES_KEYS")
+	}
+	if attr&0x0200 != 0 {
+		flags = append(flags, "CROSS_ORGANIZATION_NO_TGT_DELEGATION")
+	}
+	if attr&0x0400 != 0 {
+		flags = append(flags, "PIM_TRUST")
+	}
+
+	if len(flags) == 0 {
+		return "NONE"
+	}
+
+	return strings.Join(flags, " | ")
 }
 
 // extractDomainFromBaseDN extracts the domain name from a baseDN
@@ -1416,7 +1512,7 @@ func (l *LibraryPentestLdap) getCollectionMethods(config ldapfern.PentestLdapCon
 	if config.DomaindumpConfig != nil && config.DomaindumpConfig.CollectionMethods != nil {
 		return config.DomaindumpConfig.CollectionMethods
 	}
-	return []ldapfern.CollectionMethod{ldapfern.CollectionMethodGroup, ldapfern.CollectionMethodContainer}
+	return []ldapfern.CollectionMethod{ldapfern.CollectionMethodGroup, ldapfern.CollectionMethodContainer, ldapfern.CollectionMethodTrusts}
 }
 
 // getMaxResults extracts max results from config


### PR DESCRIPTION
### TL;DR

Improved domain trust enumeration with human-readable trust information and better field naming.

### What changed?

- Renamed domain trust fields from `sourceDomain`/`targetDomain` to more accurate `targetDomainFQDN`/`targetDomainNetBIOS` with descriptive comments
- Added parsers to convert numeric trust values to human-readable strings:
  - `parseTrustDirection`: Converts numeric values to "INBOUND", "OUTBOUND", "BIDIRECTIONAL"
  - `parseTrustType`: Converts numeric values to "MIT", "WINDOWS_ACTIVE_DIRECTORY", "DCE"
  - `parseTrustAttributes`: Converts bit flags to readable strings like "NON_TRANSITIVE", "FOREST_TRANSITIVE", etc.
- Added domain trusts to default collection methods

### How to test?

1. Run a domain dump against an Active Directory environment with domain trusts
2. Verify the trust information is displayed with human-readable values
3. Confirm both FQDN and NetBIOS names are correctly captured for trusted domains

### Why make this change?

The previous implementation stored raw numeric values for trust properties, making it difficult for users to interpret the results. This change provides more descriptive field names and converts the cryptic numeric values into human-readable strings, significantly improving the usability of domain trust information in pentest reports.