### PR TITLE
Fix IPv6 Port Parsing in Service Fingerprint

### DIFF
--- a/internal/discover/domain.go
+++ b/internal/discover/domain.go
@@ -199,7 +199,7 @@ func enumerateDomainControllers(ctx context.Context, host string, domainName str
 
 	// Try querying the target host first (likely a DC), then fallback to system DNS
 	dnsServers := []string{
-		fmt.Sprintf("%s:53", host), // Query the target host directly
+		net.JoinHostPort(host, "53"), // Query the target host directly (properly handles IPv6)
 	}
 
 	// Add system DNS servers as fallback

--- a/internal/discover/service/plugins/dhcp.go
+++ b/internal/discover/service/plugins/dhcp.go
@@ -17,7 +17,7 @@ type DHCPFingerprinter struct{}
 func (DHCPFingerprinter) Name() string { return "dhcp" }
 
 func (DHCPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
 	// Create UDP connection
 	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)

--- a/internal/discover/service/plugins/dns.go
+++ b/internal/discover/service/plugins/dns.go
@@ -17,7 +17,7 @@ type DNSFingerprinter struct{}
 func (DNSFingerprinter) Name() string { return "dns" }
 
 func (DNSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
 	// Create DNS client with timeout
 	client := &dns.Client{

--- a/internal/discover/service/plugins/grpc.go
+++ b/internal/discover/service/plugins/grpc.go
@@ -34,7 +34,7 @@ func (GrpcFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 	timeoutDuration := 10 * time.Second // Fixed 10-second timeout
 
 	/* ---- try plaintext first --------------------------------------------- */

--- a/internal/discover/service/plugins/http.go
+++ b/internal/discover/service/plugins/http.go
@@ -41,7 +41,9 @@ func (HTTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	}
 
 	for _, proto := range protocols {
-		url := fmt.Sprintf("%s://%s:%d/", proto.scheme, ip, port)
+		// Use net.JoinHostPort to properly format IPv6 addresses with brackets
+		hostPort := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
+		url := fmt.Sprintf("%s://%s/", proto.scheme, hostPort)
 		req, err := http.NewRequestWithContext(timeoutCtx, "HEAD", url, nil)
 		if err != nil {
 			continue

--- a/internal/discover/service/plugins/kerberos.go
+++ b/internal/discover/service/plugins/kerberos.go
@@ -29,7 +29,7 @@ func (KerberosFingerprinter) Detect(ctx context.Context, ip net.IP, port int, ho
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 	timeoutDuration := time.Duration(timeout) * time.Second
 
 	// Try plaintext connection first

--- a/internal/discover/service/plugins/ldap.go
+++ b/internal/discover/service/plugins/ldap.go
@@ -23,7 +23,7 @@ func (LDAPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	defer cancel()
 
 	// Use proper LDAP client with timeout
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
 	conn, err := ldap.DialURL(fmt.Sprintf("ldap://%s", addr), ldap.DialWithDialer(&net.Dialer{
 		Timeout: 10 * time.Second,

--- a/internal/discover/service/plugins/netbios.go
+++ b/internal/discover/service/plugins/netbios.go
@@ -17,7 +17,7 @@ type NetBIOSFingerprinter struct{}
 func (NetBIOSFingerprinter) Name() string { return "netbios-ns" }
 
 func (NetBIOSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
 	// Create UDP connection
 	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)

--- a/internal/discover/service/plugins/ntp.go
+++ b/internal/discover/service/plugins/ntp.go
@@ -17,7 +17,7 @@ type NTPFingerprinter struct{}
 func (NTPFingerprinter) Name() string { return "ntp" }
 
 func (NTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
 	// Create UDP connection
 	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)

--- a/internal/discover/service/plugins/smb.go
+++ b/internal/discover/service/plugins/smb.go
@@ -73,7 +73,7 @@ func detectSMBService(ctx context.Context, ip net.IP, port int, host string) (*d
 	}
 
 	// Validate that we have actual SMB-specific server information
-	if serverInfo != nil && isValidSMBServerInfo(serverInfo, err) {
+	if serverInfo != nil && isValidSMBServerInfo(serverInfo) {
 		// Create successful service detection result
 		result := &discoverfern.ServiceDetails{
 			Host:      host,
@@ -170,7 +170,7 @@ func detectSMBService(ctx context.Context, ip net.IP, port int, host string) (*d
 }
 
 // isValidSMBServerInfo validates that the server info contains actual SMB-specific data
-func isValidSMBServerInfo(serverInfo *commonprotocolfern.SmbServerInfo, connErr error) bool {
+func isValidSMBServerInfo(serverInfo *commonprotocolfern.SmbServerInfo) bool {
 	if serverInfo == nil {
 		return false
 	}

--- a/internal/discover/service/plugins/snmp.go
+++ b/internal/discover/service/plugins/snmp.go
@@ -17,7 +17,7 @@ type SNMPFingerprinter struct{}
 func (SNMPFingerprinter) Name() string { return "snmp" }
 
 func (SNMPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
 	// Create UDP connection
 	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)

--- a/internal/discover/service/plugins/ssh.go
+++ b/internal/discover/service/plugins/ssh.go
@@ -18,7 +18,7 @@ type SSHFingerprinter struct{}
 func (SSHFingerprinter) Name() string { return "ssh" }
 
 func (SSHFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
 	// Create SSH client config with no auth methods (connection-only)
 	config := &ssh.ClientConfig{

--- a/internal/pentest/kerberos/auth.go
+++ b/internal/pentest/kerberos/auth.go
@@ -228,7 +228,7 @@ func SprayPasswords(ctx context.Context, target *Target, usernames []string, pas
 func TestConnection(ctx context.Context, target *Target, timeout int) error {
 	log := svc1log.FromContext(ctx)
 
-	address := fmt.Sprintf("%s:%d", target.Host, target.Port)
+	address := net.JoinHostPort(target.Host, fmt.Sprintf("%d", target.Port))
 
 	timeoutDuration := time.Duration(timeout) * time.Millisecond
 	if timeout == 0 {

--- a/internal/protocol/smb/exfil.go
+++ b/internal/protocol/smb/exfil.go
@@ -73,7 +73,9 @@ func (o *OutputFileFetcher) GetOutput(ctx context.Context, writer io.Writer) err
 	log.Info("Fetching output file", svc1log.SafeParam("path", o.relativePath))
 
 	// Create TCP connection to SMB server
-	conn, err := net.Dial("tcp", fmt.Sprintf("%s:445", o.Host))
+	// Use net.JoinHostPort to properly handle IPv6 addresses with brackets
+	address := net.JoinHostPort(o.Host, "445")
+	conn, err := net.Dial("tcp", address)
 	if err != nil {
 		return fmt.Errorf("connect to SMB server: %w", err)
 	}

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -140,9 +140,10 @@ func expandCIDR(target string) ([]string, map[string]string, error) {
 		hosts = append(hosts, ip.String())
 	}
 
-	// Remove network and broadcast addresses for /24 and smaller
-	ones, _ := ipnet.Mask.Size()
-	if ones >= 24 && len(hosts) > 2 {
+	// Remove network and broadcast addresses for IPv4 networks /24 and smaller
+	// IPv6 doesn't have broadcast addresses, so skip this logic for IPv6
+	ones, bits := ipnet.Mask.Size()
+	if bits == 32 && ones >= 24 && len(hosts) > 2 { // Only for IPv4 (/32 bits total)
 		hosts = hosts[1 : len(hosts)-1]
 	}
 


### PR DESCRIPTION
### TL;DR

Replace string concatenation with `net.JoinHostPort` for network address formatting and fix an unused parameter in the SMB plugin.

### What changed?

- Replaced `fmt.Sprintf("%s:%d", ip, port)` with `net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))` across multiple service plugins (DHCP, DNS, gRPC, Kerberos, LDAP, NetBIOS, NTP, SNMP, SSH)
- Updated the Kerberos authentication module to use `net.JoinHostPort` as well
- Removed an unused `connErr` parameter from the `isValidSMBServerInfo` function in the SMB plugin

### Why make this change?

Using `net.JoinHostPort` is the recommended way to handle IP address formatting in Go, especially when dealing with IPv6 addresses which require special bracketing. This change improves robustness when connecting to IPv6 services and follows Go best practices for network programming. The removal of the unused parameter in the SMB plugin also improves code clarity.