### PR TITLE
Add SMB file download capability with remote-file-path flag

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -227,6 +227,8 @@ jobs:
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0.16.0
+        with:
+          syft-version: v1.17.0
 
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
@@ -295,4 +297,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          COSIGN_EXPERIMENTAL: "true" 
+          COSIGN_EXPERIMENTAL: "true"

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -265,6 +265,8 @@ Additional actions can be specified to layer more functionality on top.`,
 	// Command execution flags
 	smbCmd.Flags().StringSliceP("execute", "x", []string{}, "Commands to execute on successful auth")
 	smbCmd.Flags().String("command-file", "", "File containing commands to execute")
+	// File download flags
+	smbCmd.Flags().String("remote-file-path", "", "Remote file path to download (format: SHARE\\path\\to\\file)")
 
 	// Behavior flags
 	smbCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
@@ -468,6 +470,9 @@ func (a *NetworkScan) runSMBPentest(cmd *cobra.Command, args []string) {
 	commands, _ := cmd.Flags().GetStringSlice("execute")
 	commandFile, _ := cmd.Flags().GetString("command-file")
 
+	// Parse file download options
+	remoteFilePath, _ := cmd.Flags().GetString("remote-file-path")
+
 	// Parse behavior options
 	timeout, _ := cmd.Flags().GetInt("timeout")
 	stopFirstSuccess, _ := cmd.Flags().GetBool("stop-first-success")
@@ -512,7 +517,7 @@ func (a *NetworkScan) runSMBPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash)
+	config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, remoteFilePath, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -1103,7 +1108,7 @@ func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetSer
 }
 
 // getSMBPentestConfig creates a configuration for SMB pentest operations with the provided parameters.
-func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *smbfern.PentestSmbConfig {
+func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, remoteFilePath string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *smbfern.PentestSmbConfig {
 	var domainPtr, ntlmHashPtr *string
 	if domain != "" {
 		domainPtr = &domain
@@ -1120,17 +1125,26 @@ func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, u
 		}
 	}
 
+	// Create share download config if remote file path is provided
+	var shareDownloadConfig *smbfern.ShareDownloadConfig
+	if remoteFilePath != "" {
+		shareDownloadConfig = &smbfern.ShareDownloadConfig{
+			RemoteFilePath: remoteFilePath,
+		}
+	}
+
 	return &smbfern.PentestSmbConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Domain:           domainPtr,
-		NtlmHash:         ntlmHashPtr,
-		ExecConfig:       execConfig,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
+		Targets:             targets,
+		Actions:             actions,
+		Usernames:           usernames,
+		Passwords:           passwords,
+		Domain:              domainPtr,
+		NtlmHash:            ntlmHashPtr,
+		ExecConfig:          execConfig,
+		ShareDownloadConfig: shareDownloadConfig,
+		Timeout:             timeout,
+		StopFirstSuccess:    &stopFirstSuccess,
+		SuccessfulOnly:      &successfulOnly,
 	}
 }
 
@@ -1308,12 +1322,6 @@ func (a *NetworkScan) buildKerberosConfig(cmd *cobra.Command, targets []string, 
 				impersonatePtr = &impersonate
 			}
 			serviceTicketConfig = &kerberosfern.PentestKerberosServiceTicketConfig{
-				Targets:     targets,
-				Usernames:   usernames,
-				Passwords:   passwords,
-				Domain:      domainPtr,
-				NtlmHash:    ntlmHashPtr,
-				Timeout:     timeout,
 				Spn:         spn,
 				Impersonate: impersonatePtr,
 			}
@@ -1346,8 +1354,8 @@ func (a *NetworkScan) createMSRPCPentestCommand(parent *cobra.Command) {
 
 	// Add basic flags
 	msrpcCmd.Flags().StringSlice("targets", []string{}, "Target hosts (required)")
-	msrpcCmd.Flags().StringSlice("usernames", []string{}, "Usernames for authentication")
-	msrpcCmd.Flags().StringSlice("passwords", []string{}, "Passwords for authentication")
+	msrpcCmd.Flags().StringSliceP("usernames", "u", []string{}, "Username for authentication")
+	msrpcCmd.Flags().StringSliceP("passwords", "p", []string{}, "Password for authentication")
 	msrpcCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
 	msrpcCmd.Flags().String("kerberos-ticket", "", "Base64-encoded Kerberos ticket (TGS) for ticket-based authentication")
 	msrpcCmd.Flags().String("domain", "", "Domain name (required for DCSync)")

--- a/fern/definition/pentest/kerberos/serviceticket.yml
+++ b/fern/definition/pentest/kerberos/serviceticket.yml
@@ -5,7 +5,6 @@ types:
   # Kerberos Service Ticket request configuration
   # Supports regular ST requests, traditional constrained delegation, and resource-based constrained delegation
   PentestKerberosServiceTicketConfig:
-    extends: common.PentestGeneralConfig
     properties:
       spn: string # Target Service Principal Name (e.g., "HTTP/server.domain.com")
       impersonate: optional<string> # Username to impersonate (for delegation attacks, optional for regular ST requests)
@@ -24,6 +23,17 @@ types:
       message: string # Result message or error details
       timestamp: datetime # When the operation was performed
       errors: optional<list<string>> # Any errors encountered
+
+      # Enhanced ticket metadata
+      servicePrincipal: optional<string> # Full service principal name from ticket
+      startTime: optional<datetime> # When ticket becomes valid
+      endTime: optional<datetime> # Ticket expiration time
+      renewUntil: optional<datetime> # Ticket renewal expiration time
+      ticketFlags: optional<string> # Comma-separated ticket flags (e.g., "FORWARDABLE,RENEWABLE")
+      encryptionType: optional<string> # Encryption algorithm used (e.g., "AES256-CTS-HMAC-SHA1-96")
+      keyVersionNumber: optional<integer> # Key version number (KVNO)
+      algorithm: optional<string> # Algorithm name for compatibility
+      ticketVersionNumber: optional<integer> # Ticket version number
 
   # Final report structure for Kerberos Service Ticket
   PentestKerberosServiceTicketReport:

--- a/fern/definition/pentest/smb/sharedownload.yml
+++ b/fern/definition/pentest/smb/sharedownload.yml
@@ -1,0 +1,17 @@
+imports:
+  smbProtocol: ../../common/protocol/smb.yml
+
+types:
+  ShareDownloadConfig:
+    properties:
+      remoteFilePath: string
+
+  # Share download result
+  ShareDownloadResult:
+    properties:
+      target: string
+      remoteFilePath: string # The remote file path that was downloaded
+      content: optional<string> # File content (for text files)
+      size: optional<integer> # File size in bytes
+      downloaded: boolean # Whether the download was successful
+      errors: optional<list<string>> # Any errors during download

--- a/fern/definition/pentest/smb/sharesmap.yml
+++ b/fern/definition/pentest/smb/sharesmap.yml
@@ -2,8 +2,8 @@ imports:
   smbProtocol: ../../common/protocol/smb.yml
 
 types:
-  # Shares enumeration result
-  SharesResult:
+  # Shares mapping/enumeration result
+  SharesMapResult:
     properties:
       target: string
       shares: optional<list<smbProtocol.SmbShare>>  # List of discovered shares

--- a/fern/definition/pentest/smb/smb.yml
+++ b/fern/definition/pentest/smb/smb.yml
@@ -5,7 +5,8 @@ imports:
   auth: ./auth.yml
   samdump: ./samdump.yml
   lsadump: ./lsadump.yml
-  shares: ./shares.yml
+  sharesmap: ./sharesmap.yml
+  sharedownload: ./sharedownload.yml
   exec: ./exec.yml
 
 types:
@@ -16,7 +17,8 @@ types:
       - AUTH # Authentication/credential testing (bruteforce)
       - SAMDUMP # Extract SAM hashes from Windows registry
       - LSADUMP # Extract LSA secrets from Windows registry
-      - SHARES # Enumerate accessible shares and permissions
+      - SHARES_MAP # Enumerate accessible shares and permissions
+      - SHARE_DOWNLOAD # Download files from SMB shares
       - EXEC # Execute commands via SMB/WMI/MSRPC
 
   # SMB Result Types - union of all action results
@@ -26,7 +28,8 @@ types:
       AuthResult: auth.AuthResult
       SamdumpResult: samdump.SamdumpResult
       LsadumpResult: lsadump.LsadumpResult
-      SharesResult: shares.SharesResult
+      SharesMapResult: sharesmap.SharesMapResult
+      ShareDownloadResult: sharedownload.ShareDownloadResult
       ExecResult: exec.ExecResult
 
   # Container for list of incremental SMB results from phased approach
@@ -40,6 +43,7 @@ types:
     properties:
       actions: list<PentestSmbAction>
       execConfig: optional<exec.ExecConfig> # Command execution configuration
+      shareDownloadConfig: optional<sharedownload.ShareDownloadConfig>
 
   # Final report structure
   PentestSmbReport:

--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -223,13 +223,21 @@ func (e *Engine) executeSMBActionsWithAuthenticatedClient(ctx context.Context, t
 			} else {
 				results = append(results, smbfern.NewPentestSmbResultFromLsadumpResult(lsadumpResult))
 			}
-		case smbfern.PentestSmbActionShares:
-			log.Debug("Performing " + string(smbfern.PentestSmbActionShares))
-			sharesResult, err := smbpentest.PerformShares(ctx, target, config, authenticatedSession)
+		case smbfern.PentestSmbActionSharesMap:
+			log.Debug("Performing " + string(smbfern.PentestSmbActionSharesMap))
+			sharesResult, err := smbpentest.PerformSharesMap(ctx, target, config, authenticatedSession)
 			if err != nil {
-				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionShares), err))
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionSharesMap), err))
 			} else {
-				results = append(results, smbfern.NewPentestSmbResultFromSharesResult(sharesResult))
+				results = append(results, smbfern.NewPentestSmbResultFromSharesMapResult(sharesResult))
+			}
+		case smbfern.PentestSmbActionShareDownload:
+			log.Debug("Performing " + string(smbfern.PentestSmbActionShareDownload))
+			shareDownloadResult, err := smbpentest.PerformShareDownload(ctx, target, config, authenticatedSession)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionShareDownload), err))
+			} else {
+				results = append(results, smbfern.NewPentestSmbResultFromShareDownloadResult(shareDownloadResult))
 			}
 		case smbfern.PentestSmbActionExec:
 			log.Debug("Performing " + string(smbfern.PentestSmbActionExec))
@@ -296,13 +304,21 @@ func (e *Engine) executeSMBActionsWithAuth(ctx context.Context, target string, c
 				results = append(results, smbfern.NewPentestSmbResultFromLsadumpResult(lsadumpResult))
 			}
 
-		case smbfern.PentestSmbActionShares:
-			log.Debug("Performing " + string(smbfern.PentestSmbActionShares))
-			sharesResult, err := smbpentest.PerformShares(ctx, target, config, authenticatedSession)
+		case smbfern.PentestSmbActionSharesMap:
+			log.Debug("Performing " + string(smbfern.PentestSmbActionSharesMap))
+			sharesResult, err := smbpentest.PerformSharesMap(ctx, target, config, authenticatedSession)
 			if err != nil {
-				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionShares), err))
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionSharesMap), err))
 			} else {
-				results = append(results, smbfern.NewPentestSmbResultFromSharesResult(sharesResult))
+				results = append(results, smbfern.NewPentestSmbResultFromSharesMapResult(sharesResult))
+			}
+		case smbfern.PentestSmbActionShareDownload:
+			log.Debug("Performing " + string(smbfern.PentestSmbActionShareDownload))
+			shareDownloadResult, err := smbpentest.PerformShareDownload(ctx, target, config, authenticatedSession)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionShareDownload), err))
+			} else {
+				results = append(results, smbfern.NewPentestSmbResultFromShareDownloadResult(shareDownloadResult))
 			}
 		case smbfern.PentestSmbActionExec:
 			log.Debug("Performing " + string(smbfern.PentestSmbActionExec))
@@ -884,7 +900,7 @@ func (e *Engine) RunKerberosPentest(ctx context.Context, config *kerberosfern.Pe
 			}
 
 			log.Info("Performing Kerberos service ticket request")
-			serviceTicketResult, err := kerberospentest.RequestServiceTicket(ctx, config.ServiceTicketConfig)
+			serviceTicketResult, err := kerberospentest.RequestServiceTicket(ctx, config, config.ServiceTicketConfig)
 			if err != nil {
 				allErrors = append(allErrors, fmt.Sprintf("Service ticket request failed: %v", err))
 				continue

--- a/internal/pentest/kerberos/serviceticket.go
+++ b/internal/pentest/kerberos/serviceticket.go
@@ -12,31 +12,31 @@ import (
 )
 
 // RequestServiceTicket requests a Kerberos service ticket (supports regular requests, traditional CD, and RBCD)
-func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.PentestKerberosServiceTicketConfig) (*kerberosfern.PentestKerberosServiceTicketResult, error) {
+func RequestServiceTicket(ctx context.Context, generalConfig *kerberosfern.PentestKerberosConfig, serviceTicketConfig *kerberosfern.PentestKerberosServiceTicketConfig) (*kerberosfern.PentestKerberosServiceTicketResult, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Parse the target to extract host and port information
-	target, err := kerberos.ParseTarget(pentestConfig.Targets[0])
+	target, err := kerberos.ParseTarget(generalConfig.Targets[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse target: %v", err)
 	}
 
 	// Use the domain from the configuration instead of trying to extract from target
-	if pentestConfig.Domain != nil && *pentestConfig.Domain != "" {
-		target.Domain = strings.ToUpper(*pentestConfig.Domain)
+	if generalConfig.Domain != nil && *generalConfig.Domain != "" {
+		target.Domain = strings.ToUpper(*generalConfig.Domain)
 	}
 
 	log.Info("Starting Kerberos service ticket request",
-		svc1log.SafeParam("target", pentestConfig.Targets[0]),
-		svc1log.SafeParam("spn", pentestConfig.Spn),
-		svc1log.SafeParam("impersonate", pentestConfig.Impersonate))
+		svc1log.SafeParam("target", generalConfig.Targets[0]),
+		svc1log.SafeParam("spn", serviceTicketConfig.Spn),
+		svc1log.SafeParam("impersonate", serviceTicketConfig.Impersonate))
 
 	// Validate SPN format
-	if err := validateSPN(pentestConfig.Spn); err != nil {
+	if err := validateSPN(serviceTicketConfig.Spn); err != nil {
 		return &kerberosfern.PentestKerberosServiceTicketResult{
-			Target:          pentestConfig.Targets[0],
-			Spn:             pentestConfig.Spn,
-			ImpersonateUser: pentestConfig.Impersonate,
+			Target:          generalConfig.Targets[0],
+			Spn:             serviceTicketConfig.Spn,
+			ImpersonateUser: serviceTicketConfig.Impersonate,
 			RequestingUser:  "",
 			TicketAcquired:  false,
 			Message:         err.Error(),
@@ -49,12 +49,12 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 	cfg := clientManager.CreateConfiguration()
 
 	// Set up client with appropriate credentials from unified auth config
-	krb5Client, requestingUser, err := clientManager.CreateClientFromConfig(pentestConfig)
+	krb5Client, requestingUser, err := clientManager.CreateClientFromConfig(generalConfig)
 	if err != nil {
 		return &kerberosfern.PentestKerberosServiceTicketResult{
-			Target:          pentestConfig.Targets[0],
-			Spn:             pentestConfig.Spn,
-			ImpersonateUser: pentestConfig.Impersonate,
+			Target:          generalConfig.Targets[0],
+			Spn:             serviceTicketConfig.Spn,
+			ImpersonateUser: serviceTicketConfig.Impersonate,
 			RequestingUser:  "",
 			TicketAcquired:  false,
 			Message:         err.Error(),
@@ -66,9 +66,9 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 	err = krb5Client.Login()
 	if err != nil {
 		return &kerberosfern.PentestKerberosServiceTicketResult{
-			Target:          pentestConfig.Targets[0],
-			Spn:             pentestConfig.Spn,
-			ImpersonateUser: pentestConfig.Impersonate,
+			Target:          generalConfig.Targets[0],
+			Spn:             serviceTicketConfig.Spn,
+			ImpersonateUser: serviceTicketConfig.Impersonate,
 			RequestingUser:  requestingUser,
 			TicketAcquired:  false,
 			Message:         fmt.Sprintf("Failed to authenticate delegation user: %v", err),
@@ -80,17 +80,17 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 
 	// Perform service ticket request (with optional impersonation via S4U2Self and S4U2Proxy)
 	var impersonateUser string
-	if pentestConfig.Impersonate != nil {
-		impersonateUser = *pentestConfig.Impersonate
+	if serviceTicketConfig.Impersonate != nil {
+		impersonateUser = *serviceTicketConfig.Impersonate
 	}
 
 	ticketManager := kerberos.NewTicketManager(krb5Client, cfg)
-	ticketInfo, err := ticketManager.RequestServiceTicket(ctx, requestingUser, target.Domain, impersonateUser, pentestConfig.Spn)
+	ticketInfo, err := ticketManager.RequestServiceTicket(ctx, requestingUser, target.Domain, impersonateUser, serviceTicketConfig.Spn)
 	if err != nil {
 		return &kerberosfern.PentestKerberosServiceTicketResult{
-			Target:          pentestConfig.Targets[0],
-			Spn:             pentestConfig.Spn,
-			ImpersonateUser: pentestConfig.Impersonate,
+			Target:          generalConfig.Targets[0],
+			Spn:             serviceTicketConfig.Spn,
+			ImpersonateUser: serviceTicketConfig.Impersonate,
 			RequestingUser:  requestingUser,
 			TicketAcquired:  false,
 			Message:         fmt.Sprintf("Service ticket request failed: %v", err),
@@ -101,9 +101,9 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 	log.Info("Successfully acquired service ticket")
 
 	return &kerberosfern.PentestKerberosServiceTicketResult{
-		Target:          pentestConfig.Targets[0],
-		Spn:             pentestConfig.Spn,
-		ImpersonateUser: pentestConfig.Impersonate,
+		Target:          generalConfig.Targets[0],
+		Spn:             serviceTicketConfig.Spn,
+		ImpersonateUser: serviceTicketConfig.Impersonate,
 		RequestingUser:  requestingUser,
 		Principal:       &ticketInfo.Principal,
 		Realm:           &ticketInfo.Realm,
@@ -111,6 +111,17 @@ func RequestServiceTicket(ctx context.Context, pentestConfig *kerberosfern.Pente
 		TicketBase64:    &ticketInfo.Base64,
 		Message:         "Service ticket acquired successfully",
 		Timestamp:       time.Now(),
+
+		// Enhanced ticket metadata
+		ServicePrincipal:    ticketInfo.ServicePrincipal,
+		StartTime:           ticketInfo.StartTime,
+		EndTime:             ticketInfo.EndTime,
+		RenewUntil:          ticketInfo.RenewUntil,
+		TicketFlags:         ticketInfo.TicketFlags,
+		EncryptionType:      ticketInfo.EncryptionType,
+		KeyVersionNumber:    ticketInfo.KeyVersionNumber,
+		Algorithm:           ticketInfo.Algorithm,
+		TicketVersionNumber: ticketInfo.TicketVersionNumber,
 	}, nil
 }
 

--- a/internal/pentest/smb/sharedownload.go
+++ b/internal/pentest/smb/sharedownload.go
@@ -1,0 +1,131 @@
+package smb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
+	"github.com/Method-Security/networkscan/utils"
+	gosmb "github.com/jfjallid/go-smb/smb"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// PerformShareDownload downloads a file from SMB share using the provided authenticated session
+func PerformShareDownload(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authenticatedSession *gosmb.Connection) (*smbfern.ShareDownloadResult, error) {
+	log := svc1log.FromContext(ctx)
+	log.Info("Starting SMB share file download using authenticated session", svc1log.SafeParam("target", target))
+
+	host, port := utils.ParseHostPort(target, 445)
+	// Set the actual connection target (ip:port)
+	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+
+	result := &smbfern.ShareDownloadResult{
+		Target:     connectionTarget,
+		Downloaded: false,
+	}
+
+	var errors []string
+
+	// Check if remote file path is provided in config
+	if config.ShareDownloadConfig == nil || config.ShareDownloadConfig.RemoteFilePath == "" {
+		errors = append(errors, "No remote file path specified. Use --remote-file-path flag to specify the file to download")
+		result.Errors = errors
+		return result, nil
+	}
+
+	remotePath := config.ShareDownloadConfig.RemoteFilePath
+	result.RemoteFilePath = remotePath
+
+	// Parse the remote path to get share and file path
+	pathParts := strings.SplitN(remotePath, "\\", 2)
+	if len(pathParts) < 2 {
+		errors = append(errors, "Invalid remote path format. Expected format: SHARE\\path\\to\\file")
+		result.Errors = errors
+		return result, nil
+	}
+
+	shareName := pathParts[0]
+	filePath := pathParts[1]
+
+	log.Info("Attempting to download file from SMB share",
+		svc1log.SafeParam("share", shareName),
+		svc1log.SafeParam("filePath", filePath),
+		svc1log.SafeParam("target", target))
+
+	// Download the file content
+	content, size, err := downloadFileFromShare(ctx, authenticatedSession, shareName, filePath, log)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("File download failed: %v", err))
+	} else {
+		result.Downloaded = true
+		result.Content = &content
+		result.Size = &size
+		log.Info("File download completed successfully",
+			svc1log.SafeParam("size", size),
+			svc1log.SafeParam("target", target))
+	}
+
+	if len(errors) > 0 {
+		result.Errors = errors
+	}
+
+	log.Info("SMB share file download completed", svc1log.SafeParam("target", target))
+	return result, nil
+}
+
+// downloadFileFromShare downloads a file from the specified SMB share
+func downloadFileFromShare(ctx context.Context, conn *gosmb.Connection, shareName, filePath string, log svc1log.Logger) (string, int, error) {
+	// Connect to the share
+	err := conn.TreeConnect(shareName)
+	if err != nil {
+		log.Debug("Failed to connect to share",
+			svc1log.SafeParam("share", shareName),
+			svc1log.SafeParam("error", err.Error()))
+		return "", 0, fmt.Errorf("failed to connect to share %s: %v", shareName, err)
+	}
+	defer func() {
+		_ = conn.TreeDisconnect(shareName)
+	}()
+
+	// Use strings.Builder to collect the file content
+	var content strings.Builder
+	totalSize := 0
+
+	// RetrieveFile function that writes to our content builder
+	writeFunc := func(data []byte) (int, error) {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+		}
+
+		n, err := content.Write(data)
+		if err != nil {
+			return n, err
+		}
+		totalSize += n
+
+		// Limit file size to prevent memory issues (e.g., 1MB limit)
+		if totalSize > 1024*1024 {
+			return n, fmt.Errorf("file size exceeds limit of 1MB, truncating")
+		}
+
+		return n, nil
+	}
+
+	// Use the SMB library's RetrieveFile method (same as go-shareenum)
+	err = conn.RetrieveFile(shareName, filePath, 0, writeFunc)
+	if err != nil {
+		log.Debug("Failed to retrieve file",
+			svc1log.SafeParam("share", shareName),
+			svc1log.SafeParam("filePath", filePath),
+			svc1log.SafeParam("error", err.Error()))
+		return "", 0, fmt.Errorf("failed to retrieve file %s: %v", filePath, err)
+	}
+
+	log.Debug("File download completed",
+		svc1log.SafeParam("size", totalSize))
+
+	return content.String(), totalSize, nil
+}

--- a/internal/pentest/smb/sharesmap.go
+++ b/internal/pentest/smb/sharesmap.go
@@ -15,8 +15,8 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-// PerformShares performs share enumeration using the provided authenticated session
-func PerformShares(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authenticatedSession *gosmb.Connection) (*smbfern.SharesResult, error) {
+// PerformSharesMap performs share enumeration using the provided authenticated session
+func PerformSharesMap(ctx context.Context, target string, config *smbfern.PentestSmbConfig, authenticatedSession *gosmb.Connection) (*smbfern.SharesMapResult, error) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting SMB share enumeration using authenticated session", svc1log.SafeParam("target", target))
 
@@ -24,7 +24,7 @@ func PerformShares(ctx context.Context, target string, config *smbfern.PentestSm
 	// Set the actual connection target (ip:port)
 	connectionTarget := fmt.Sprintf("%s:%d", host, port)
 
-	result := &smbfern.SharesResult{
+	result := &smbfern.SharesMapResult{
 		Target: connectionTarget,
 	}
 

--- a/internal/protocol/kerberos/client.go
+++ b/internal/protocol/kerberos/client.go
@@ -68,7 +68,7 @@ func (kcm *ClientManager) CreateConfiguration() *config.Config {
 }
 
 // CreateClientFromConfig creates a Kerberos client from the provided config
-func (kcm *ClientManager) CreateClientFromConfig(pentestConfig *kerberosfern.PentestKerberosServiceTicketConfig) (*client.Client, string, error) {
+func (kcm *ClientManager) CreateClientFromConfig(pentestConfig *kerberosfern.PentestKerberosConfig) (*client.Client, string, error) {
 	if kcm.Config == nil {
 		kcm.CreateConfiguration()
 	}

--- a/internal/protocol/kerberos/ticket.go
+++ b/internal/protocol/kerberos/ticket.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jfjallid/gokrb5/v8/client"
 	"github.com/jfjallid/gokrb5/v8/config"
@@ -20,6 +21,17 @@ type TicketInfo struct {
 	Base64    string
 	Principal string
 	Realm     string
+
+	// Enhanced ticket metadata
+	ServicePrincipal    *string
+	StartTime           *time.Time
+	EndTime             *time.Time
+	RenewUntil          *time.Time
+	TicketFlags         *string
+	EncryptionType      *string
+	KeyVersionNumber    *int
+	Algorithm           *string
+	TicketVersionNumber *int
 }
 
 // TicketManager handles Kerberos ticket operations
@@ -76,7 +88,7 @@ func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUse
 		log.Debug("Successfully obtained service ticket")
 	}
 
-	// Step 4: Generate base64 encoded ccache
+	// Common path: Extract ticket information after successful acquisition
 	var ticketPrincipal string
 	if impersonateUser != "" {
 		ticketPrincipal = impersonateUser
@@ -84,16 +96,8 @@ func (tm *TicketManager) RequestServiceTicket(ctx context.Context, requestingUse
 		ticketPrincipal = requestingUser
 	}
 
-	ticketBase64, err := tm.GenerateTicketBase64(ticketPrincipal, strings.ToUpper(userDomain), spn)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate ticket: %v", err)
-	}
-
-	return &TicketInfo{
-		Base64:    ticketBase64,
-		Principal: ticketPrincipal,
-		Realm:     strings.ToUpper(userDomain),
-	}, nil
+	// Use modular extraction method that works for both regular and impersonation flows
+	return tm.extractEnhancedTicketInfo(spn, ticketPrincipal, strings.ToUpper(userDomain))
 }
 
 // GenerateTicketBase64 generates the acquired ticket as a base64-encoded ccache
@@ -126,4 +130,165 @@ func (tm *TicketManager) GenerateTicketBase64(impersonateUser, userDomain, spn s
 // GetTGT retrieves a Ticket Granting Ticket for the specified domain
 func (tm *TicketManager) GetTGT(userDomain string) (messages.Ticket, types.EncryptionKey, error) {
 	return tm.Client.GetTGT(strings.ToUpper(userDomain))
+}
+
+// extractEnhancedTicketInfo extracts comprehensive ticket information for both regular and impersonation flows
+func (tm *TicketManager) extractEnhancedTicketInfo(spn, principal, realm string) (*TicketInfo, error) {
+	ticketInfo := &TicketInfo{
+		Principal:        principal,
+		Realm:            realm,
+		ServicePrincipal: &spn,
+	}
+
+	// Try to extract enhanced information by attempting to get the service ticket from client
+	// This works for both regular tickets and tickets added via S4U delegation
+	if ticket, sessionKey, err := tm.tryGetServiceTicketFromClient(spn); err == nil {
+		// Successfully retrieved ticket - extract enhanced metadata
+		tm.populateTicketMetadata(ticketInfo, ticket, sessionKey)
+	}
+
+	// Generate base64 encoded ccache and extract timing info from it
+	ticketBase64, err := tm.generateTicketWithTiming(ticketInfo, principal, realm, spn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ticket: %v", err)
+	}
+	ticketInfo.Base64 = ticketBase64
+
+	return ticketInfo, nil
+}
+
+// tryGetServiceTicketFromClient attempts to retrieve the service ticket from the client
+// This works for both regular tickets and tickets added via S4U delegation
+func (tm *TicketManager) tryGetServiceTicketFromClient(spn string) (messages.Ticket, types.EncryptionKey, error) {
+	// Try to get the service ticket - this should work whether it was obtained
+	// through regular GetServiceTicket or added via S4U delegation
+	return tm.Client.GetServiceTicket(spn)
+}
+
+// generateTicketWithTiming generates the base64 ccache AND extracts timing information from it
+func (tm *TicketManager) generateTicketWithTiming(ticketInfo *TicketInfo, principal, realm, spn string) (string, error) {
+	// Create ccache
+	cache := credentials.NewV4CCache()
+	clientPrincipal := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, principal)
+	principalObj := credentials.NewPrincipal(clientPrincipal, realm)
+	cache.SetDefaultPrincipal(principalObj)
+	cache.SetKDCTimeOffset(0xFFFFFFFF, 0)
+
+	// Save the service ticket to ccache - this includes timing information!
+	err := tm.Client.SaveSPNToCCache(cache, clientPrincipal, realm, spn, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to save SPN to ccache: %v", err)
+	}
+
+	// Extract timing information from the ccache entries BEFORE marshaling
+	tm.extractTimingFromCCache(ticketInfo, cache, spn)
+
+	// Marshal ccache to bytes
+	cacheBytes, err := cache.Marshal()
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal ccache: %v", err)
+	}
+
+	// Encode as base64
+	return base64.StdEncoding.EncodeToString(cacheBytes), nil
+}
+
+// extractTimingFromCCache extracts timing information from the ccache entries
+func (tm *TicketManager) extractTimingFromCCache(ticketInfo *TicketInfo, cache *credentials.CCache, spn string) {
+	// Iterate through cache entries to find our service ticket
+	for _, entry := range cache.GetEntries() {
+		// Check if this entry matches our SPN
+		if tm.matchesSPN(entry, spn) {
+			// Extract timing information from the cache entry
+			if !entry.StartTime.IsZero() {
+				ticketInfo.StartTime = &entry.StartTime
+			}
+			if !entry.EndTime.IsZero() {
+				ticketInfo.EndTime = &entry.EndTime
+			}
+			if !entry.RenewTill.IsZero() {
+				ticketInfo.RenewUntil = &entry.RenewTill
+			}
+			break
+		}
+	}
+}
+
+// matchesSPN checks if a cache entry matches the given SPN
+func (tm *TicketManager) matchesSPN(entry *credentials.Credential, spn string) bool {
+	// Convert entry SPN to string and compare (from Server.PrincipalName)
+	if len(entry.Server.PrincipalName.NameString) >= 2 {
+		entrySPN := strings.Join(entry.Server.PrincipalName.NameString, "/")
+		return entrySPN == spn
+	}
+	return false
+}
+
+// populateTicketMetadata populates the TicketInfo with enhanced metadata from the ticket and session key
+func (tm *TicketManager) populateTicketMetadata(ticketInfo *TicketInfo, ticket messages.Ticket, sessionKey types.EncryptionKey) {
+	// Extract ticket version number
+	if ticket.TktVNO != 0 {
+		tktVNO := ticket.TktVNO
+		ticketInfo.TicketVersionNumber = &tktVNO
+	}
+
+	// Extract key version number if available
+	if ticket.EncPart.KVNO != 0 {
+		kvno := ticket.EncPart.KVNO
+		ticketInfo.KeyVersionNumber = &kvno
+	}
+
+	// Extract encryption type from session key
+	if sessionKey.KeyType != 0 {
+		encType := tm.getEncryptionTypeName(sessionKey.KeyType)
+		ticketInfo.EncryptionType = &encType
+		ticketInfo.Algorithm = &encType // For compatibility
+	}
+
+	// Try to extract timing information from decrypted ticket part
+	tm.extractTimingInfo(ticketInfo, ticket, sessionKey)
+}
+
+// extractTimingInfo attempts to extract timing information from the ticket's encrypted part
+func (tm *TicketManager) extractTimingInfo(ticketInfo *TicketInfo, ticket messages.Ticket, sessionKey types.EncryptionKey) {
+	// Check if ticket already has decrypted part
+	if ticket.DecryptedEncPart.EndTime.IsZero() {
+		// Try to decrypt the ticket part to access timing information
+		// Note: This requires the service key, which we typically don't have as a client
+		// The timing info would need to be extracted differently, possibly from the TGS response
+		return
+	}
+
+	// If we have decrypted timing info, extract it
+	if !ticket.DecryptedEncPart.StartTime.IsZero() {
+		ticketInfo.StartTime = &ticket.DecryptedEncPart.StartTime
+	}
+
+	if !ticket.DecryptedEncPart.EndTime.IsZero() {
+		ticketInfo.EndTime = &ticket.DecryptedEncPart.EndTime
+	}
+
+	if !ticket.DecryptedEncPart.RenewTill.IsZero() {
+		ticketInfo.RenewUntil = &ticket.DecryptedEncPart.RenewTill
+	}
+}
+
+// getEncryptionTypeName returns the human-readable name for an encryption type
+func (tm *TicketManager) getEncryptionTypeName(etypeID int32) string {
+	switch etypeID {
+	case 17:
+		return "AES128-CTS-HMAC-SHA1-96"
+	case 18:
+		return "AES256-CTS-HMAC-SHA1-96"
+	case 19:
+		return "AES128-CTS-HMAC-SHA256-128"
+	case 20:
+		return "AES256-CTS-HMAC-SHA384-192"
+	case 23:
+		return "RC4-HMAC"
+	case 16:
+		return "DES3-CBC-SHA1-KD"
+	default:
+		return fmt.Sprintf("Unknown-EType-%d", etypeID)
+	}
 }

--- a/utils/action_parser.go
+++ b/utils/action_parser.go
@@ -39,7 +39,7 @@ func (p *SMBActionParser) ParseActions(actionStrings []string) ([]smbfern.Pentes
 }
 
 func (p *SMBActionParser) GetValidActions() []string {
-	return []string{"PROBE", "AUTH", "SAMDUMP", "LSADUMP", "SHARES", "EXEC"}
+	return []string{"PROBE", "AUTH", "SAMDUMP", "LSADUMP", "SHARES_MAP", "SHARE_DOWNLOAD", "EXEC"}
 }
 
 func (p *SMBActionParser) ContainsAction(actions []smbfern.PentestSmbAction, target smbfern.PentestSmbAction) bool {


### PR DESCRIPTION
### TL;DR

Added SMB file download capability and enhanced Kerberos ticket metadata.

### What changed?

- Added a new SMB action `SHARE_DOWNLOAD` to download files from SMB shares
- Added a new flag `--remote-file-path` to specify the file to download (format: `SHARE\path\to\file`)
- Renamed the existing `SHARES` action to `SHARES_MAP` for clarity
- Enhanced Kerberos service ticket results with additional metadata:
  - Service principal name
  - Ticket validity times (start, end, renewal)
  - Encryption type and key version information
  - Ticket flags and version numbers
- Fixed MSRPC command flags to use short forms (`-u` and `-p`)
- Removed redundant properties from `PentestKerberosServiceTicketConfig` that were already in the parent config

### How to test?

1. Test SMB file download:
   ```
   networkscan pentest smb --targets 192.168.1.10 --usernames Administrator --passwords Password123 --actions SHARE_DOWNLOAD --remote-file-path "C$\Windows\win.ini"
   ```

2. Test Kerberos service ticket with enhanced metadata:
   ```
   networkscan pentest kerberos --targets dc.domain.local --usernames user --passwords pass --domain domain.local --actions SERVICE_TICKET --spn HTTP/server.domain.local
   ```

### Why make this change?

The SMB file download capability allows users to retrieve specific files from remote systems during penetration testing, which is a common requirement for evidence collection and further analysis. The enhanced Kerberos ticket metadata provides more detailed information about acquired tickets, helping security professionals better understand ticket properties and potential security implications.