### PR TITLE
Add DNS resolution for domain computer hostnames in LDAP enumeration

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -398,6 +398,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	ldapCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delays")
 	ldapCmd.Flags().Int("max-queries", 0, "Maximum total LDAP queries to perform (0 = unlimited)")
 	ldapCmd.Flags().Bool("minimal-queries", false, "Use minimal query sets and essential attributes only")
+	ldapCmd.Flags().Bool("resolveHosts", false, "Perform DNS resolution for domain computer hostnames")
 
 	parent.AddCommand(ldapCmd)
 }
@@ -728,6 +729,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	jitter, _ := cmd.Flags().GetInt("jitter")
 	maxQueries, _ := cmd.Flags().GetInt("max-queries")
 	minimalQueries, _ := cmd.Flags().GetBool("minimal-queries")
+	resolveHosts, _ := cmd.Flags().GetBool("resolveHosts")
 
 	// Parse DCSync options
 
@@ -766,7 +768,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, sleep, jitter, maxQueries, minimalQueries)
+	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, sleep, jitter, maxQueries, minimalQueries, resolveHosts)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -1158,7 +1160,7 @@ func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnet
 }
 
 // getLDAPPentestConfig creates a configuration for LDAP pentest operations with the provided parameters.
-func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, sleep int, jitter int, maxQueries int, minimalQueries bool) *ldapfern.PentestLdapConfig {
+func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, sleep int, jitter int, maxQueries int, minimalQueries bool, resolveHosts bool) *ldapfern.PentestLdapConfig {
 	var domainPtr, ntlmHashPtr *string
 	if domain != "" {
 		domainPtr = &domain
@@ -1198,8 +1200,13 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 	var domainDumpConfig *ldapfern.DomainDumpConfig
 	for _, action := range actions {
 		if action == ldapfern.PentestLdapActionDomaindump {
+			var resolveHostsPtr *bool
+			if resolveHosts {
+				resolveHostsPtr = &resolveHosts
+			}
 			domainDumpConfig = &ldapfern.DomainDumpConfig{
-				Stealth: stealthConfig,
+				Stealth:      stealthConfig,
+				ResolveHosts: resolveHostsPtr,
 			}
 			break
 		}

--- a/fern/definition/pentest/ldap/domaindump.yml
+++ b/fern/definition/pentest/ldap/domaindump.yml
@@ -96,6 +96,7 @@ types:
       distinguishedName: optional<string>
       samAccountName: optional<string>
       dnsHostName: optional<string>
+      ipAddresses: optional<list<string>> # Resolved IP addresses from DNS lookup
       description: optional<string>
       objectSid: optional<string>
       operatingSystem: optional<string>
@@ -178,3 +179,4 @@ types:
       collectionMethods: optional<list<CollectionMethod>>
       maxResults: optional<integer>
       stealth: optional<DomainDumpStealthConfig>
+      resolveHosts: optional<boolean> # Perform DNS resolution for domain computer hostnames

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +26,56 @@ import (
 func stringPtr(s string) *string { return &s }
 func intPtr(i int) *int          { return &i }
 func boolPtr(b bool) *bool       { return &b }
+
+// resolveHostname resolves a hostname to IP addresses using a specific nameserver
+func (l *LibraryPentestLdap) resolveHostname(ctx context.Context, hostname, nameserver string, stealthCtx *StealthContext) ([]string, error) {
+	if hostname == "" {
+		return nil, nil
+	}
+
+	logger := stealthCtx.Logger
+	logger.Debug("Resolving hostname",
+		svc1log.SafeParam("hostname", hostname),
+		svc1log.SafeParam("nameserver", nameserver))
+
+	// Create a custom resolver using the target as nameserver
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: time.Second * 10, // 10 second DNS timeout
+			}
+			// Use the nameserver (LDAP server) for DNS resolution
+			return d.DialContext(ctx, network, nameserver+":53")
+		},
+	}
+
+	// Track DNS query for stealth mode
+	stealthCtx.IncrementQuery()
+
+	// Perform DNS lookup
+	ips, err := resolver.LookupIPAddr(ctx, hostname)
+	if err != nil {
+		logger.Debug("DNS resolution failed",
+			svc1log.SafeParam("hostname", hostname),
+			svc1log.SafeParam("error", err.Error()))
+		return nil, err
+	}
+
+	// Convert IP addresses to strings
+	var ipStrings []string
+	for _, ip := range ips {
+		ipStrings = append(ipStrings, ip.IP.String())
+	}
+
+	if len(ipStrings) > 0 {
+		logger.Debug("DNS resolution successful",
+			svc1log.SafeParam("hostname", hostname),
+			svc1log.SafeParam("ips", ipStrings))
+	}
+
+	return ipStrings, nil
+}
 
 // StealthContext tracks stealth parameters and query count
 type StealthContext struct {
@@ -848,7 +899,7 @@ func (l *LibraryPentestLdap) determineMemberType(ctx context.Context, conn *ldap
 	return "Unknown"
 }
 
-func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.DomainComputer, []string) {
+func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext, nameserver string, resolveHosts bool) (*[]*ldapfern.DomainComputer, []string) {
 	var errors []string
 	var computers []*ldapfern.DomainComputer
 
@@ -905,6 +956,18 @@ func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.
 
 		if dnsHostName := l.getAttributeValue(entry, "dNSHostName"); dnsHostName != "" {
 			computer.DnsHostName = stringPtr(dnsHostName)
+
+			// Perform DNS resolution if enabled and we have a valid hostname
+			if resolveHosts && nameserver != "" && stealthCtx.ShouldContinue() {
+				ips, err := l.resolveHostname(ctx, dnsHostName, nameserver, stealthCtx)
+				if err != nil {
+					stealthCtx.Logger.Debug("Failed to resolve hostname",
+						svc1log.SafeParam("hostname", dnsHostName),
+						svc1log.SafeParam("error", err.Error()))
+				} else if len(ips) > 0 {
+					computer.IpAddresses = ips
+				}
+			}
 		}
 		if desc := l.getAttributeValue(entry, "description"); desc != "" {
 			computer.Description = stringPtr(desc)
@@ -1456,11 +1519,23 @@ func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn 
 			collectionMethods := l.getCollectionMethods(config)
 			maxResults := l.getMaxResults(config)
 
+			// Extract nameserver and resolveHosts flag from config
+			nameserver := ""
+			resolveHosts := false
+			if len(config.Targets) > 0 {
+				if target, err := ParseTarget(config.Targets[0]); err == nil {
+					nameserver = target.Host
+				}
+			}
+			if config.DomaindumpConfig != nil && config.DomaindumpConfig.ResolveHosts != nil {
+				resolveHosts = *config.DomaindumpConfig.ResolveHosts
+			}
+
 			for _, method := range collectionMethods {
 				if !stealthCtx.ShouldContinue() {
 					break
 				}
-				l.processCollectionMethod(ctx, conn, baseDN, method, maxResults, stealthCtx, domainResult, &errors)
+				l.processCollectionMethod(ctx, conn, baseDN, method, maxResults, stealthCtx, nameserver, resolveHosts, domainResult, &errors)
 			}
 		}
 	}
@@ -1524,7 +1599,7 @@ func (l *LibraryPentestLdap) getMaxResults(config ldapfern.PentestLdapConfig) *i
 }
 
 // processCollectionMethod processes a single collection method
