### PR TITLE
Add FortiGate FGFM protocol fingerprinting support

### DIFF
--- a/fern/definition/common/common.yml
+++ b/fern/definition/common/common.yml
@@ -6,6 +6,7 @@ types:
       - DHCP
       - DNS
       - ECHO
+      - FGFM
       - FTP
       - GRPC
       - HTTP

--- a/fern/definition/common/protocol/fgfm.yml
+++ b/fern/definition/common/protocol/fgfm.yml
@@ -1,0 +1,13 @@
+types:
+  # FortiGate to FortiManager Protocol Server Information
+  FgfmServerInfo:
+    properties:
+      # Discovery fields
+      vendor: optional<string> # Vendor name (e.g., "Fortinet")
+      product: optional<string> # Product name (e.g., "FortiGate")
+      certificateAuthority: optional<string> # Certificate authority (e.g., "fortinet-ca")
+      supportDomain: optional<string> # Support domain (e.g., "support.fortinet.com")
+
+      # Additional FGFM protocol details
+      managementEnabled: optional<boolean> # Whether FortiManager access is enabled
+      port: optional<integer> # FGFM service port (typically 541)

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -19,6 +19,7 @@ imports:
   netbiosProtocol: ../common/protocol/netbios.yml
   ipmiProtocol: ../common/protocol/ipmi.yml
   ubiquitiProtocol: ../common/protocol/ubiquiti.yml
+  fgfmProtocol: ../common/protocol/fgfm.yml
 
 types:
   # Generic metadata for fingerprintx and other sources
@@ -50,6 +51,7 @@ types:
       netbios: netbiosProtocol.NetbiosServerInfo
       ipmi: ipmiProtocol.IpmiServerInfo
       ubiquiti: ubiquitiProtocol.UbiquitiServerInfo
+      fgfm: fgfmProtocol.FgfmServerInfo
 
   # Stealth service types
   StealthServiceType:

