### PR TITLE
Add UDP service discovery mode with DNS, NTP, SNMP, NetBIOS and DHCP support

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -287,8 +287,8 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	// Service Command
 	discoverServiceCmd := &cobra.Command{
 		Use:   "service",
-		Short: "Identify and fingerprint the network service running on a specific open port of a target host.",
-		Long:  `Identify and fingerprint the network service running on a specific open port of a target host.`,
+		Short: "Identify and fingerprint network services on a target host or specific port.",
+		Long:  `Identify and fingerprint network services on a target host or specific port. Use --udp to scan common UDP ports.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			target, err := cmd.Flags().GetString("target")
 			if err != nil {
@@ -296,6 +296,13 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				return
 			}
 			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// UDP mode flag
+			udp, err := cmd.Flags().GetBool("udp")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -309,7 +316,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverServiceConfig(target, timeout, serviceType)
+			config := getDiscoverServiceConfig(target, timeout, serviceType, udp)
 
 			// Generate the report
 			report, err := discoverservice.RunServiceFingerprint(cmd.Context(), config)
@@ -320,8 +327,9 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	discoverServiceCmd.Flags().String("target", "", "Target address in format IP:port or hostname:port (e.g., 192.168.1.1:443)")
+	discoverServiceCmd.Flags().String("target", "", "Target address (IP:port or hostname:port for TCP, IP or hostname for UDP mode)")
 	discoverServiceCmd.Flags().Int("timeout", 5, "Timeout in seconds for each service fingerprinting attempt")
+	discoverServiceCmd.Flags().Bool("udp", false, "Enable UDP service discovery mode (scans common UDP ports like DNS, NTP, SNMP, etc.)")
 	discoverServiceCmd.Flags().String("service-type", "", "Service type to fingerprint for stealth mode: SSH, HTTP, GRPC, KERBEROS, LDAP, SMB (stealth mode enabled when specified)")
 
 	// Mark Required Flags
@@ -452,11 +460,14 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 }
 
 // getDiscoverServiceConfig creates a configuration for service fingerprinting with the provided parameters.
-// It sets up the target (in IP:port format), timeout, and stealth-specific options.
-func getDiscoverServiceConfig(target string, timeout int, serviceType string) discoverfern.DiscoverServiceConfig {
+// It sets up the target (in IP:port format for TCP, or just IP for UDP), timeout, UDP mode, and stealth-specific options.
+func getDiscoverServiceConfig(target string, timeout int, serviceType string, udp bool) discoverfern.DiscoverServiceConfig {
 	config := discoverfern.DiscoverServiceConfig{
 		Target:  target,
 		Timeout: timeout,
+	}
+	if udp {
+		config.Udp = &udp
 	}
 	if serviceType != "" {
 		// Convert to uppercase for enum parsing

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -31,9 +31,10 @@ types:
   # Config
   DiscoverServiceConfig:
     properties:
-      target: string  # Format: IP:port or hostname:port
+      target: string  # Format: IP:port or hostname:port for TCP, IP or hostname for UDP mode
       timeout: integer
       stealth: optional<ServiceStealthConfig>
+      udp: optional<boolean>  # Enable UDP service discovery mode (scans common UDP ports)
   # Final report
   DiscoverServiceReport:
     properties:

--- a/internal/discover/service/plugins/dhcp.go
+++ b/internal/discover/service/plugins/dhcp.go
@@ -1,0 +1,251 @@
+// Package plugins provides DHCP service fingerprinting
+package plugins
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+)
+
+type DHCPFingerprinter struct{}
+
+func (DHCPFingerprinter) Name() string { return "dhcp" }
+
+func (DHCPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	addr := fmt.Sprintf("%s:%d", ip, port)
+
+	// Create UDP connection
+	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Set read deadline
+	if err := conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second)); err != nil {
+		return nil, err
+	}
+
+	// Build DHCP DISCOVER packet
+	dhcpDiscover := buildDHCPDiscover()
+
+	// Send the request
+	if _, err := conn.Write(dhcpDiscover); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	buffer := make([]byte, 1500)
+	n, err := conn.Read(buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	// DHCP response must be at least 236 bytes (minimum DHCP packet size)
+	if n < 236 {
+		return nil, fmt.Errorf("response too short: %d bytes", n)
+	}
+
+	// Verify it's a DHCP response (op = 2 for BOOTREPLY)
+	op := buffer[0]
+	if op != 2 {
+		return nil, fmt.Errorf("not a DHCP response (op=%d)", op)
+	}
+
+	// Verify DHCP magic cookie (0x63825363)
+	if n < 240 {
+		return nil, fmt.Errorf("packet too short for DHCP")
+	}
+	magicCookie := binary.BigEndian.Uint32(buffer[236:240])
+	if magicCookie != 0x63825363 {
+		return nil, fmt.Errorf("invalid DHCP magic cookie")
+	}
+
+	// DHCP service detected
+	result := &discoverfern.ServiceDetails{
+		Host:      host,
+		Ip:        ip.String(),
+		Port:      port,
+		Tls:       false,
+		Transport: common.TransportTypeUdp,
+		Protocol:  common.ProtocolTypeDhcp,
+		Metadata:  make(map[string]string),
+	}
+
+	version := "DHCP Server"
+	result.Version = &version
+
+	// Parse offered IP address (yiaddr field at bytes 16-19)
+	offeredIP := net.IPv4(buffer[16], buffer[17], buffer[18], buffer[19])
+	result.Metadata["offered_ip"] = offeredIP.String()
+
+	// Parse server identifier (siaddr field at bytes 20-23)
+	serverIP := net.IPv4(buffer[20], buffer[21], buffer[22], buffer[23])
+	result.Metadata["server_ip"] = serverIP.String()
+
+	// Try to parse DHCP options
+	if n > 240 {
+		options := parseDHCPOptions(buffer[240:n])
+		for k, v := range options {
+			result.Metadata[k] = v
+		}
+	}
+
+	return result, nil
+}
+
+// buildDHCPDiscover creates a DHCP DISCOVER packet
+func buildDHCPDiscover() []byte {
+	packet := make([]byte, 300)
+
+	// op: BOOTREQUEST (1)
+	packet[0] = 1
+
+	// htype: Ethernet (1)
+	packet[1] = 1
+
+	// hlen: MAC address length (6)
+	packet[2] = 6
+
+	// hops: 0
+	packet[3] = 0
+
+	// xid: transaction ID (random)
+	binary.BigEndian.PutUint32(packet[4:8], 0x12345678)
+
+	// secs: 0
+	binary.BigEndian.PutUint16(packet[8:10], 0)
+
+	// flags: 0
+	binary.BigEndian.PutUint16(packet[10:12], 0)
+
+	// ciaddr: 0.0.0.0
+	// yiaddr: 0.0.0.0
+	// siaddr: 0.0.0.0
+	// giaddr: 0.0.0.0
+	// (all zeros, already set)
+
+	// chaddr: client hardware address (fake MAC)
+	packet[28] = 0x00
+	packet[29] = 0x11
+	packet[30] = 0x22
+	packet[31] = 0x33
+	packet[32] = 0x44
+	packet[33] = 0x55
+
+	// sname and file: all zeros (already set)
+
+	// DHCP magic cookie
+	binary.BigEndian.PutUint32(packet[236:240], 0x63825363)
+
+	// DHCP options
+	offset := 240
+
+	// Option 53: DHCP Message Type = DISCOVER (1)
+	packet[offset] = 53
+	offset++
+	packet[offset] = 1 // length
+	offset++
+	packet[offset] = 1 // DHCPDISCOVER
+	offset++
+
+	// Option 55: Parameter Request List
+	packet[offset] = 55
+	offset++
+	packet[offset] = 4 // length
+	offset++
+	packet[offset] = 1 // Subnet Mask
+	offset++
+	packet[offset] = 3 // Router
+	offset++
+	packet[offset] = 6 // DNS
+	offset++
+	packet[offset] = 15 // Domain Name
+	offset++
+
+	// Option 255: End
+	packet[offset] = 255
+
+	return packet[:offset+1]
+}
+
+// parseDHCPOptions parses DHCP options from the packet
+func parseDHCPOptions(options []byte) map[string]string {
+	result := make(map[string]string)
+
+	for i := 0; i < len(options); {
+		optionType := options[i]
+		i++
+
+		// Check for end option
+		if optionType == 255 {
+			break
+		}
+
+		// Check for pad option
+		if optionType == 0 {
+			continue
+		}
+
+		// Check if we have enough data for length
+		if i >= len(options) {
+			break
+		}
+
+		optionLen := int(options[i])
+		i++
+
+		// Check if we have enough data for the option value
+		if i+optionLen > len(options) {
+			break
+		}
+
+		optionData := options[i : i+optionLen]
+		i += optionLen
+
+		// Parse specific options
+		switch optionType {
+		case 53: // DHCP Message Type
+			if optionLen == 1 {
+				msgType := getDHCPMessageType(optionData[0])
+				result["dhcp_message_type"] = msgType
+			}
+		case 54: // Server Identifier
+			if optionLen == 4 {
+				serverIP := net.IPv4(optionData[0], optionData[1], optionData[2], optionData[3])
+				result["dhcp_server_id"] = serverIP.String()
+			}
+		}
+	}
+
+	return result
+}
+
+// getDHCPMessageType returns a human-readable DHCP message type
+func getDHCPMessageType(msgType byte) string {
+	switch msgType {
+	case 1:
+		return "DHCPDISCOVER"
+	case 2:
+		return "DHCPOFFER"
+	case 3:
+		return "DHCPREQUEST"
+	case 4:
+		return "DHCPDECLINE"
+	case 5:
+		return "DHCPACK"
+	case 6:
+		return "DHCPNAK"
+	case 7:
+		return "DHCPRELEASE"
+	case 8:
+		return "DHCPINFORM"
+	default:
+		return fmt.Sprintf("Unknown (%d)", msgType)
+	}
+}

--- a/internal/discover/service/plugins/dns.go
+++ b/internal/discover/service/plugins/dns.go
@@ -1,0 +1,82 @@
+// Package plugins provides DNS service fingerprinting
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/miekg/dns"
+)
+
+type DNSFingerprinter struct{}
+
+func (DNSFingerprinter) Name() string { return "dns" }
+
+func (DNSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	addr := fmt.Sprintf("%s:%d", ip, port)
+
+	// Create DNS client with timeout
+	client := &dns.Client{
+		Net:     "udp",
+		Timeout: time.Duration(timeout) * time.Second,
+	}
+
+	// Create a DNS query for version.bind (CHAOS TXT record)
+	// This is commonly used to fingerprint DNS servers
+	msg := new(dns.Msg)
+	msg.SetQuestion("version.bind.", dns.TypeTXT)
+	msg.Question[0].Qclass = dns.ClassCHAOS
+
+	// Send the query
+	resp, _, err := client.Exchange(msg, addr)
+	if err != nil {
+		// Try a standard query as fallback
+		msg = new(dns.Msg)
+		msg.SetQuestion(".", dns.TypeNS)
+		resp, _, err = client.Exchange(msg, addr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// DNS service detected
+	result := &discoverfern.ServiceDetails{
+		Host:      host,
+		Ip:        ip.String(),
+		Port:      port,
+		Tls:       false,
+		Transport: common.TransportTypeUdp,
+		Protocol:  common.ProtocolTypeDns,
+		Metadata:  make(map[string]string),
+	}
+
+	// Extract version information if available
+	if resp != nil {
+		result.Metadata["response_code"] = dns.RcodeToString[resp.Rcode]
+		result.Metadata["authoritative"] = fmt.Sprintf("%t", resp.Authoritative)
+		result.Metadata["recursion_available"] = fmt.Sprintf("%t", resp.RecursionAvailable)
+
+		// Try to extract version from CHAOS TXT response
+		for _, ans := range resp.Answer {
+			if txt, ok := ans.(*dns.TXT); ok {
+				if len(txt.Txt) > 0 {
+					version := txt.Txt[0]
+					result.Version = &version
+					result.Metadata["dns_version"] = version
+				}
+			}
+		}
+
+		// Check for EDNS0 support
+		if opt := resp.IsEdns0(); opt != nil {
+			result.Metadata["edns0_support"] = "true"
+			result.Metadata["udp_buffer_size"] = fmt.Sprintf("%d", opt.UDPSize())
+		}
+	}
+
+	return result, nil
+}

--- a/internal/discover/service/plugins/netbios.go
+++ b/internal/discover/service/plugins/netbios.go
@@ -1,0 +1,161 @@
+// Package plugins provides NetBIOS Name Service fingerprinting
+package plugins
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+)
+
+type NetBIOSFingerprinter struct{}
+
+func (NetBIOSFingerprinter) Name() string { return "netbios-ns" }
+
+func (NetBIOSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	addr := fmt.Sprintf("%s:%d", ip, port)
+
+	// Create UDP connection
+	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Set read deadline
+	if err := conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second)); err != nil {
+		return nil, err
+	}
+
+	// Build NetBIOS Name Query for "*" (wildcard)
+	// This is a status query that requests all NetBIOS names
+	nbnsQuery := buildNetBIOSStatusQuery()
+
+	// Send the request
+	if _, err := conn.Write(nbnsQuery); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	buffer := make([]byte, 4096)
+	n, err := conn.Read(buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if we got a valid NetBIOS response (minimum header size is 12 bytes)
+	if n < 12 {
+		return nil, fmt.Errorf("response too short")
+	}
+
+	// Verify it's a NetBIOS response by checking the header
+	// Transaction ID should match (we use 0x1337)
+	transID := binary.BigEndian.Uint16(buffer[0:2])
+	if transID != 0x1337 {
+		return nil, fmt.Errorf("invalid NetBIOS response")
+	}
+
+	// NetBIOS service detected
+	result := &discoverfern.ServiceDetails{
+		Host:      host,
+		Ip:        ip.String(),
+		Port:      port,
+		Tls:       false,
+		Transport: common.TransportTypeUdp,
+		Protocol:  common.ProtocolTypeNetbios,
+		Metadata:  make(map[string]string),
+	}
+
+	version := "NetBIOS Name Service"
+	result.Version = &version
+	result.Metadata["service"] = "NetBIOS-NS"
+
+	// Try to parse NetBIOS names from response
+	if n > 56 {
+		// NetBIOS name response format has names starting at offset 56
+		names := parseNetBIOSNames(buffer[56:n])
+		if len(names) > 0 {
+			result.Metadata["netbios_names"] = fmt.Sprintf("%v", names)
+		}
+	}
+
+	return result, nil
+}
+
+// buildNetBIOSStatusQuery creates a NetBIOS Name Query packet for status
+func buildNetBIOSStatusQuery() []byte {
+	query := make([]byte, 50)
+
+	// Transaction ID
+	binary.BigEndian.PutUint16(query[0:2], 0x1337)
+
+	// Flags: Standard query
+	binary.BigEndian.PutUint16(query[2:4], 0x0000)
+
+	// Questions: 1
+	binary.BigEndian.PutUint16(query[4:6], 0x0001)
+
+	// Answer RRs: 0
+	binary.BigEndian.PutUint16(query[6:8], 0x0000)
+
+	// Authority RRs: 0
+	binary.BigEndian.PutUint16(query[8:10], 0x0000)
+
+	// Additional RRs: 0
+	binary.BigEndian.PutUint16(query[10:12], 0x0000)
+
+	// Query Name: "*" encoded in NetBIOS format
+	// Length of first label
+	query[12] = 0x20
+
+	// Encode "*" (0x2A) in NetBIOS half-ASCII format
+	// Each byte is split into two 4-bit nibbles and added to 'A' (0x41)
+	for i := 0; i < 32; i++ {
+		query[13+i] = 'A' // 'A' is the base for NetBIOS encoding
+	}
+	// First two characters encode the actual name "*"
+	query[13] = 'C' // High nibble of '*' (0x2)
+	query[14] = 'K' // Low nibble of '*' (0xA)
+
+	// End of name
+	query[45] = 0x00
+
+	// Query Type: NBSTAT (0x21)
+	binary.BigEndian.PutUint16(query[46:48], 0x0021)
+
+	// Query Class: IN (0x0001)
+	binary.BigEndian.PutUint16(query[48:50], 0x0001)
+
+	return query
+}
+
+// parseNetBIOSNames attempts to extract NetBIOS names from the response
+func parseNetBIOSNames(data []byte) []string {
+	var names []string
+
+	// Each NetBIOS name entry is 18 bytes
+	for i := 0; i+18 <= len(data); i += 18 {
+		// First 15 bytes are the name (padded with spaces)
+		// 16th byte is the name type
+		name := string(data[i : i+15])
+		// Trim spaces
+		name = trimSpaces(name)
+		if len(name) > 0 {
+			names = append(names, name)
+		}
+	}
+
+	return names
+}
+
+// trimSpaces removes trailing spaces from a string
+func trimSpaces(s string) string {
+	for len(s) > 0 && s[len(s)-1] == ' ' {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/discover/service/plugins/ntp.go
+++ b/internal/discover/service/plugins/ntp.go
@@ -1,0 +1,150 @@
+// Package plugins provides NTP service fingerprinting
+package plugins
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+)
+
+type NTPFingerprinter struct{}
+
+func (NTPFingerprinter) Name() string { return "ntp" }
+
+func (NTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	addr := fmt.Sprintf("%s:%d", ip, port)
+
+	// Create UDP connection
+	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Set read deadline
+	if err := conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second)); err != nil {
+		return nil, err
+	}
+
+	// Build NTP request packet (48 bytes)
+	ntpRequest := buildNTPRequest()
+
+	// Send the request
+	if _, err := conn.Write(ntpRequest); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	buffer := make([]byte, 48)
+	n, err := conn.Read(buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	// NTP response must be exactly 48 bytes
+	if n != 48 {
+		return nil, fmt.Errorf("invalid NTP response size: %d", n)
+	}
+
+	// Parse NTP response header
+	leapIndicator := (buffer[0] >> 6) & 0x03
+	versionNumber := (buffer[0] >> 3) & 0x07
+	mode := buffer[0] & 0x07
+	stratum := buffer[1]
+
+	// Validate it's an NTP response (mode should be 4 for server response)
+	if mode != 4 && mode != 5 {
+		return nil, fmt.Errorf("invalid NTP mode: %d", mode)
+	}
+
+	// NTP service detected
+	result := &discoverfern.ServiceDetails{
+		Host:      host,
+		Ip:        ip.String(),
+		Port:      port,
+		Tls:       false,
+		Transport: common.TransportTypeUdp,
+		Protocol:  common.ProtocolTypeNtp,
+		Metadata:  make(map[string]string),
+	}
+
+	version := fmt.Sprintf("NTPv%d", versionNumber)
+	result.Version = &version
+	result.Metadata["ntp_version"] = fmt.Sprintf("%d", versionNumber)
+	result.Metadata["stratum"] = fmt.Sprintf("%d", stratum)
+	result.Metadata["leap_indicator"] = getLeapIndicatorString(leapIndicator)
+	result.Metadata["mode"] = getNTPModeString(mode)
+
+	// Parse reference identifier (bytes 12-15)
+	if stratum == 1 {
+		// For stratum 1, reference ID is an ASCII string (reference clock identifier)
+		refID := string(buffer[12:16])
+		result.Metadata["reference_id"] = refID
+	} else if stratum > 1 {
+		// For stratum > 1, reference ID is an IP address
+		refIP := net.IPv4(buffer[12], buffer[13], buffer[14], buffer[15])
+		result.Metadata["reference_ip"] = refIP.String()
+	}
+
+	return result, nil
+}
+
+// buildNTPRequest creates an NTP client request packet
+func buildNTPRequest() []byte {
+	packet := make([]byte, 48)
+
+	// Set Leap Indicator (0), Version (3), and Mode (3 = client)
+	packet[0] = 0x1B // 00 011 011 = LI=0, Version=3, Mode=3
+
+	// All other fields can remain zero for a basic request
+
+	return packet
+}
+
+// getLeapIndicatorString returns a human-readable leap indicator string
+func getLeapIndicatorString(li byte) string {
+	switch li {
+	case 0:
+		return "no warning"
+	case 1:
+		return "last minute has 61 seconds"
+	case 2:
+		return "last minute has 59 seconds"
+	case 3:
+		return "alarm condition (clock not synchronized)"
+	default:
+		return "unknown"
+	}
+}
+
+// getNTPModeString returns a human-readable NTP mode string
+func getNTPModeString(mode byte) string {
+	switch mode {
+	case 0:
+		return "reserved"
+	case 1:
+		return "symmetric active"
+	case 2:
+		return "symmetric passive"
+	case 3:
+		return "client"
+	case 4:
+		return "server"
+	case 5:
+		return "broadcast"
+	case 6:
+		return "NTP control message"
+	case 7:
+		return "reserved for private use"
+	default:
+		return "unknown"
+	}
+}
+
+// Prevent unused import warning
+var _ = binary.BigEndian

--- a/internal/discover/service/plugins/snmp.go
+++ b/internal/discover/service/plugins/snmp.go
@@ -1,0 +1,131 @@
+// Package plugins provides SNMP service fingerprinting
+package plugins
+
+import (
+	"context"
+	"encoding/asn1"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+)
+
+type SNMPFingerprinter struct{}
+
+func (SNMPFingerprinter) Name() string { return "snmp" }
+
+func (SNMPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	addr := fmt.Sprintf("%s:%d", ip, port)
+
+	// Create UDP connection
+	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Set read deadline
+	if err := conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second)); err != nil {
+		return nil, err
+	}
+
+	// Build SNMP v1 GetRequest for sysDescr (1.3.6.1.2.1.1.1.0)
+	// This is a basic SNMP probe
+	snmpRequest := buildSNMPGetRequest("public", "1.3.6.1.2.1.1.1.0")
+
+	// Send the request
+	if _, err := conn.Write(snmpRequest); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	buffer := make([]byte, 4096)
+	n, err := conn.Read(buffer)
+	if err != nil {
+		return nil, fmt.Errorf("read error: %w", err)
+	}
+
+	// Check if we got a valid SNMP response
+	if n < 10 {
+		return nil, fmt.Errorf("response too short: %d bytes", n)
+	}
+
+	// Verify it starts with SEQUENCE tag (0x30)
+	if buffer[0] != 0x30 {
+		return nil, fmt.Errorf("invalid SNMP response: expected SEQUENCE tag, got 0x%02x", buffer[0])
+	}
+
+	// Parse basic SNMP response structure
+	// We use RawValue for Community because SNMP servers may return different ASN.1 types
+	var snmpMsg struct {
+		Version   int
+		Community asn1.RawValue
+		PDU       asn1.RawValue
+	}
+
+	_, err = asn1.Unmarshal(buffer[:n], &snmpMsg)
+	if err != nil {
+		return nil, fmt.Errorf("asn1 unmarshal error (got %d bytes): %w", n, err)
+	}
+
+	// Extract community string from RawValue
+	var community string
+	if snmpMsg.Community.Tag == 4 { // OCTET STRING
+		community = string(snmpMsg.Community.Bytes)
+	} else if snmpMsg.Community.Tag == 19 { // PrintableString
+		community = string(snmpMsg.Community.Bytes)
+	}
+
+	// SNMP service detected
+	result := &discoverfern.ServiceDetails{
+		Host:      host,
+		Ip:        ip.String(),
+		Port:      port,
+		Tls:       false,
+		Transport: common.TransportTypeUdp,
+		Protocol:  common.ProtocolTypeSnmp,
+		Metadata:  make(map[string]string),
+	}
+
+	// Map SNMP version
+	var versionStr string
+	switch snmpMsg.Version {
+	case 0:
+		versionStr = "SNMPv1"
+	case 1:
+		versionStr = "SNMPv2c"
+	case 3:
+		versionStr = "SNMPv3"
+	default:
+		versionStr = fmt.Sprintf("SNMP (version %d)", snmpMsg.Version)
+	}
+
+	result.Version = &versionStr
+	result.Metadata["snmp_version"] = versionStr
+	result.Metadata["community"] = community
+
+	return result, nil
+}
+
+// buildSNMPGetRequest creates a simple SNMP v1 GetRequest packet
+func buildSNMPGetRequest(community, oid string) []byte {
+	// This is a simplified SNMP GetRequest packet for sysDescr
+	// SNMP v1, community "public", GetRequest for 1.3.6.1.2.1.1.1.0
+	snmpPacket := []byte{
+		0x30, 0x29, // SEQUENCE (41 bytes)
+		0x02, 0x01, 0x00, // INTEGER version (SNMPv1 = 0)
+		0x04, 0x06, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, // OCTET STRING "public"
+		0xa0, 0x1c, // GetRequest PDU
+		0x02, 0x04, 0x00, 0x00, 0x00, 0x01, // request-id = 1
+		0x02, 0x01, 0x00, // error-status = 0
+		0x02, 0x01, 0x00, // error-index = 0
+		0x30, 0x0e, // variable-bindings SEQUENCE
+		0x30, 0x0c, // variable SEQUENCE
+		0x06, 0x08, 0x2b, 0x06, 0x01, 0x02, 0x01, 0x01, 0x01, 0x00, // OID 1.3.6.1.2.1.1.1.0
+		0x05, 0x00, // NULL value
+	}
+
+	return snmpPacket
+}

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -47,13 +47,30 @@ var customFingerprintModules = []Fingerprinter{
 	&localPlugins.GrpcFingerprinter{},
 }
 
+// UDP fingerprinters mapped to their specific ports
+// Each UDP service is only probed on its well-known port(s)
+var udpFingerprinters = map[uint16]Fingerprinter{
+	53:  &localPlugins.DNSFingerprinter{},     // DNS
+	67:  &localPlugins.DHCPFingerprinter{},    // DHCP Server
+	123: &localPlugins.NTPFingerprinter{},     // NTP
+	137: &localPlugins.NetBIOSFingerprinter{}, // NetBIOS Name Service
+	161: &localPlugins.SNMPFingerprinter{},    // SNMP
+	162: &localPlugins.SNMPFingerprinter{},    // SNMP Trap
+}
+
 // RunServiceFingerprint fingerprints the service at target:port.
-//  1. If stealth mode is enabled, use targeted fingerprinting for the specified service type.
-//  2. Otherwise, let fingerprintx try first.
-//  3. If fingerprintx fails, run the custom modules in order until one hits.
+//  1. If UDP mode is enabled, scan common UDP ports on the target host.
+//  2. If stealth mode is enabled, use targeted fingerprinting for the specified service type.
+//  3. Otherwise, let fingerprintx try first.
+//  4. If fingerprintx fails, run the custom modules in order until one hits.
 func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServiceConfig) (*discoverfern.DiscoverServiceReport, error) {
 	report := &discoverfern.DiscoverServiceReport{Config: &config}
 	var results []*discoverfern.ServiceDetails
+
+	// Check if UDP mode is enabled
+	if config.Udp != nil && *config.Udp {
+		return RunUDPServiceDiscovery(ctx, config)
+	}
 
 	// Parse target to get host and port
 	host, port := utils.ParseHostPort(config.Target, 80) // Default to port 80 if no port specified
@@ -153,4 +170,48 @@ func fxToServiceDetails(result *plugins.Service) *discoverfern.ServiceDetails {
 	}
 
 	return serviceDetails
+}
+
+// RunUDPServiceDiscovery scans common UDP ports on the target host and fingerprints discovered services.
+// It uses custom UDP fingerprinters for DNS, NTP, SNMP, NetBIOS-NS, and DHCP.
+// Each service is only probed on its well-known port(s) to avoid false positives.
+func RunUDPServiceDiscovery(ctx context.Context, config discoverfern.DiscoverServiceConfig) (*discoverfern.DiscoverServiceReport, error) {
+	report := &discoverfern.DiscoverServiceReport{Config: &config}
+	var results []*discoverfern.ServiceDetails
+
+	// Parse target to get host (should be just IP or hostname, no port)
+	host := config.Target
+	// Strip port if someone accidentally included it
+	if strings.Contains(host, ":") {
+		host, _, _ = net.SplitHostPort(host)
+	}
+
+	ips, err := utils.GetIPs(host)
+	if err != nil {
+		report.Errors = append(report.Errors, fmt.Sprintf("failed to resolve target %s: %v", host, err))
+		return report, nil
+	}
+
+	// Scan each IP
+	for _, ip := range ips {
+		// Try each UDP port that has a custom fingerprinter
+		for port, fingerprinter := range udpFingerprinters {
+			detection, err := fingerprinter.Detect(ctx, ip, int(port), host, config.Timeout)
+			if err != nil {
+				// UDP errors are expected when services aren't running
+				// We silently skip these as they're normal behavior
+				continue
+			}
+			if detection != nil {
+				results = append(results, detection)
+			}
+		}
+	}
+
+	if len(results) == 0 {
+		report.Errors = append(report.Errors, fmt.Sprintf("no UDP services found on %s", host))
+	}
+
+	report.Result = &discoverfern.DiscoverServiceResult{Services: results}
+	return report, nil
 }


### PR DESCRIPTION
### TL;DR

Added UDP service discovery to the `discover service` command, enabling detection of common UDP services like DNS, NTP, SNMP, DHCP, and NetBIOS.

### What changed?

- Added a new `--udp` flag to the `discover service` command to enable UDP service discovery mode
- Implemented fingerprinters for common UDP services:
  - DNS (port 53)
  - DHCP (port 67)
  - NTP (port 123)
  - NetBIOS Name Service (port 137)
  - SNMP (ports 161/162)
- Updated command help text to reflect the new UDP scanning capability
- Modified the service discovery logic to handle UDP mode differently from TCP mode

### How to test?

Test the new UDP service discovery mode:

```bash
# Scan a host for UDP services
networkscan discover service --target 192.168.1.1 --udp

# Scan with increased timeout for slower networks
networkscan discover service --target example.com --udp --timeout 10
```

Each UDP service will be probed on its well-known port. The command will report any discovered services along with metadata specific to each protocol.

### Why make this change?

UDP services are common in enterprise networks but were not previously detectable with the `discover service` command. This change enables discovery of critical network services like DNS, DHCP, and NTP that typically run over UDP. The implementation is designed to be non-intrusive, only probing well-known ports with protocol-specific packets to minimize false positives and network noise.