### PR TITLE
Update No Service Detected Logic

### DIFF
--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -79,10 +79,12 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 	for _, ip := range ips {
 		addrPort := netip.AddrPortFrom(netip.MustParseAddr(ip.String()), uint16(port))
 		fingerprintTarget := plugins.Target{Address: addrPort, Host: host}
+		serviceFound := false
 
 		/* --- 1. fingerprintx ------------------------------------------------- */
 		if fingerprintResult, fingerprintError := fingerprintConfig.SimpleScanTarget(fingerprintTarget); fingerprintError == nil && fingerprintResult != nil && fingerprintResult.Protocol != "" {
 			results = append(results, fxToServiceDetails(fingerprintResult))
+			serviceFound = true
 			continue // done with this IP
 		}
 
@@ -95,8 +97,14 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 			}
 			if detection != nil { // hit!
 				results = append(results, detection)
+				serviceFound = true
 				break
 			}
+		}
+
+		/* --- 3. no service found -------------------------------------------- */
+		if !serviceFound {
+			report.Errors = append(report.Errors, fmt.Sprintf("no service found on %s:%d", ip, port))
 		}
 	}
 

--- a/internal/discover/service/stealth.go
+++ b/internal/discover/service/stealth.go
@@ -67,6 +67,9 @@ func RunStealthServiceFingerprint(ctx context.Context, config discoverfern.Disco
 
 		if detection != nil {
 			results = append(results, detection)
+		} else {
+			// No service found for this specific service type
+			report.Errors = append(report.Errors, fmt.Sprintf("no %s service found on %s:%d", config.Stealth.ServiceType, ip, port))
 		}
 	}
 


### PR DESCRIPTION
### TL;DR

Added error reporting when no services are detected during service fingerprinting.

### What changed?

- Added a `serviceFound` flag in `RunServiceFingerprint` to track if any service was detected
- Added error reporting when no service is found on a specific IP:port combination
- Added similar error reporting in `RunStealthServiceFingerprint` when no service of the specified type is found
