### PR TITLE
Add delegation properties to LDAP domain dump

### DIFF
--- a/fern/definition/pentest/ldap/domaindump.yml
+++ b/fern/definition/pentest/ldap/domaindump.yml
@@ -39,7 +39,11 @@ types:
       domainsid: optional<string>
       distinguishedname: optional<string>
       unconstraineddelegation: optional<boolean>
+      constraineddelegation: optional<boolean>
+      constraineddelegationspns: optional<list<string>>
       trustedtoauth: optional<boolean>
+      resourceBasedConstrainedDelegation: optional<boolean>
+      resourceBasedConstrainedDelegationPrincipals: optional<list<string>>
       passwordnotreqd: optional<boolean>
       enabled: optional<boolean>
       lastlogon: optional<string>
@@ -104,6 +108,12 @@ types:
       lastLogon: optional<string>
       servicePrincipalNames: optional<list<string>>
       isDomainController: optional<boolean>
+      unconstrainedDelegation: optional<boolean>
+      constrainedDelegation: optional<boolean>
+      constrainedDelegationSpns: optional<list<string>>
+      trustedToAuth: optional<boolean>
+      resourceBasedConstrainedDelegation: optional<boolean>
+      resourceBasedConstrainedDelegationPrincipals: optional<list<string>>
 
   # Domain Controller Objects
   DomainController:
@@ -133,6 +143,21 @@ types:
       gpcFileSysPath: optional<string>
       versionNumber: optional<integer>
 
+  # Domain Container Objects
+  DomainContainer:
+    properties:
+      objectIdentifier: optional<string>
+      distinguishedName: optional<string>
+      name: optional<string>
+      domain: optional<string>
+      domainSid: optional<string>
+      description: optional<string>
+      highValue: optional<boolean>
+      whenCreated: optional<string>
+      isDeleted: optional<boolean>
+      isACLProtected: optional<boolean>
+      childObjects: optional<list<string>>   # List of child object identifiers
+
   # Domain Trust Objects
   DomainTrust:
     properties:
@@ -141,6 +166,16 @@ types:
       trustDirection: optional<string>
       trustType: optional<string>
       trustAttributes: optional<string>
+
+  # Domain Object
+  DomainObject:
+    properties:
+      name: optional<string>                    # Domain FQDN (e.g., CORP.EXAMPLE.COM)
+      netbiosName: optional<string>             # NetBIOS name (e.g., CORP)
+      distinguishedName: optional<string>       # Domain DN (e.g., DC=corp,DC=example,DC=com)
+      objectSid: optional<string>               # Domain SID (e.g., S-1-5-21-1234567890-123456789-1234567890)
+      functionalLevel: optional<string>         # Domain functional level
+      domainMode: optional<string>              # Domain mode information
 
   # Result Types - matching BloodHound reference structure
   DomainDataMeta:
@@ -163,12 +198,14 @@ types:
   # Domain Dump Result
   DomainDumpResult:
     properties:
+      domain: optional<DomainObject>
       users: optional<DomainUsersResult>
       groups: optional<DomainGroupsResult>
       computers: optional<list<DomainComputer>>
       domainControllers: optional<list<DomainController>>
       organizationalUnits: optional<list<OrganizationalUnit>>
       groupPolicyObjects: optional<list<GroupPolicyObject>>
+      containers: optional<list<DomainContainer>>
       domainTrusts: optional<list<DomainTrust>>
       totalObjects: optional<integer>
 

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -379,7 +379,8 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 		"distinguishedName", "sAMAccountName", "userPrincipalName", "displayName",
 		"description", "objectSid", "userAccountControl", "sAMAccountType",
 		"lastLogon", "lastLogonTimestamp", "pwdLastSet", "adminCount", "servicePrincipalName",
