### PR TITLE
Add principal and realm fields to Kerberos service ticket results

### DIFF
--- a/fern/definition/pentest/kerberos/serviceticket.yml
+++ b/fern/definition/pentest/kerberos/serviceticket.yml
@@ -17,6 +17,8 @@ types:
       spn: string # Service Principal Name used
       impersonateUser: optional<string> # User being impersonated (if any)
       requestingUser: string # User requesting the service ticket (from auth config)
+      principal: optional<string> # Principal name from the ticket
+      realm: optional<string> # Realm from the ticket
       ticketAcquired: boolean # Whether service ticket was successfully acquired
       ticketBase64: optional<string> # Base64-encoded ccache ticket data
       message: string # Result message or error details

--- a/internal/pentest/kerberos/serviceticket.go
+++ b/internal/pentest/kerberos/serviceticket.go
@@ -85,7 +85,7 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 	}
 
 	ticketManager := kerberos.NewTicketManager(krb5Client, cfg)
-	ticketBase64, err := ticketManager.RequestServiceTicket(ctx, requestingUser, target.Domain, impersonateUser, pentestConfig.Spn)
+	ticketInfo, err := ticketManager.RequestServiceTicket(ctx, requestingUser, target.Domain, impersonateUser, pentestConfig.Spn)
 	if err != nil {
 		return &kerberosfern.PentestKerberosServiceTicketResult{
 			Target:          pentestConfig.Targets[0],
@@ -105,8 +105,10 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 		Spn:             pentestConfig.Spn,
 		ImpersonateUser: pentestConfig.Impersonate,
 		RequestingUser:  requestingUser,
+		Principal:       &ticketInfo.Principal,
+		Realm:           &ticketInfo.Realm,
 		TicketAcquired:  true,
-		TicketBase64:    &ticketBase64,
+		TicketBase64:    &ticketInfo.Base64,
 		Message:         "Service ticket acquired successfully",
 		Timestamp:       time.Now(),
 	}, nil

--- a/internal/protocol/kerberos/ticket.go
+++ b/internal/protocol/kerberos/ticket.go
@@ -15,6 +15,13 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+// TicketInfo contains information extracted from a Kerberos ticket
+type TicketInfo struct {
+	Base64    string
+	Principal string
+	Realm     string
+}
+
 // TicketManager handles Kerberos ticket operations
 type TicketManager struct {
 	Client *client.Client
@@ -30,13 +37,13 @@ func NewTicketManager(client *client.Client, config *config.Config) *TicketManag
 }
 
 // RequestServiceTicket performs service ticket acquisition (with optional S4U2Self and S4U2Proxy for impersonation)
-func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUser, userDomain, impersonateUser, spn string) (string, error) {
+func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUser, userDomain, impersonateUser, spn string) (*TicketInfo, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Step 1: Get TGT for delegation user
 	tgt, sessionKey, err := tm.Client.GetTGT(strings.ToUpper(userDomain))
 	if err != nil {
-		return "", fmt.Errorf("failed to get TGT: %v", err)
+		return nil, fmt.Errorf("failed to get TGT: %v", err)
 	}
 
 	log.Debug("Successfully obtained TGT for requesting user")
@@ -47,7 +54,7 @@ func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUse
 
 		s4u2SelfTicket, err := s4uManager.PerformS4U2Self(ctx, requestingUser, userDomain, impersonateUser, tgt, sessionKey)
 		if err != nil {
-			return "", fmt.Errorf("S4U2Self failed: %v", err)
+			return nil, fmt.Errorf("S4U2Self failed: %v", err)
 		}
 
 		log.Debug("Successfully performed S4U2Self")
@@ -55,7 +62,7 @@ func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUse
 		// Step 3: Perform S4U2Proxy to get service ticket for target SPN
 		err = s4uManager.PerformS4U2Proxy(ctx, requestingUser, userDomain, impersonateUser, tgt, s4u2SelfTicket, sessionKey, spn)
 		if err != nil {
-			return "", fmt.Errorf("S4U2Proxy failed: %v", err)
+			return nil, fmt.Errorf("S4U2Proxy failed: %v", err)
 		}
 
 		log.Debug("Successfully performed S4U2Proxy")
@@ -63,7 +70,7 @@ func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUse
 		// Regular service ticket request without impersonation
 		_, _, err := tm.Client.GetServiceTicket(spn)
 		if err != nil {
-			return "", fmt.Errorf("failed to get service ticket: %v", err)
+			return nil, fmt.Errorf("failed to get service ticket: %v", err)
 		}
 
 		log.Debug("Successfully obtained service ticket")
@@ -79,10 +86,14 @@ func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUse
 
 	ticketBase64, err := tm.GenerateTicketBase64(ticketPrincipal, strings.ToUpper(userDomain), spn)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate ticket: %v", err)
+		return nil, fmt.Errorf("failed to generate ticket: %v", err)
 	}
 
-	return ticketBase64, nil
+	return &TicketInfo{
+		Base64:    ticketBase64,
+		Principal: ticketPrincipal,
+		Realm:     strings.ToUpper(userDomain),
+	}, nil
 }
 
 // GenerateTicketBase64 generates the acquired ticket as a base64-encoded ccache


### PR DESCRIPTION
### TL;DR

Enhanced Kerberos service ticket results to include principal and realm information.

### What changed?

- Added two new optional fields to the `PentestKerberosServiceTicketResult` type:
  - `principal`: The principal name extracted from the ticket
  - `realm`: The realm extracted from the ticket
- Created a new `TicketInfo` struct in the Kerberos protocol package to encapsulate ticket data
- Modified the `RequestServiceTicket` function to return the new `TicketInfo` struct instead of just the base64-encoded ticket

### How to test?

1. Request a Kerberos service ticket using the API
2. Verify that the response includes the new principal and realm fields
3. Confirm that the principal matches the expected user and the realm matches the expected domain

### Why make this change?

This change provides more detailed information about the acquired Kerberos tickets, making it easier for users to verify the ticket's identity information without having to decode the ticket themselves. The principal and realm fields are critical components of Kerberos authentication that help identify who the ticket belongs to and which authentication domain issued it.