--- a/internal/discover/service/plugins/fortigate.go
+++ b/internal/discover/service/plugins/fortigate.go
@@ -1,0 +1,130 @@
+// Package plugins provides FortiGate FGFM service fingerprinting
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	"github.com/Method-Security/networkscan/generated/go/common/protocol"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+)
+
+type FortiGateFingerprinter struct{}
+
+func (FortiGateFingerprinter) Name() string { return "fortigate-fgfm" }
+
+// DefaultPorts returns port 541 (FGFM - FortiGate to FortiManager protocol)
+func (FortiGateFingerprinter) DefaultPorts() []int { return []int{541} }
+
+func (FortiGateFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	// Channel to receive the result or error from the goroutine
+	resultChan := make(chan *discoverfern.ServiceDetails, 1)
+	errorChan := make(chan error, 1)
+
+	// Run the FortiGate detection in a goroutine
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				errorChan <- context.DeadlineExceeded
+			}
+		}()
+
+		result, err := detectFortiGateService(ctx, ip, port, host, timeout)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		resultChan <- result
+	}()
+
+	// Wait for either the result, error, or timeout
+	select {
+	case result := <-resultChan:
+		return result, nil
+	case err := <-errorChan:
+		return nil, err
+	case <-time.After(time.Duration(timeout) * time.Second):
+		return nil, context.DeadlineExceeded
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// detectFortiGateService performs the actual FortiGate FGFM detection
+// FGFM runs over SSL/TLS and responds immediately upon connection with handshake data
+// containing Fortinet identifiers in the certificate information
+func detectFortiGateService(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	// Create a dialer with timeout
+	dialer := &net.Dialer{
+		Timeout: time.Duration(timeout) * time.Second,
+	}
+
+	// Connect to the target
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port)))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Set read deadline
+	_ = conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second))
+
+	// FGFM service responds immediately with SSL/TLS handshake upon connection
+	// No need to send any data - just read the response
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if err != nil && n == 0 {
+		return nil, err
+	}
+
+	// Convert response to string for pattern matching
+	response := string(buf[:n])
+
+	// Check for Fortinet/FortiGate identifiers in the response
+	// These appear in SSL/TLS handshake data or certificate information
+	if strings.Contains(strings.ToLower(response), "fortinet") ||
+		strings.Contains(strings.ToLower(response), "fortigate") {
+
+		// Build metadata
+		vendor := "Fortinet"
+		product := "FortiGate"
+		managementEnabled := true
+		metadata := &protocol.FgfmServerInfo{
+			Vendor:            &vendor,
+			Product:           &product,
+			ManagementEnabled: &managementEnabled,
+			Port:              &port,
+		}
+
+		// Try to extract additional information from the response
+		if strings.Contains(response, "fortinet-ca") {
+			ca := "fortinet-ca"
+			metadata.CertificateAuthority = &ca
+		}
+		if strings.Contains(response, "support.fortinet.com") {
+			supportDomain := "support.fortinet.com"
+			metadata.SupportDomain = &supportDomain
+		}
+
+		version := "FortiGate Management Service"
+		result := &discoverfern.ServiceDetails{
+			Host:      host,
+			Ip:        ip.String(),
+			Port:      port,
+			Tls:       true, // FGFM runs over SSL/TLS
+			Transport: common.TransportTypeTcp,
+			Protocol:  common.ProtocolTypeFgfm,
+			Version:   &version,
+			Metadata:  discoverfern.NewServiceMetadataFromFgfm(metadata),
+		}
+
+		return result, nil
+	}
+
+	// Not a FortiGate FGFM service
+	return nil, fmt.Errorf("no FortiGate FGFM service detected")
+}

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -46,14 +46,15 @@ type Fingerprinter interface {
 // Custom fingerprinters for protocols that need specialized detection
 // These run BEFORE fingerprintx to provide more specific detection
 var customFingerprintModules = []Fingerprinter{
-	&localPlugins.GrpcFingerprinter{},     // gRPC can run on any port
-	&localPlugins.MongoDBFingerprinter{},  // MongoDB driver manages its own connections
-	&localPlugins.BGPFingerprinter{},      // BGP protocol detection
-	&localPlugins.DCERPCFingerprinter{},   // Windows DCE/RPC
-	&localPlugins.IPPFingerprinter{},      // Internet Printing Protocol
-	&localPlugins.WinRMFingerprinter{},    // Windows Remote Management
-	&localPlugins.KerberosFingerprinter{}, // Kerberos (Kerberos 5),
-	&localPlugins.SMBFingerprinter{},      // SMB (Server Message Block),
+	&localPlugins.GrpcFingerprinter{},      // gRPC can run on any port
+	&localPlugins.MongoDBFingerprinter{},   // MongoDB driver manages its own connections
+	&localPlugins.BGPFingerprinter{},       // BGP protocol detection
+	&localPlugins.DCERPCFingerprinter{},    // Windows DCE/RPC
+	&localPlugins.IPPFingerprinter{},       // Internet Printing Protocol
+	&localPlugins.WinRMFingerprinter{},     // Windows Remote Management
+	&localPlugins.KerberosFingerprinter{},  // Kerberos (Kerberos 5),
+	&localPlugins.SMBFingerprinter{},       // SMB (Server Message Block),
+	&localPlugins.FortiGateFingerprinter{}, // FortiGate FGFM (FortiGate to FortiManager),
 }
 
 // UDP fingerprinters mapped to their specific ports


### PR DESCRIPTION
### TL;DR

Added support for detecting FortiGate FGFM (FortiGate to FortiManager) protocol on port 541.

### What changed?

- Added `FGFM` to the list of supported protocol types in common.yml
- Created a new protocol definition file `fgfm.yml` with the `FgfmServerInfo` type
- Added FGFM protocol support to the discover service
- Implemented a FortiGate fingerprinter plugin that detects FGFM services running on port 541
- Registered the FortiGate fingerprinter in the list of custom fingerprint modules

### How to test?

1. Run a scan against a network with FortiGate devices
2. Verify that port 541 is properly identified as FGFM protocol
3. Check that the service details include vendor (Fortinet), product (FortiGate), and management status

### Why make this change?

FortiGate devices are common in enterprise networks, and detecting their management protocol (FGFM) provides valuable information during network scans. This enhancement improves the scanner's ability to identify and fingerprint Fortinet security appliances, giving users better visibility into their network infrastructure.