-		"primaryGroupID", "isDeleted", "sIDHistory", "objectClass",
+		"primaryGroupID", "isDeleted", "sIDHistory", "objectClass", "msDS-AllowedToDelegateTo",
+		"msDS-AllowedToActOnBehalfOfOtherIdentity",
 	}
 	if stealthCtx.MinimalQueries {
 		// Only essential attributes for stealth mode
@@ -511,6 +512,28 @@ func (l *LibraryPentestLdap) enumerateUsers(ctx context.Context, conn *ldap.Conn
 		// Get service principal names
 		if spnValues := entry.GetAttributeValues("servicePrincipalName"); len(spnValues) > 0 {
 			properties.Serviceprincipalnames = spnValues
+		}
+
+		// Get constrained delegation information
+		constrainedDelegationSPNs := entry.GetAttributeValues("msDS-AllowedToDelegateTo")
+		if len(constrainedDelegationSPNs) > 0 {
+			properties.Constraineddelegation = boolPtr(true)
+			properties.Constraineddelegationspns = constrainedDelegationSPNs
+		} else {
+			properties.Constraineddelegation = boolPtr(false)
+		}
+
+		// Get Resource-Based Constrained Delegation (RBCD) information for users
+		rbcdData := entry.GetRawAttributeValue("msDS-AllowedToActOnBehalfOfOtherIdentity")
+		if len(rbcdData) > 0 {
+			properties.ResourceBasedConstrainedDelegation = boolPtr(true)
+			// Parse the security descriptor to extract allowed principals
+			allowedPrincipals := l.parseRBCDSecurityDescriptor(string(rbcdData))
+			if len(allowedPrincipals) > 0 {
+				properties.ResourceBasedConstrainedDelegationPrincipals = allowedPrincipals
+			}
+		} else {
+			properties.ResourceBasedConstrainedDelegation = boolPtr(false)
 		}
 
 		user.Properties = properties
@@ -856,13 +879,14 @@ func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.
 	var attributes []string
 	if stealthCtx.MinimalQueries {
 		attributes = []string{
-			"distinguishedName", "sAMAccountName", "objectSid", "dNSHostName",
+			"distinguishedName", "sAMAccountName", "objectSid", "dNSHostName", "userAccountControl",
 		}
 	} else {
 		attributes = []string{
 			"distinguishedName", "sAMAccountName", "dNSHostName", "description",
 			"objectSid", "sAMAccountType", "operatingSystem", "operatingSystemVersion", "userAccountControl",
 			"lastLogon", "lastLogonTimestamp", "pwdLastSet", "servicePrincipalName", "isDeleted", "whenCreated",
+			"msDS-AllowedToDelegateTo", "msDS-AllowedToActOnBehalfOfOtherIdentity",
 		}
 	}
 
@@ -925,7 +949,36 @@ func (l *LibraryPentestLdap) enumerateComputers(ctx context.Context, conn *ldap.
 
 				// Domain Controller detection using UserAccountControl (standard method)
 				computer.IsDomainController = boolPtr((uacInt & 0x00002000) != 0) // SERVER_TRUST_ACCOUNT
+
+				// Delegation flags for computers
+				unconstrainedDelegation := (uacInt & 0x00080000) != 0 // UF_TRUSTED_FOR_DELEGATION
+				computer.UnconstrainedDelegation = boolPtr(unconstrainedDelegation)
+
+				trustedToAuth := (uacInt & 0x01000000) != 0 // UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION
+				computer.TrustedToAuth = boolPtr(trustedToAuth)
 			}
+		}
+
+		// Get constrained delegation information for computers
+		constrainedDelegationSPNs := entry.GetAttributeValues("msDS-AllowedToDelegateTo")
+		if len(constrainedDelegationSPNs) > 0 {
+			computer.ConstrainedDelegation = boolPtr(true)
+			computer.ConstrainedDelegationSpns = constrainedDelegationSPNs
+		} else {
+			computer.ConstrainedDelegation = boolPtr(false)
+		}
+
+		// Get Resource-Based Constrained Delegation (RBCD) information
+		rbcdData := entry.GetRawAttributeValue("msDS-AllowedToActOnBehalfOfOtherIdentity")
+		if len(rbcdData) > 0 {
+			computer.ResourceBasedConstrainedDelegation = boolPtr(true)
+			// Parse the security descriptor to extract allowed principals
+			allowedPrincipals := l.parseRBCDSecurityDescriptor(string(rbcdData))
+			if len(allowedPrincipals) > 0 {
+				computer.ResourceBasedConstrainedDelegationPrincipals = allowedPrincipals
+			}
+		} else {
+			computer.ResourceBasedConstrainedDelegation = boolPtr(false)
 		}
 
 		// Process timestamps
@@ -1440,6 +1493,327 @@ func (l *LibraryPentestLdap) extractDomainSID(conn *ldap.Conn, baseDN string) st
 	return ""
 }
 
