### PR TITLE
Fix LDAP NTLM hash authentication with proper hash format

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -388,7 +388,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	ldapCmd.Flags().String("password-file", "", "File containing passwords (one per line)")
 	ldapCmd.Flags().String("credentials", "", "Credentials in user:pass format")
 	ldapCmd.Flags().StringP("domain", "d", "", "Domain for authentication")
-	ldapCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
+	ldapCmd.Flags().StringSlice("ntlm-hashes", []string{}, "NTLM hashes for pass-the-hash authentication")
 
 	// Behavior flags
 	ldapCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
@@ -721,7 +721,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	passwordFile, _ := cmd.Flags().GetString("password-file")
 	credentials, _ := cmd.Flags().GetString("credentials")
 	domain, _ := cmd.Flags().GetString("domain")
-	ntlmHash, _ := cmd.Flags().GetString("ntlm-hash")
+	ntlmHashes, _ := cmd.Flags().GetStringSlice("ntlm-hashes")
 
 	// Parse behavior options
 	timeout, _ := cmd.Flags().GetInt("timeout")
@@ -768,6 +768,12 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 			usernames = append(usernames, parts[0])
 			passwords = append(passwords, parts[1])
 		}
+	}
+
+	// Get first NTLM hash if provided (only support one hash for now)
+	var ntlmHash string
+	if len(ntlmHashes) > 0 {
+		ntlmHash = ntlmHashes[0]
 	}
 
 	// Set Config

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -388,7 +388,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	ldapCmd.Flags().String("password-file", "", "File containing passwords (one per line)")
 	ldapCmd.Flags().String("credentials", "", "Credentials in user:pass format")
 	ldapCmd.Flags().StringP("domain", "d", "", "Domain for authentication")
-	ldapCmd.Flags().StringSlice("ntlm-hashes", []string{}, "NTLM hashes for pass-the-hash authentication")
+	ldapCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
 
 	// Behavior flags
 	ldapCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
@@ -721,7 +721,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	passwordFile, _ := cmd.Flags().GetString("password-file")
 	credentials, _ := cmd.Flags().GetString("credentials")
 	domain, _ := cmd.Flags().GetString("domain")
-	ntlmHashes, _ := cmd.Flags().GetStringSlice("ntlm-hashes")
+	ntlmHash, _ := cmd.Flags().GetString("ntlm-hash")
 
 	// Parse behavior options
 	timeout, _ := cmd.Flags().GetInt("timeout")
@@ -768,12 +768,6 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 			usernames = append(usernames, parts[0])
 			passwords = append(passwords, parts[1])
 		}
-	}
-
-	// Get first NTLM hash if provided (only support one hash for now)
-	var ntlmHash string
-	if len(ntlmHashes) > 0 {
-		ntlmHash = ntlmHashes[0]
 	}
 
 	// Set Config

--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/projectdiscovery/retryabledns v1.0.94 // indirect
 	github.com/projectdiscovery/retryablehttp-go v1.0.101 // indirect
 	github.com/projectdiscovery/uncover v1.0.9 // indirect
-	github.com/projectdiscovery/utils v0.4.18 // indirect
+	github.com/projectdiscovery/utils v0.4.18
 	github.com/projectdiscovery/wappalyzergo v0.2.41 // indirect
 	github.com/rbetts/go-ntlm v0.0.0-20130522135510-f22198915663
 	github.com/refraction-networking/utls v1.8.0 // indirect

--- a/internal/pentest/ldap/auth.go
+++ b/internal/pentest/ldap/auth.go
@@ -563,6 +563,10 @@ func attemptLDAPHashAuthenticationWithConnection(ctx context.Context, target *Ta
 
 	log := svc1log.FromContext(ctx)
 
+	// Prepare NTLM hash for LDAP (requires LM:NT format)
+	processor := ntlm.NewHashProcessor()
+	fullHash := processor.ProcessHashForLDAP(ntlmHash)
+
 	// Try each bind DN format
 	for _, bindDN := range bindDNS {
 		select {
@@ -583,8 +587,8 @@ func attemptLDAPHashAuthenticationWithConnection(ctx context.Context, target *Ta
 			continue
 		}
 
-		// Attempt to bind with hash using SASL
-		err = conn.NTLMBind(target.Domain, username, ntlmHash)
+		// Attempt to bind with hash using NTLM
+		err = conn.NTLMBindWithHash(target.Domain, username, fullHash)
 		if err != nil {
 			_ = conn.Close()
 			log.Debug("LDAP hash authentication failed",


### PR DESCRIPTION
### TL;DR

Updated LDAP hash authentication to properly process NTLM hashes for LDAP connections.

### What changed?

- Added hash processing functionality to properly format NTLM hashes for LDAP authentication
- Updated the authentication method from `NTLMBind` to `NTLMBindWithHash` to work with the processed hash format
- Added a hash processor to convert NTLM hashes to the LM:NT format required by LDAP
- Explicitly included the projectdiscovery/utils dependency in go.mod

### How to test?

1. Run LDAP pentest with NTLM hash authentication
2. Verify that pass-the-hash authentication works correctly with the new hash processing
3. Test with various NTLM hash formats to ensure they're properly converted to the LM:NT format required by LDAP

### Why make this change?

This change enhances the reliability of LDAP authentication when using NTLM hashes by ensuring proper hash formatting. The previous implementation may have failed with certain hash formats, while the new implementation properly processes the hash into the LM:NT format required for successful LDAP authentication.