### PR TITLE
Add New Service Fingerprint Modules

### DIFF
--- a/fern/definition/common/common.yml
+++ b/fern/definition/common/common.yml
@@ -8,6 +8,7 @@ types:
       - DHCP
       - DNS
       - ECHO
+      - ETHERNETIP
       - FGFM
       - FINS
       - FOX

--- a/fern/definition/common/protocol/unistream.yml
+++ b/fern/definition/common/protocol/unistream.yml
@@ -1,0 +1,11 @@
+types:
+  # Unitronics UniStream (EtherNet/IP) PLC Information
+  UnistreamServerInfo:
+    properties:
+      # Discovery fields
+      version: optional<string>
+      productName: optional<string>
+      vendorId: optional<string>
+      serialNumber: optional<string>
+      deviceType: optional<string>
+      deviceIp: optional<string>

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -37,6 +37,7 @@ imports:
   hartProtocol: ../common/protocol/hart.yml
   foxProtocol: ../common/protocol/fox.yml
   memcachedProtocol: ../common/protocol/memcached.yml
+  unistreamProtocol: ../common/protocol/unistream.yml
 
 types:
   # Generic metadata for fingerprintx and other sources
@@ -86,6 +87,7 @@ types:
       hart: hartProtocol.HartServerInfo
       fox: foxProtocol.FoxServerInfo
       memcached: memcachedProtocol.MemcachedServerInfo
+      unistream: unistreamProtocol.UnistreamServerInfo
 
   # Stealth service types
   StealthServiceType:

--- a/internal/discover/service/plugins/pcom.go
+++ b/internal/discover/service/plugins/pcom.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Method-Security/networkscan/generated/go/common"
@@ -38,77 +40,141 @@ func (PcomFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		return nil, err
 	}
 
