### PR TITLE
Pluralize MSRPC command flag names for consistency

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -1345,9 +1345,9 @@ func (a *NetworkScan) createMSRPCPentestCommand(parent *cobra.Command) {
 	}
 
 	// Add basic flags
-	msrpcCmd.Flags().StringSlice("target", []string{}, "Target hosts (required)")
-	msrpcCmd.Flags().StringSlice("username", []string{}, "Usernames for authentication")
-	msrpcCmd.Flags().StringSlice("password", []string{}, "Passwords for authentication")
+	msrpcCmd.Flags().StringSlice("targets", []string{}, "Target hosts (required)")
+	msrpcCmd.Flags().StringSlice("usernames", []string{}, "Usernames for authentication")
+	msrpcCmd.Flags().StringSlice("passwords", []string{}, "Passwords for authentication")
 	msrpcCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
 	msrpcCmd.Flags().String("kerberos-ticket", "", "Base64-encoded Kerberos ticket (TGS) for ticket-based authentication")
 	msrpcCmd.Flags().String("domain", "", "Domain name (required for DCSync)")
@@ -1355,7 +1355,7 @@ func (a *NetworkScan) createMSRPCPentestCommand(parent *cobra.Command) {
 	msrpcCmd.Flags().Int("timeout", 10, "Connection timeout in seconds")
 
 	// Mark required flags
-	_ = msrpcCmd.MarkFlagRequired("target")
+	_ = msrpcCmd.MarkFlagRequired("targets")
 	_ = msrpcCmd.MarkFlagRequired("actions")
 	_ = msrpcCmd.MarkFlagRequired("domain")
 
@@ -1379,9 +1379,9 @@ func (a *NetworkScan) runMSRPCPentest(cmd *cobra.Command) {
 
 // getMSRPCPentestConfig extracts MSRPC pentest configuration from command flags
 func (a *NetworkScan) getMSRPCPentestConfig(cmd *cobra.Command) *msrpcfern.PentestMsrpcConfig {
-	targets, _ := cmd.Flags().GetStringSlice("target")
-	usernames, _ := cmd.Flags().GetStringSlice("username")
-	passwords, _ := cmd.Flags().GetStringSlice("password")
+	targets, _ := cmd.Flags().GetStringSlice("targets")
+	usernames, _ := cmd.Flags().GetStringSlice("usernames")
+	passwords, _ := cmd.Flags().GetStringSlice("passwords")
 	ntlmHash, _ := cmd.Flags().GetString("ntlm-hash")
 	kerberosTicket, _ := cmd.Flags().GetString("kerberos-ticket")
 	domain, _ := cmd.Flags().GetString("domain")


### PR DESCRIPTION
### TL;DR

Updated MSRPC pentest command flag names to use plural form for consistency.

### What changed?

- Changed the flag `target` to `targets`
- Changed the flag `username` to `usernames`
- Changed the flag `password` to `passwords`
- Updated the corresponding flag references in the `getMSRPCPentestConfig` function
- Updated the required flag marking for the renamed `targets` flag

### How to test?

1. Run the MSRPC pentest command with the new flag names:
   ```
   ./tool msrpc --targets 192.168.1.1,192.168.1.2 --usernames admin,user --passwords pass1,pass2 --domain example.com --actions enum
   ```
2. Verify that the command works as expected with the new flag names
3. Confirm that the old flag names no longer work

### Why make this change?

The flag names were inconsistent - some were singular while others were plural. This change standardizes all related flags to use plural form, which better represents that these flags accept multiple values (StringSlice type). This improves the command-line interface consistency and makes the API more intuitive for users.