### PR TITLE
Port Scan: Add Rate Config

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -188,6 +188,11 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			packetsPerSecond, err := cmd.Flags().GetInt("packets-per-second")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			scanType, err := cmd.Flags().GetString("scan-type")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -255,7 +260,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPortConfig(target, ports, topPorts, threads, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, sleep, jitter)
+			config := getDiscoverPortConfig(target, ports, topPorts, threads, packetsPerSecond, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, sleep, jitter)
 
 			// Generate the report
 			report, err := discoverport.RunPortScan(cmd.Context(), config)
@@ -271,6 +276,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverPortCmd.Flags().String("top-ports", "", "Scan the top N most common TCP ports (options: full, 100, 1000)")
 	discoverPortCmd.Flags().Int("threads", 25, "Number of concurrent threads to use during port scanning")
 	discoverPortCmd.Flags().String("scan-type", "SYN", "Port scan type: SYN (default, requires root) or CONNECT")
+	discoverPortCmd.Flags().Int("packets-per-second", 1000, "Packets per second to send (default: 1000)")
 	discoverPortCmd.Flags().Bool("validate", false, "Validate open ports by using service detection techniques")
 	discoverPortCmd.Flags().String("validate-hostname", "", "Hostname to validate against (e.g., example.com)")
 	discoverPortCmd.Flags().Int("validate-attempt-timeout", 10, "Timeout in seconds for each service detection attempt")
@@ -420,12 +426,13 @@ func (a *NetworkScan) InitDiscoverCommand() {
 
 // getDiscoverPortConfig creates a configuration for port scanning with the provided parameters.
 // It handles both specific port ranges and top ports scanning modes.
-func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, sleep int, jitter int) discoverfern.DiscoverPortConfig {
+func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, packetsPerSecond int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, sleep int, jitter int) discoverfern.DiscoverPortConfig {
 	// Start with common fields that apply to both stealth and regular scans
 	config := discoverfern.DiscoverPortConfig{
-		Target:   target,
-		Ports:    &ports,
-		TopPorts: &topPorts,
+		Target:           target,
+		Ports:            &ports,
+		TopPorts:         &topPorts,
+		PacketsPerSecond: packetsPerSecond,
 	}
 
 	if sleep > 0 || jitter > 0 {

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -31,6 +31,7 @@ types:
       ports: optional<string>
       topPorts: optional<string>
       threads: integer
+      packetsPerSecond: integer # Packets per second to send (default: 10)
       scanType: PortScanType
       validate: boolean
       validateHostname: optional<string>

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -101,7 +101,7 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 
 	output := result.HostResult{}
 	hosts := []*discoverfern.SocketDetails{}
-	// These settings mimic naabu's default settings
+	// These settings mimic naabu's default settings with hardcoded slower rate
 	portscanOpts := &runner.Options{
 		Silent:            false,
 		JSON:              true,
@@ -109,7 +109,7 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 		Verbose:           false,
 		Debug:             false,
 		Stream:            false,
-		Rate:              runner.DefaultRateConnectScan,
+		Rate:              config.PacketsPerSecond, // Global rate limit: packets per second across all threads (this is the bottleneck, not thread count)
 		Retries:           runner.DefaultRetriesConnectScan,
 		Threads:           config.Threads,
 		Timeout:           runner.DefaultPortTimeoutConnectScan,


### PR DESCRIPTION
### TL;DR

Added a new `--packets-per-second` flag to the port scanning functionality to control scan rate.

### What changed?

- Added a new `--packets-per-second` parameter to the `discover port` command with a default value of 1000
- Updated the port scanning configuration to use this parameter instead of a hardcoded rate
- Modified the `DiscoverPortConfig` struct in the Fern definition to include the new parameter
- Passed the parameter through the command chain to the underlying port scanning implementation