-	// PCOM identification request
-	// PCOM protocol structure: /ID + command code
-	// Command 0x4D (ID request) to identify the PLC
-	pcomRequest := []byte{
-		0x2F, 0x5F, // ASCII "/_" - PCOM header
-		0x49, 0x44, // ASCII "ID" - Identification command
-		0x02,       // STX (Start of Text)
-		0x30, 0x30, // Unit ID "00"
-		0x4D, // Command: Get PLC Name
-		0x03, // ETX (End of Text)
+	// Try multiple PCOM identification requests
+	// PCOM protocol can vary between models, so try different approaches
+
+	var response []byte
+	var n int
+	var lastErr error
+
+	// Approach 1: Standard PCOM ID command
+	pcomRequests := [][]byte{
+		// Standard ID command
+		{0x2F, 0x49, 0x44, 0x02, 0x30, 0x30, 0x4D, 0x03, 0x6A, 0x0D}, // /ID with checksum
+		// Alternative ID command format
+		{0x2F, 0x5F, 0x49, 0x44, 0x02, 0x30, 0x30, 0x4D, 0x03, 0x6E, 0x0D}, // /_ID variant
+		// Simple identification
+		{0x2F, 0x49, 0x44, 0x0D}, // /ID simple
+		// PCOM info request
+		{0x2F, 0x49, 0x4E, 0x46, 0x4F, 0x0D}, // /INFO
 	}
 
-	// Calculate and append checksum (XOR of all bytes between STX and ETX)
-	checksum := byte(0)
-	for i := 4; i < len(pcomRequest)-1; i++ {
-		checksum ^= pcomRequest[i]
-	}
-	pcomRequest = append(pcomRequest, checksum)
-	pcomRequest = append(pcomRequest, 0x0D) // CR (Carriage Return)
+	responseBuffer := make([]byte, 1024)
 
-	// Send identification request
-	if _, err := conn.Write(pcomRequest); err != nil {
-		return nil, err
+	for _, req := range pcomRequests {
+		// Send request
+		if _, err := conn.Write(req); err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Set a shorter read timeout for each attempt
+		if err := conn.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Read response
+		n, err = conn.Read(responseBuffer)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if n > 0 {
+			response = responseBuffer[:n]
+			break
+		}
 	}
 
-	// Read response
-	response := make([]byte, 512)
-	n, err := conn.Read(response)
-	if err != nil {
-		return nil, err
+	// If no response from any request, return the last error
+	if n == 0 || response == nil {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("no response from PCOM requests")
 	}
 
-	// PCOM responses typically start with "/_"
-	if n < 6 {
+	// PCOM responses can vary, but typically contain readable text
+	if n < 3 {
 		return nil, fmt.Errorf("response too short")
 	}
 
-	// Verify PCOM response header
-	if response[0] != 0x2F || response[1] != 0x41 { // "/A" for acknowledgment
-		return nil, fmt.Errorf("invalid PCOM response header")
+	// Convert response to string for pattern matching
+	responseStr := string(response[:n])
+
+	// Check for PCOM indicators in response (be more flexible)
+	isPcomResponse := false
+
+	// Check for common PCOM response patterns
+	if strings.Contains(responseStr, "PCOM") ||
+		strings.Contains(responseStr, "Unitronics") ||
+		strings.Contains(responseStr, "Model:") ||
+		strings.Contains(responseStr, "PLC") ||
+		strings.Contains(responseStr, "Vision") ||
+		strings.Contains(responseStr, "V") ||
+		(response[0] == 0x2F && (response[1] == 0x41 || response[1] == 0x49)) { // "/A" or "/I" response
+		isPcomResponse = true
 	}
 
-	// Extract PLC information from response
-	var plcModel, plcName, firmwareVersion *string
-
-	// Parse response payload (after header)
-	if n > 10 && response[2] == 0x02 { // STX found
-		// Find ETX to determine payload length
-		etxPos := -1
-		for i := 3; i < n; i++ {
-			if response[i] == 0x03 {
-				etxPos = i
-				break
-			}
-		}
-
-		if etxPos > 3 {
-			payload := response[3:etxPos]
-			// Try to extract ASCII strings that might indicate PLC model
-			if len(payload) > 0 {
-				plcInfo := string(payload)
-				if len(plcInfo) > 0 && isPrintableString(plcInfo) {
-					plcModel = &plcInfo
+	// Also check for binary response patterns that might indicate PCOM
+	if !isPcomResponse {
+		// Look for structured binary data that might be PCOM
+		for i := 0; i < n-3; i++ {
+			if response[i] == 0x02 && response[i+1] != 0x00 { // STX followed by data
+				// Look for ETX
+				for j := i + 2; j < n && j < i+50; j++ {
+					if response[j] == 0x03 { // Found ETX
+						isPcomResponse = true
+						break
+					}
+				}
+				if isPcomResponse {
+					break
 				}
 			}
 		}
 	}
 
-	// Extract version from response if available
+	if !isPcomResponse {
+		return nil, fmt.Errorf("not a PCOM response")
+	}
+
+	// Extract PLC information from response using regex patterns
+	var plcModel, plcName, firmwareVersion, hardwareVersion, osVersion, osBuild, uniqueID *string
+
+	// Define patterns to extract information from PCOM response
+	patterns := map[string]**string{
+		`Model:\s*([^\r\n]+)`:            &plcModel,
+		`PLC Name:\s*([^\r\n]+)`:         &plcName,
+		`Hardware Version:\s*([^\r\n]+)`: &hardwareVersion,
+		`OS Version:\s*([^\r\n]+)`:       &osVersion,
+		`OS Build:\s*([^\r\n]+)`:         &osBuild,
+		`PLC Unique ID:\s*([^\r\n]+)`:    &uniqueID,
+	}
+
+	for pattern, field := range patterns {
+		if re := regexp.MustCompile(pattern); re != nil {
+			if matches := re.FindStringSubmatch(responseStr); len(matches) > 1 {
+				value := strings.TrimSpace(matches[1])
+				if value != "" {
+					*field = &value
+				}
+			}
+		}
+	}
+
+	// If we have OS Version and Build, combine them for firmware version
+	if osVersion != nil && osBuild != nil {
+		combined := *osVersion + " Build " + *osBuild
+		firmwareVersion = &combined
+	} else if osVersion != nil {
+		firmwareVersion = osVersion
+	}
+
+	// Set version based on detection
 	var version *string
-	if plcModel != nil {
+	if plcModel != nil || strings.Contains(responseStr, "PCOM") || strings.Contains(responseStr, "Unitronics") {
 		versionStr := "PCOM"
 		version = &versionStr
 	}
@@ -132,18 +198,4 @@ func (PcomFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	}
 
 	return result, nil
-}
-
-// isPrintableString checks if a string contains mostly printable ASCII characters
-func isPrintableString(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
-	printableCount := 0
-	for _, c := range s {
-		if c >= 32 && c <= 126 {
-			printableCount++
-		}
-	}
-	return printableCount > len(s)/2
 }

--- a/internal/discover/service/plugins/unistream.go
+++ b/internal/discover/service/plugins/unistream.go
@@ -1,0 +1,205 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	"github.com/Method-Security/networkscan/generated/go/common/protocol"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+)
+
+type UnistreamFingerprinter struct{}
+
+func (UnistreamFingerprinter) Name() string { return "unistream" }
+
+func (UnistreamFingerprinter) DefaultPorts() []int { return []int{44818} }
+
+func (UnistreamFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
+
+	// Create connection with timeout
+	dialer := net.Dialer{
+		Timeout: time.Duration(timeout) * time.Second,
+	}
+
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Set read/write deadline
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	if err := conn.SetDeadline(deadline); err != nil {
+		return nil, err
+	}
+
+	// EtherNet/IP List Identity request
+	// EtherNet/IP encapsulation header: Command 0x0063 (List Identity)
+	ethernetIPRequest := []byte{
+		0x63, 0x00, // Command: List Identity (0x0063)
+		0x00, 0x00, // Length: 0 (no data)
+		0x00, 0x00, 0x00, 0x00, // Session Handle: 0
+		0x00, 0x00, 0x00, 0x00, // Status: 0 (success)
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Sender Context: 8 bytes of 0
+		0x00, 0x00, 0x00, 0x00, // Options: 0
+	}
+
+	// Send List Identity request
+	if _, err := conn.Write(ethernetIPRequest); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	response := make([]byte, 512)
+	n, err := conn.Read(response)
+	if err != nil {
+		return nil, err
+	}
+
+	// EtherNet/IP List Identity response should be at least 24 bytes (header)
+	if n < 24 {
+		return nil, fmt.Errorf("response too short")
+	}
+
+	// Verify EtherNet/IP List Identity response header
+	// Command should be 0x0063, Status should be 0x0000 (success)
+	if response[0] != 0x63 || response[1] != 0x00 {
+		return nil, fmt.Errorf("invalid EtherNet/IP command response")
+	}
+
+	// Check status (bytes 8-11 should be 0x00000000 for success)
+	if response[8] != 0x00 || response[9] != 0x00 || response[10] != 0x00 || response[11] != 0x00 {
+		return nil, fmt.Errorf("EtherNet/IP error status")
+	}
+
+	// Extract device information from List Identity response
+	var productName, vendorID, serialNumber, deviceType, deviceIP *string
+
+	// Convert response to string for pattern matching - EtherNet/IP can contain readable strings
+	responseStr := string(response[:n])
+
+	// Look for Unitronics/UniStream indicators first
+	if strings.Contains(strings.ToLower(responseStr), "unistream") {
+		product := "Unistream"
+		productName = &product
+	}
+
+	if strings.Contains(strings.ToLower(responseStr), "unitronics") {
+		vendor := "Unitronics (1989) (RG) LTD"
+		vendorID = &vendor
+	}
+
+	// Try to extract fields using regex patterns from readable strings in the response
+	patterns := map[string]**string{
+		`Product name:\s*([^\r\n]+)`:                                    &productName,
+		`Vendor ID:\s*([^\r\n]+)`:                                       &vendorID,
+		`Serial number:\s*(0x[a-fA-F0-9]+|[0-9]+)`:                      &serialNumber,
+		`Device type:\s*([^\r\n]+)`:                                     &deviceType,
+		`Device IP:\s*([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})`: &deviceIP,
+	}
+
+	for pattern, field := range patterns {
+		if re := regexp.MustCompile(pattern); re != nil {
+			if matches := re.FindStringSubmatch(responseStr); len(matches) > 1 {
+				value := strings.TrimSpace(matches[1])
+				if value != "" {
+					*field = &value
+				}
+			}
+		}
+	}
+
+	// Parse the identity item structure for additional data (starts at byte 24 if present)
+	if n > 24 {
+		pos := 24
+		for pos < n-6 {
+			// Check for Identity Item (Type ID 0x000C)
+			if pos+6 < n && response[pos] == 0x0C && response[pos+1] == 0x00 {
+				// Extract length of identity data
+				length := int(response[pos+2]) | (int(response[pos+3]) << 8)
+				if pos+6+length <= n {
+					identityData := response[pos+6 : pos+6+length]
+
+					// Extract any additional readable strings from binary data
+					if len(identityData) >= 8 && productName == nil {
+						productNameStr := extractStringFromIdentity(identityData, length)
+						if productNameStr != "" {
+							productName = &productNameStr
+						}
+					}
+				}
+				break
+			}
+			pos++
+		}
+	}
+
+	// Set version based on detection
+	var version *string
+	if productName != nil || vendorID != nil {
+		versionStr := "EtherNet/IP"
+		version = &versionStr
+	}
+
+	metadata := &protocol.UnistreamServerInfo{
+		Version:      version,
+		ProductName:  productName,
+		VendorId:     vendorID,
+		SerialNumber: serialNumber,
+		DeviceType:   deviceType,
+		DeviceIp:     deviceIP,
+	}
+
+	result := &discoverfern.ServiceDetails{
+		Host:      host,
+		Ip:        ip.String(),
+		Port:      port,
+		Tls:       false,
+		Transport: common.TransportTypeTcp,
+		Protocol:  common.ProtocolTypeEthernetip,
+		Version:   version,
+		Metadata:  discoverfern.NewServiceMetadataFromUnistream(metadata),
+	}
+
+	return result, nil
+}
+
+// extractStringFromIdentity extracts printable strings from EtherNet/IP identity data
+func extractStringFromIdentity(data []byte, length int) string {
+	// Look for printable ASCII strings in the identity data
+	var result strings.Builder
+	inString := false
+
+	for i := 0; i < len(data) && i < length; i++ {
+		char := data[i]
+		if char >= 32 && char <= 126 { // Printable ASCII
+			if !inString {
+				if result.Len() > 0 {
+					result.WriteString(" ")
+				}
+				inString = true
+			}
+			result.WriteByte(char)
+		} else if inString {
+			inString = false
+		}
+	}
+
+	str := result.String()
+
+	// Clean up the extracted string
+	str = strings.TrimSpace(str)
+
+	// Return only if it looks like useful device information
+	if len(str) > 3 && len(str) < 100 {
+		return str
+	}
+
+	return ""
+}

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -70,6 +70,7 @@ var customFingerprintModules = []Fingerprinter{
 	&localPlugins.HartFingerprinter{},      // HART-IP (Highway Addressable Remote Transducer)
 	&localPlugins.FoxFingerprinter{},       // FOX (Tridium Niagara Framework)
 	&localPlugins.MemcachedFingerprinter{}, // MEMCACHED
+	&localPlugins.UnistreamFingerprinter{}, // Unitronics UniStream (EtherNet/IP)
 }
 
 // UDP fingerprinters mapped to their specific ports


### PR DESCRIPTION
### TL;DR

Added support for detecting Unitronics UniStream PLCs using the EtherNet/IP protocol and improved PCOM detection.

### What changed?

- Added `ETHERNETIP` to the list of supported protocols in common.yml
- Created a new `unistream.yml` file defining the `UnistreamServerInfo` type for Unitronics UniStream PLC information
- Added the UniStream type to the service metadata in discover/service.yml
- Implemented a new `UnistreamFingerprinter` to detect Unitronics PLCs using EtherNet/IP protocol on port 44818
- Enhanced the existing PCOM fingerprinter with more robust detection methods:
    - Added multiple PCOM identification request formats
    - Improved response parsing with regex patterns
    - Added extraction of additional device information (hardware version, OS version, etc.)