### PR TITLE
Bump Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "0.89.0"
+  "version": "1.2.0"
 }


### PR DESCRIPTION
### TL;DR

Updated Fern configuration version from 0.89.0 to 1.2.0.

### What changed?

Bumped the version in `fern/fern.config.json` from 0.89.0 to 1.2.0, which represents a significant version upgrade.