### PR TITLE
Rename ParsedOsVersion to MappedOsVersion in NTLM server info

### DIFF
--- a/fern/definition/common/protocol/ntlm.yml
+++ b/fern/definition/common/protocol/ntlm.yml
@@ -23,7 +23,7 @@ types:
   NtlmServerInfo:
     properties:
       # Parsed OS version (derived from OsInfo)
-      parsedOsVersion: optional<string> # Parsed OS version (e.g., "Windows Server 2022")
+      mappedOsVersion: optional<string> # Mapped OS version (e.g., "Windows Server 2022")
 
       # Protocol-specific fields
       signingRequired: optional<boolean> # Whether SMB signing is required

--- a/internal/common/ntlm/serverinfo.go
+++ b/internal/common/ntlm/serverinfo.go
@@ -84,7 +84,7 @@ func ExtractServerInfoFromChallenge(challengeMessage []byte, log svc1log.Logger)
 			RawVersionData:      &rawOSVersion,
 		}
 
-		result.ParsedOsVersion = &osVersion
+		result.MappedOsVersion = &osVersion
 	}
 	result.OsInfo = ntlmOsInfo
 
@@ -108,8 +108,8 @@ func ConvertToLDAPServerInfo(ntlmInfo *commonprotocolfern.NtlmServerInfo) *commo
 	result := &commonprotocolfern.LdapServerInfo{}
 
 	// Copy core fields that exist in cleaned structure