-func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *ldap.Conn, baseDN string, method ldapfern.CollectionMethod, maxResults *int, stealthCtx *StealthContext, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *ldap.Conn, baseDN string, method ldapfern.CollectionMethod, maxResults *int, stealthCtx *StealthContext, nameserver string, resolveHosts bool, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
 	switch method {
 	case ldapfern.CollectionMethodGroup:
 		l.processGroupCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
@@ -1533,7 +1608,7 @@ func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *
 	case ldapfern.CollectionMethodObjectprops:
 		l.processObjectPropsCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
 	case ldapfern.CollectionMethodContainer:
-		l.processContainerCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
+		l.processContainerCollection(ctx, conn, baseDN, maxResults, stealthCtx, nameserver, resolveHosts, domainResult, errors)
 	default:
 		logger := svc1log.FromContext(ctx)
 		logger.Info("Collection method not yet implemented", svc1log.SafeParam("method", string(method)))
@@ -1611,9 +1686,9 @@ func (l *LibraryPentestLdap) processObjectPropsCollection(ctx context.Context, c
 }
 
 // processContainerCollection handles computer and domain controller enumeration
-func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext, nameserver string, resolveHosts bool, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
 	// Enumerate computers
-	computers, errs := l.enumerateComputers(ctx, conn, baseDN, maxResults, stealthCtx)
+	computers, errs := l.enumerateComputers(ctx, conn, baseDN, maxResults, stealthCtx, nameserver, resolveHosts)
 	if computers != nil {
 		domainResult.Computers = *computers
 		*domainResult.TotalObjects += len(*computers)


### PR DESCRIPTION
### TL;DR

Added DNS resolution capability for computer hostnames in LDAP domain enumeration.

### What changed?

- Added a new `--resolveHosts` flag to the LDAP pentest command that enables DNS resolution for domain computer hostnames
- Implemented hostname resolution functionality that uses the LDAP server as a nameserver
- Added an `ipAddresses` field to the `DomainComputer` type to store resolved IP addresses
- Updated the domain enumeration logic to perform DNS lookups when the flag is enabled
- Propagated the new parameter through the relevant configuration structures

### How to test?

1. Run an LDAP domain enumeration with the new flag:
   ```
   ./pentest ldap domaindump --target ldap.example.com --username user --password pass --resolveHosts
   ```
2. Verify that computer objects in the results include IP addresses in the `ipAddresses` field
3. Test without the flag to confirm that DNS resolution is skipped
4. Test with various domain controllers to ensure DNS resolution works correctly

### Why make this change?

This enhancement provides more comprehensive network information during domain enumeration by resolving hostnames to IP addresses. This is valuable for security assessments and network mapping, as it allows for better understanding of the domain's network topology without requiring separate DNS lookup tools.