+// enumerateContainers enumerates domain container objects (CN=Users, CN=Computers, etc.)
+func (l *LibraryPentestLdap) enumerateContainers(ctx context.Context, conn *ldap.Conn, baseDN string, maxResults *int, stealthCtx *StealthContext) (*[]*ldapfern.DomainContainer, []string) {
+	var errors []string
+	var containers []*ldapfern.DomainContainer
+
+	// Extract domain information
+	domain := l.extractDomainFromBaseDN(baseDN)
+	domainSID := l.extractDomainSID(conn, baseDN)
+
+	// Use minimal attributes in stealth mode to reduce query size
+	var attributes []string
+	if stealthCtx.MinimalQueries {
+		attributes = []string{
+			"distinguishedName", "name", "objectGUID", "description",
+		}
+	} else {
+		attributes = []string{
+			"distinguishedName", "name", "objectGUID", "description", "whenCreated",
+			"isDeleted", "nTSecurityDescriptor", "objectClass",
+		}
+	}
+
+	// Use pagination for large domains (1000 results per page)
+	const pageSize = 1000
+	var totalProcessed int
+
+	// Search for container objects - these are typically built-in AD containers
+	searchRequest := ldap.NewSearchRequest(
+		baseDN,
+		ldap.ScopeWholeSubtree,
+		ldap.NeverDerefAliases,
+		0, // No size limit - we'll use pagination
+		0, // No time limit
+		false,
+		"(&(objectClass=container)(!(objectClass=organizationalUnit)))",
+		attributes,
+		nil,
+	)
+
+	// Track query and apply stealth delay
+	stealthCtx.IncrementQuery()
+
+	sr, err := l.executeSearchWithRetry(conn, searchRequest, pageSize, stealthCtx)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Failed to search containers: %v", err))
+		return nil, errors
+	}
+
+	for _, entry := range sr.Entries {
+		// Check if we've reached max results limit
+		if maxResults != nil && totalProcessed >= *maxResults {
+			break
+		}
+		totalProcessed++
+
+		container := &ldapfern.DomainContainer{
+			DistinguishedName: stringPtr(entry.DN),
+			Name:              stringPtr(l.formatContainerName(entry.GetAttributeValue("name"), domain)),
+			Domain:            stringPtr(domain),
+			DomainSid:         stringPtr(domainSID),
+		}
+
+		// Generate object identifier from objectGUID if available
+		if objectGUID := entry.GetRawAttributeValue("objectGUID"); len(objectGUID) > 0 {
+			guidString := l.convertGUIDToString(string(objectGUID))
+			container.ObjectIdentifier = stringPtr(guidString)
+		}
+
+		// Optional fields
+		if description := entry.GetAttributeValue("description"); description != "" {
+			container.Description = stringPtr(description)
+		}
+
+		// Parse whenCreated timestamp
+		if whenCreated := entry.GetAttributeValue("whenCreated"); whenCreated != "" {
+			container.WhenCreated = stringPtr(whenCreated)
+		}
+
+		// Check if object is deleted
+		isDeleted := false
+		if deletedStr := entry.GetAttributeValue("isDeleted"); deletedStr != "" {
+			if deleted, err := strconv.ParseBool(deletedStr); err == nil {
+				isDeleted = deleted
+			}
+		}
+		container.IsDeleted = boolPtr(isDeleted)
+
+		// Determine if this is a high-value container (e.g., Users, Computers, System)
+		containerName := strings.ToUpper(entry.GetAttributeValue("name"))
+		highValue := l.isHighValueContainer(containerName)
+		container.HighValue = boolPtr(highValue)
+
+		// Initialize child objects as empty list - could be populated in future enhancement
+		container.ChildObjects = []string{}
+
+		containers = append(containers, container)
+	}
+
+	logger := svc1log.FromContext(ctx)
+	logger.Info("Enumerated containers", svc1log.SafeParam("count", len(containers)))
+	return &containers, errors
+}
+
+// formatContainerName formats container name to match BloodHound format
+func (l *LibraryPentestLdap) formatContainerName(name, domain string) string {
+	return fmt.Sprintf("%s@%s", strings.ToUpper(name), strings.ToUpper(domain))
+}
+
+// isHighValueContainer determines if a container is considered high value
+func (l *LibraryPentestLdap) isHighValueContainer(containerName string) bool {
+	highValueContainers := []string{
+		"USERS", "COMPUTERS", "SYSTEM", "KEYS", "FOREIGNSECURITYPRINCIPALS",
+		"ADMINSDHOLDER", "PROGRAM DATA", "MANAGED SERVICE ACCOUNTS",
+	}
+
+	for _, hvContainer := range highValueContainers {
+		if strings.EqualFold(containerName, hvContainer) {
+			return true
+		}
+	}
+	return false
+}
+
+// convertGUIDToString converts a binary GUID to string representation
+func (l *LibraryPentestLdap) convertGUIDToString(guidBytes string) string {
+	if len(guidBytes) != 16 {
+		return guidBytes // Return as-is if not a proper GUID
+	}
+
+	data := []byte(guidBytes)
+
+	// Parse GUID according to Microsoft format (little-endian for first 3 groups)
+	return fmt.Sprintf("%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+		data[3], data[2], data[1], data[0],
+		data[5], data[4],
+		data[7], data[6],
+		data[8], data[9],
+		data[10], data[11], data[12], data[13], data[14], data[15])
+}
+
+// parseRBCDSecurityDescriptor parses the msDS-AllowedToActOnBehalfOfOtherIdentity security descriptor
+// This attribute contains a security descriptor that specifies which principals are allowed to delegate
+func (l *LibraryPentestLdap) parseRBCDSecurityDescriptor(secDescriptor string) []string {
+	var principals []string
+
+	// The msDS-AllowedToActOnBehalfOfOtherIdentity attribute contains a Windows security descriptor
+	// in binary format. Parsing this fully requires understanding the Windows security descriptor format.
+	// For now, we'll attempt to extract SIDs from the raw data using pattern matching.
+
+	data := []byte(secDescriptor)
+
+	// Windows SIDs typically start with 0x01 (revision) followed by authority count
+	// This is a simplified approach - a full implementation would properly parse the SD structure
+	for i := 0; i < len(data)-12; i++ {
+		// Look for SID patterns (revision=1, authority count, then authority bytes)
+		if i+12 < len(data) && data[i] == 0x01 {
+			// Try to extract what might be a SID
+			if sidString := l.tryExtractSIDFromBytes(data[i:]); sidString != "" {
+				// Avoid duplicates
+				found := false
+				for _, existing := range principals {
+					if existing == sidString {
+						found = true
+						break
+					}
+				}
+				if !found {
+					principals = append(principals, sidString)
+				}
+			}
+		}
+	}
+
+	return principals
+}
+
+// tryExtractSIDFromBytes attempts to extract a SID from a byte array at the current position
+func (l *LibraryPentestLdap) tryExtractSIDFromBytes(data []byte) string {
+	if len(data) < 12 {
+		return ""
+	}
+
+	// Check if this looks like a SID structure
+	revision := data[0]
+	subAuthorityCount := data[1]
+
+	// Basic validation
+	if revision != 0x01 || subAuthorityCount == 0 || subAuthorityCount > 15 {
+		return ""
+	}
+
+	// Calculate expected SID length
+	expectedLength := 8 + (int(subAuthorityCount) * 4) // 8 bytes header + 4 bytes per sub-authority
+	if len(data) < expectedLength {
+		return ""
+	}
+
+	// Extract authority (6 bytes, big-endian)
+	authority := uint64(data[2])<<40 | uint64(data[3])<<32 | uint64(data[4])<<24 |
+		uint64(data[5])<<16 | uint64(data[6])<<8 | uint64(data[7])
+
+	// Build SID string
+	sidString := fmt.Sprintf("S-%d-%d", revision, authority)
+
+	// Extract sub-authorities (4 bytes each, little-endian)
+	for i := 0; i < int(subAuthorityCount); i++ {
+		offset := 8 + (i * 4)
+		if offset+4 > len(data) {
+			break
+		}
+		subAuth := uint32(data[offset]) | uint32(data[offset+1])<<8 |
+			uint32(data[offset+2])<<16 | uint32(data[offset+3])<<24
+		sidString += fmt.Sprintf("-%d", subAuth)
+	}
+
+	// Basic validation - ensure the SID looks reasonable
+	if len(sidString) < 10 || !strings.HasPrefix(sidString, "S-1-") {
+		return ""
+	}
+
+	return sidString
+}
+
+// enumerateDomainObject extracts domain-level information including domain SID
+func (l *LibraryPentestLdap) enumerateDomainObject(ctx context.Context, conn *ldap.Conn, baseDN string, stealthCtx *StealthContext) (*ldapfern.DomainObject, []string) {
+	var errors []string
+
+	// Get basic domain information that we already extract
+	domain := l.extractDomainFromBaseDN(baseDN)
+	domainSID := l.extractDomainSID(conn, baseDN)
+
+	// Search for additional domain attributes
+	searchRequest := ldap.NewSearchRequest(
+		baseDN,
+		ldap.ScopeBaseObject, ldap.NeverDerefAliases, 1, 0, false,
+		"(objectClass=*)",
+		[]string{"objectSid", "name", "netBIOSName", "msDS-Behavior-Version", "domainFunctionality"},
+		nil,
+	)
+
+	// Track query and apply stealth delay
+	stealthCtx.IncrementQuery()
+
+	sr, err := conn.Search(searchRequest)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Failed to search domain object: %v", err))
+		// Still return basic info even if extended search fails
+		domainObject := &ldapfern.DomainObject{
+			Name:              stringPtr(domain),
+			DistinguishedName: stringPtr(baseDN),
+			ObjectSid:         stringPtr(domainSID),
+		}
+		return domainObject, errors
+	}
+
+	domainObject := &ldapfern.DomainObject{
+		Name:              stringPtr(domain),
+		DistinguishedName: stringPtr(baseDN),
+		ObjectSid:         stringPtr(domainSID),
+	}
+
+	if len(sr.Entries) > 0 {
+		entry := sr.Entries[0]
+
+		// Get NetBIOS name if available
+		if netbiosName := entry.GetAttributeValue("netBIOSName"); netbiosName != "" {
+			domainObject.NetbiosName = stringPtr(netbiosName)
+		} else {
+			// Extract NetBIOS from domain name (first part before dot)
+			if parts := strings.Split(domain, "."); len(parts) > 0 {
+				domainObject.NetbiosName = stringPtr(parts[0])
+			}
+		}
+
+		// Get functional level information
+		if functionalLevel := entry.GetAttributeValue("msDS-Behavior-Version"); functionalLevel != "" {
+			parsed := l.parseFunctionalLevel(functionalLevel)
+			domainObject.FunctionalLevel = stringPtr(parsed)
+		}
+		if domainFunc := entry.GetAttributeValue("domainFunctionality"); domainFunc != "" {
+			parsed := l.parseFunctionalLevel(domainFunc)
+			domainObject.DomainMode = stringPtr(parsed)
+		}
+	}
+
+	logger := svc1log.FromContext(ctx)
+	logger.Info("Enumerated domain object",
+		svc1log.SafeParam("domain", domain),
+		svc1log.SafeParam("domain_sid", domainSID))
+
+	return domainObject, errors
+}
+
+// parseFunctionalLevel converts numeric functional level to readable string
+func (l *LibraryPentestLdap) parseFunctionalLevel(level string) string {
+	switch level {
+	case "0":
+		return "2000"
+	case "1":
+		return "2003 Interim"
+	case "2":
+		return "2003"
+	case "3":
+		return "2008"
+	case "4":
+		return "2008 R2"
+	case "5":
+		return "2012"
+	case "6":
+		return "2012 R2"
+	case "7":
+		return "2016"
+	case "8":
+		return "2019"
+	case "10":
+		return "2022"
+	default:
+		return fmt.Sprintf("Unknown (%s)", level)
+	}
+}
+
 // processDomainDumpActions processes all domain dump actions and returns the consolidated result
 func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn *ldap.Conn, baseDN string, config ldapfern.PentestLdapConfig) (*ldapfern.DomainDumpResult, []string) {
 	var errors []string
@@ -1449,6 +1823,14 @@ func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn 
 
 	// Create stealth context from config
 	stealthCtx := l.createStealthContext(ctx, config)
+
+	// Always enumerate the domain object itself first to get domain SID
+	domainObj, domainErrors := l.enumerateDomainObject(ctx, conn, baseDN, stealthCtx)
+	if domainObj != nil {
+		domainResult.Domain = domainObj
+		*domainResult.TotalObjects++
+	}
+	errors = append(errors, domainErrors...)
 
 	// Process each action
 	for _, action := range config.Actions {
@@ -1625,6 +2007,14 @@ func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, con
 	if dcs != nil {
 		domainResult.DomainControllers = *dcs
 		*domainResult.TotalObjects += len(*dcs)
+	}
+	*errors = append(*errors, errs...)
+
+	// Enumerate containers
+	containers, errs := l.enumerateContainers(ctx, conn, baseDN, maxResults, stealthCtx)
+	if containers != nil {
+		domainResult.Containers = *containers
+		*domainResult.TotalObjects += len(*containers)
 	}
 	*errors = append(*errors, errs...)
 }


### PR DESCRIPTION
### TL;DR

Enhanced domain enumeration capabilities by adding support for delegation types and additional domain objects.

### What changed?

- Added support for constrained delegation and resource-based constrained delegation (RBCD) for both users and computers
- Added new domain container object enumeration to discover important containers like Users, Computers, System, etc.
- Added domain object information collection to gather domain functional level and NetBIOS name
- Enhanced the schema to support these new object types and properties
- Implemented security descriptor parsing to extract RBCD principals

### How to test?

1. Run a domain dump against an Active Directory environment with delegation configured
2. Verify the output includes:
   - Constrained delegation information for users and computers
   - Resource-based constrained delegation data
   - Domain container objects
   - Domain functional level information
3. Check that delegation SPNs are correctly listed for objects with delegation configured

### Why make this change?

These enhancements provide more comprehensive Active Directory security assessment capabilities, particularly for detecting delegation-based attack paths. Constrained delegation and RBCD are important security features that can be misconfigured and abused for privilege escalation. Adding container enumeration and domain object details provides better context for security assessments and matches the data structure used by tools like BloodHound for attack path analysis.