-	if ntlmInfo.ParsedOsVersion != nil {
-		result.ParsedOsVersion = ntlmInfo.ParsedOsVersion
+	if ntlmInfo.MappedOsVersion != nil {
+		result.MappedOsVersion = ntlmInfo.MappedOsVersion
 	}
 	if ntlmInfo.SigningRequired != nil {
 		result.SigningRequired = ntlmInfo.SigningRequired
@@ -252,8 +252,8 @@ func GetDomainName(serverInfo *commonprotocolfern.NtlmServerInfo) string {
 
 // GetOSVersion extracts parsed OS version from server info
 func GetOSVersion(serverInfo *commonprotocolfern.NtlmServerInfo) string {
-	if serverInfo != nil && serverInfo.ParsedOsVersion != nil {
-		return *serverInfo.ParsedOsVersion
+	if serverInfo != nil && serverInfo.MappedOsVersion != nil {
+		return *serverInfo.MappedOsVersion
 	}
 	return ""
 }
@@ -362,8 +362,8 @@ func GetSMBDomainName(serverInfo *commonprotocolfern.SmbServerInfo) string {
 }
 
 func GetSMBOSVersion(serverInfo *commonprotocolfern.SmbServerInfo) string {
-	if serverInfo != nil && serverInfo.ParsedOsVersion != nil {
-		return *serverInfo.ParsedOsVersion
+	if serverInfo != nil && serverInfo.MappedOsVersion != nil {
+		return *serverInfo.MappedOsVersion
 	}
 	return ""
 }

--- a/internal/discover/domain.go
+++ b/internal/discover/domain.go
@@ -307,8 +307,8 @@ func enumerateDomainControllers(ctx context.Context, host string, domainName str
 
 			domainControllers = append(domainControllers, dcInfo)
 			var serverVersion string
-			if dcInfo.SmbServerInfo != nil && dcInfo.SmbServerInfo.ParsedOsVersion != nil {
-				serverVersion = *dcInfo.SmbServerInfo.ParsedOsVersion
+			if dcInfo.SmbServerInfo != nil && dcInfo.SmbServerInfo.MappedOsVersion != nil {
+				serverVersion = *dcInfo.SmbServerInfo.MappedOsVersion
 			}
 			log.Debug("Found domain controller",
 				svc1log.SafeParam("hostname", hostname),
@@ -404,8 +404,8 @@ func gatherDomainControllerDetails(ctx context.Context, hostname, ipAddress stri
 		_ = client.Close()
 
 		var osVersion string
-		if serverInfo.ParsedOsVersion != nil {
-			osVersion = *serverInfo.ParsedOsVersion
+		if serverInfo.MappedOsVersion != nil {
+			osVersion = *serverInfo.MappedOsVersion
 		}
 		log.Debug("Successfully gathered DC details",
 			svc1log.SafeParam("target", target),

--- a/internal/discover/service/plugins/smb.go
+++ b/internal/discover/service/plugins/smb.go
@@ -96,8 +96,8 @@ func detectSMBService(ctx context.Context, ip net.IP, port int, host string) (*d
 		result.Metadata["authenticated"] = "false"
 
 		// Add available server info to metadata and version
-		if serverInfo.GetParsedOsVersion() != nil {
-			version := *serverInfo.GetParsedOsVersion()
+		if serverInfo.GetMappedOsVersion() != nil {
+			version := *serverInfo.GetMappedOsVersion()
 			result.Version = &version
 			result.Metadata["os_version"] = version
 		}

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -4,6 +4,7 @@ package service
 import (
 	// Standard
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/netip"
@@ -22,6 +23,8 @@ import (
 	localPlugins "github.com/Method-Security/networkscan/internal/discover/service/plugins"
 	// Fingerprintx plugins
 	_ "github.com/Method-Security/networkscan/internal/discover/service/plugins/fingerprintx"
+	// Internal
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
 	// Utilities
 	"github.com/Method-Security/networkscan/utils"
 )
@@ -103,7 +106,7 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 
 // fxToServiceDetails converts fingerprintx result to ServiceDetails
 func fxToServiceDetails(result *plugins.Service) *discoverfern.ServiceDetails {
-	return &discoverfern.ServiceDetails{
+	serviceDetails := &discoverfern.ServiceDetails{
 		Host: result.Host,
 		Ip:   result.IP,
 		Port: result.Port,
@@ -125,4 +128,21 @@ func fxToServiceDetails(result *plugins.Service) *discoverfern.ServiceDetails {
 			"raw": string(result.Raw),
 		},
 	}
+
+	// Parse Windows OS version from NTLM metadata if available
+	var rawData map[string]interface{}
+	if err := json.Unmarshal(result.Raw, &rawData); err == nil {
+		if osVersion, exists := rawData["osVersion"]; exists {
+			if osVersionStr, ok := osVersion.(string); ok && osVersionStr != "" {
+				// Extract build number from version like "10.0.20348" -> "Build 20348"
+				parts := strings.Split(osVersionStr, ".")
+				if len(parts) >= 3 {
+					buildVersion := fmt.Sprintf("Build %s", parts[2])
+					serviceDetails.Metadata["mappedOsVersion"] = ntlm.ParseWindowsVersion(buildVersion)
+				}
+			}
+		}
+	}
+
+	return serviceDetails
 }

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -180,7 +180,7 @@ func (s *LibraryEnumerateSMB) processServerInfo(serverInfo *commonprotocolfern.S
 		ntlmServerInfo := &commonprotocolfern.NtlmServerInfo{
 			TargetInfo:      serverInfo.TargetInfo,
 			OsInfo:          serverInfo.OsInfo,
-			ParsedOsVersion: serverInfo.ParsedOsVersion,
+			MappedOsVersion: serverInfo.MappedOsVersion,
 			SigningRequired: serverInfo.SigningRequired,
 		}
 		ntlm.LogServerInfoDetails(ntlmServerInfo, target, log)

--- a/internal/protocol/smb/client.go
+++ b/internal/protocol/smb/client.go
@@ -219,7 +219,7 @@ func (c *Client) ExtractServerInfoFromChallenge(ctx context.Context) (*commonpro
 	smbInfo.SupportedSmbVersions = []commonprotocolfern.SmbVersion{} // Set when we have negotiation info
 
 	log.Debug("Successfully extracted server info from unified NTLM challenge parser",
-		svc1log.SafeParam("parsedOsVersion", smbInfo.ParsedOsVersion))
+		svc1log.SafeParam("mappedOsVersion", smbInfo.MappedOsVersion))
 
 	return smbInfo, nil
 }
@@ -591,7 +591,7 @@ func (c *Client) GetSMBSession() (*gosmb.Connection, error) {
 // convertNtlmToSmbServerInfo converts NtlmServerInfo to SmbServerInfo, preserving nested structures
 func convertNtlmToSmbServerInfo(ntlmInfo *commonprotocolfern.NtlmServerInfo) *commonprotocolfern.SmbServerInfo {
 	return &commonprotocolfern.SmbServerInfo{
-		ParsedOsVersion:      ntlmInfo.ParsedOsVersion,
+		MappedOsVersion:      ntlmInfo.MappedOsVersion,
 		SigningRequired:      ntlmInfo.SigningRequired,
 		TargetInfo:           ntlmInfo.TargetInfo,
 		OsInfo:               ntlmInfo.OsInfo,


### PR DESCRIPTION
### TL;DR

Renamed `parsedOsVersion` field to `mappedOsVersion` across the codebase to better reflect its purpose.

### What changed?

- Renamed the `parsedOsVersion` field to `mappedOsVersion` in the NTLM server info data structure
- Updated all references to this field throughout the codebase to use the new name
- Added OS version mapping functionality in the service discovery module to extract and map Windows build numbers to readable OS versions

### How to test?

1. Run service discovery against Windows hosts to verify OS version mapping works correctly
2. Verify that Windows version information is properly displayed in scan results
3. Check that domain controller enumeration still correctly shows OS version information

### Why make this change?

The term "mapped" more accurately describes what this field represents - it's not just parsing the raw version string but actually mapping Windows build numbers to human-readable OS version names (e.g., mapping "Build 20348" to "Windows Server 2022"). This change improves code clarity and better represents the actual functionality.