### PR TITLE
confirm conn != nil before calling Close()

### DIFF
--- a/internal/discover/service/plugins/grpc.go
+++ b/internal/discover/service/plugins/grpc.go
@@ -49,7 +49,11 @@ func (GrpcFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 			return nil, nil // neither path worked → not gRPC
 		}
 	}
-	defer func() { _ = conn.Close() }()
+	defer func() {
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}()
 
 	/* ---- Server-reflection ListServices ---------------------------------- */
 	rctx, cancel := context.WithTimeout(timeoutCtx, timeoutDuration/2)

--- a/internal/discover/service/plugins/kerberos.go
+++ b/internal/discover/service/plugins/kerberos.go
@@ -41,7 +41,11 @@ func (KerberosFingerprinter) Detect(ctx context.Context, ip net.IP, port int, ho
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
+	defer func() {
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}()
 
 	// Try Kerberos detection on plaintext connection
 	result, tlsUsed, err := detectKerberos(conn, host, timeoutDuration, false)
@@ -52,7 +56,11 @@ func (KerberosFingerprinter) Detect(ctx context.Context, ip net.IP, port int, ho
 		if err != nil {
 			return nil, err
 		}
-		defer func() { _ = conn.Close() }()
+		defer func() {
+			if conn != nil {
+				_ = conn.Close()
+			}
+		}()
 
 		result, tlsUsed, err = detectKerberos(conn, host, timeoutDuration, true)
 		if err != nil || !result {


### PR DESCRIPTION
Had some SIGSEGV pop up from calling Close() when conn was nil
