### PR TITLE
Update Comment

### DIFF
--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -104,7 +104,7 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 
 		/* --- 3. no service found -------------------------------------------- */
 		if !serviceFound {
-			report.Errors = append(report.Errors, fmt.Sprintf("no service found on %s:%d", ip, port))
+			report.Errors = append(report.Errors, fmt.Sprintf("no service found on ip address: %s and port: %d", ip, port))
 		}
 	}
 


### PR DESCRIPTION
### TL;DR

Improved error message clarity when no service is found during service fingerprinting.

### What changed?

Enhanced the error message format in the `RunServiceFingerprint` function to be more descriptive. Changed from `"no service found on %s:%d"` to `"no service found on ip address: %s and port: %d"` to make the error message more explicit about which components are the IP address and port number.

### How to test?

1. Run a service discovery scan against a non-existent service
2. Verify that the error message now shows the more descriptive format with labeled IP address and port
3. Check that the error appears in the report.Errors collection with the new format

### Why make this change?

This change improves error message clarity for users and operators by explicitly labeling the IP address and port components in the error message. This makes troubleshooting easier, especially for users who may not be familiar with the `host:port` notation format.