### PR TITLE
Add IKE protocol fingerprinting support

### DIFF
--- a/fern/definition/common/common.yml
+++ b/fern/definition/common/common.yml
@@ -19,6 +19,7 @@ types:
       - HTTPS
       - HTTP2
       - IEC104
+      - IKE
       - IMAP
       - IMAPS
       - IPP

--- a/fern/definition/common/protocol/ike.yml
+++ b/fern/definition/common/protocol/ike.yml
@@ -1,0 +1,20 @@
+types:
+  # IKE Server Information
+  IkeServerInfo:
+    properties:
+      # Discovery fields
+      version: optional<string>
+      initiatorSpi: optional<string>
+      responderSpi: optional<string>
+      exchangeType: optional<string>
+      flags: optional<string>
+      messageId: optional<string>
+
+      # Vendor ID information
+      vendorIds: optional<list<string>>
+
+      # Security Association details
+      encryptionAlgorithms: optional<list<string>>
+      hashAlgorithms: optional<list<string>>
+      authenticationMethods: optional<list<string>>
+      dhGroups: optional<list<string>>

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -26,6 +26,7 @@ imports:
   xdmcpProtocol: ../common/protocol/xdmcp.yml
   pcomProtocol: ../common/protocol/pcom.yml
   iec104Protocol: ../common/protocol/iec104.yml
+  ikeProtocol: ../common/protocol/ike.yml
   gesrtpProtocol: ../common/protocol/gesrtp.yml
   finsProtocol: ../common/protocol/fins.yml
   atgProtocol: ../common/protocol/atg.yml
@@ -75,6 +76,7 @@ types:
       xdmcp: xdmcpProtocol.XdmcpServerInfo
       pcom: pcomProtocol.PcomServerInfo
       iec104: iec104Protocol.Iec104ServerInfo
+      ike: ikeProtocol.IkeServerInfo
       gesrtp: gesrtpProtocol.GesrtpServerInfo
       fins: finsProtocol.FinsServerInfo
       atg: atgProtocol.AtgServerInfo

--- a/internal/discover/service/plugins/ike.go
+++ b/internal/discover/service/plugins/ike.go
@@ -1,0 +1,471 @@
+// Package plugins provides IKE (Internet Key Exchange) service fingerprinting
+package plugins
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	"github.com/Method-Security/networkscan/generated/go/common/protocol"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+)
+
+type IKEFingerprinter struct{}
+
+func (IKEFingerprinter) Name() string { return "ike" }
+
+func (IKEFingerprinter) DefaultPorts() []int { return []int{500, 4500} }
+
+func (IKEFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
+
+	// Create UDP connection
+	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Set read deadline
+	if err := conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second)); err != nil {
+		return nil, err
+	}
+
+	// Build IKEv2 SA_INIT request packet
+	ikeRequest := buildIKEv2SAInitRequest()
+
+	// Send the request
+	if _, err := conn.Write(ikeRequest); err != nil {
+		return nil, err
+	}
+
+	// Read response
+	buffer := make([]byte, 4096)
+	n, err := conn.Read(buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	// IKE response must be at least 28 bytes (header size)
+	if n < 28 {
+		return nil, fmt.Errorf("invalid IKE response size: %d", n)
+	}
+
+	// Parse IKE response header
+	response := buffer[:n]
+	ikeHeader, err := parseIKEHeader(response)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate it's an IKE response
+	if ikeHeader.NextPayload == 0 && ikeHeader.MajorVersion == 0 {
+		return nil, fmt.Errorf("invalid IKE header")
+	}
+
+	// Parse payloads for additional information
+	vendorIDs, proposals := parseIKEPayloads(response[28:n], ikeHeader.NextPayload)
+
+	version := fmt.Sprintf("IKEv%d", ikeHeader.MajorVersion)
+	initiatorSPI := hex.EncodeToString(ikeHeader.InitiatorSPI[:])
+	responderSPI := hex.EncodeToString(ikeHeader.ResponderSPI[:])
+	exchangeType := getExchangeTypeName(ikeHeader.ExchangeType)
+	flags := fmt.Sprintf("0x%02x", ikeHeader.Flags)
+	messageID := fmt.Sprintf("%d", ikeHeader.MessageID)
+
+	metadata := &protocol.IkeServerInfo{
+		Version:      &version,
+		InitiatorSpi: &initiatorSPI,
+		ResponderSpi: &responderSPI,
+		ExchangeType: &exchangeType,
+		Flags:        &flags,
+		MessageId:    &messageID,
+	}
+
+	// Add vendor IDs if any were found
+	if len(vendorIDs) > 0 {
+		metadata.VendorIds = vendorIDs
+	}
+
+	// Add security proposal details if found
+	if len(proposals.EncryptionAlgs) > 0 {
+		metadata.EncryptionAlgorithms = proposals.EncryptionAlgs
+	}
+	if len(proposals.HashAlgs) > 0 {
+		metadata.HashAlgorithms = proposals.HashAlgs
+	}
+	if len(proposals.AuthMethods) > 0 {
+		metadata.AuthenticationMethods = proposals.AuthMethods
+	}
+	if len(proposals.DHGroups) > 0 {
+		metadata.DhGroups = proposals.DHGroups
+	}
+
+	result := &discoverfern.ServiceDetails{
+		Host:      host,
+		Ip:        ip.String(),
+		Port:      port,
+		Tls:       false,
+		Transport: common.TransportTypeUdp,
+		Protocol:  common.ProtocolTypeIke,
+		Version:   &version,
+		Metadata:  discoverfern.NewServiceMetadataFromIke(metadata),
+	}
+
+	return result, nil
+}
+
+// IKEHeader represents the IKE message header
+type IKEHeader struct {
+	InitiatorSPI [8]byte
+	ResponderSPI [8]byte
+	NextPayload  byte
+	MajorVersion byte
+	MinorVersion byte
+	ExchangeType byte
+	Flags        byte
+	MessageID    uint32
+	Length       uint32
+}
+
+// SecurityProposals holds parsed security association proposals
+type SecurityProposals struct {
+	EncryptionAlgs []string
+	HashAlgs       []string
+	AuthMethods    []string
+	DHGroups       []string
+}
+
+// parseIKEHeader parses the IKE message header
+func parseIKEHeader(data []byte) (*IKEHeader, error) {
+	if len(data) < 28 {
+		return nil, fmt.Errorf("data too short for IKE header")
+	}
+
+	header := &IKEHeader{
+		NextPayload:  data[16],
+		MajorVersion: (data[17] & 0xF0) >> 4,
+		MinorVersion: data[17] & 0x0F,
+		ExchangeType: data[18],
+		Flags:        data[19],
+		MessageID:    binary.BigEndian.Uint32(data[20:24]),
+		Length:       binary.BigEndian.Uint32(data[24:28]),
+	}
+
+	copy(header.InitiatorSPI[:], data[0:8])
+	copy(header.ResponderSPI[:], data[8:16])
+
+	return header, nil
+}
+
+// parseIKEPayloads extracts vendor IDs and security proposals from IKE payloads
+func parseIKEPayloads(data []byte, nextPayload byte) ([]string, *SecurityProposals) {
+	var vendorIDs []string
+	proposals := &SecurityProposals{
+		EncryptionAlgs: []string{},
+		HashAlgs:       []string{},
+		AuthMethods:    []string{},
+		DHGroups:       []string{},
+	}
+
+	currentPayload := nextPayload
+	offset := 0
+
+	for offset < len(data) && currentPayload != 0 {
+		if offset+4 > len(data) {
+			break
+		}
+
+		payloadLength := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		if payloadLength < 4 || offset+payloadLength > len(data) {
+			break
+		}
+
+		payloadData := data[offset+4 : offset+payloadLength]
+
+		// Parse vendor ID payloads (type 43)
+		if currentPayload == 43 && len(payloadData) > 0 {
+			vendorID := string(payloadData)
+			// Only add printable vendor IDs
+			if isIKEVendorIDPrintable(vendorID) {
+				vendorIDs = append(vendorIDs, vendorID)
+			} else {
+				// Store as hex if not printable
+				vendorIDs = append(vendorIDs, hex.EncodeToString(payloadData))
+			}
+		}
+
+		// Parse Security Association payloads (type 33)
+		if currentPayload == 33 && len(payloadData) > 0 {
+			parseSAPayload(payloadData, proposals)
+		}
+
+		// Move to next payload
+		currentPayload = data[offset]
+		offset += payloadLength
+	}
+
+	return vendorIDs, proposals
+}
+
+// parseSAPayload extracts security proposals from SA payload
+func parseSAPayload(data []byte, proposals *SecurityProposals) {
+	offset := 0
+	for offset+8 <= len(data) {
+		// Parse proposal
+		proposalLength := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		if proposalLength < 8 || offset+proposalLength > len(data) {
+			break
+		}
+
+		numTransforms := int(data[offset+7])
+		transformOffset := offset + 8
+
+		// Parse transforms
+		for i := 0; i < numTransforms && transformOffset+8 <= len(data); i++ {
+			transformLength := int(binary.BigEndian.Uint16(data[transformOffset+2 : transformOffset+4]))
+			if transformLength < 8 {
+				break
+			}
+
+			transformType := data[transformOffset+4]
+			transformID := binary.BigEndian.Uint16(data[transformOffset+6 : transformOffset+8])
+
+			switch transformType {
+			case 1: // Encryption Algorithm
+				proposals.EncryptionAlgs = appendUnique(proposals.EncryptionAlgs, getEncryptionAlgorithmName(transformID))
+			case 2: // PRF (Pseudo-random Function)
+				proposals.HashAlgs = appendUnique(proposals.HashAlgs, getPRFName(transformID))
+			case 3: // Integrity Algorithm
+				proposals.HashAlgs = appendUnique(proposals.HashAlgs, getIntegrityAlgorithmName(transformID))
+			case 4: // Diffie-Hellman Group
+				proposals.DHGroups = appendUnique(proposals.DHGroups, getDHGroupName(transformID))
+			}
+
+			transformOffset += transformLength
+		}
+
+		offset += proposalLength
+	}
+}
+
+// Helper function to append unique strings
+func appendUnique(slice []string, item string) []string {
+	for _, existing := range slice {
+		if existing == item {
+			return slice
+		}
+	}
+	return append(slice, item)
+}
+
+// isIKEVendorIDPrintable checks if a string contains only printable ASCII characters
+func isIKEVendorIDPrintable(s string) bool {
+	for _, r := range s {
+		if r < 32 || r > 126 {
+			return false
+		}
+	}
+	return true
+}
+
+// buildIKEv2SAInitRequest creates an IKEv2 SA_INIT request packet
+func buildIKEv2SAInitRequest() []byte {
+	// IKE header (28 bytes)
+	packet := make([]byte, 28)
+
+	// Initiator SPI (8 bytes) - random
+	initiatorSPI := []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}
+	copy(packet[0:8], initiatorSPI)
+
+	// Responder SPI (8 bytes) - zeros for initial request
+	// Already zeros from make()
+
+	// Next Payload: SA (33)
+	packet[16] = 33
+
+	// Version: 2.0
+	packet[17] = 0x20 // Major: 2, Minor: 0
+
+	// Exchange Type: IKE_SA_INIT (34)
+	packet[18] = 34
+
+	// Flags: Initiator
+	packet[19] = 0x08
+
+	// Message ID: 0
+	// Already zeros
+
+	// Length: 28 (just header for simple detection)
+	binary.BigEndian.PutUint32(packet[24:28], 28)
+
+	return packet
+}
+
+// getExchangeTypeName returns the human-readable name for an exchange type
+func getExchangeTypeName(exchangeType byte) string {
+	switch exchangeType {
+	case 34:
+		return "IKE_SA_INIT"
+	case 35:
+		return "IKE_AUTH"
+	case 36:
+		return "CREATE_CHILD_SA"
+	case 37:
+		return "INFORMATIONAL"
+	default:
+		return fmt.Sprintf("UNKNOWN_%d", exchangeType)
+	}
+}
+
+// getEncryptionAlgorithmName returns the name for an encryption algorithm ID
+func getEncryptionAlgorithmName(id uint16) string {
+	switch id {
+	case 1:
+		return "DES-CBC"
+	case 2:
+		return "IDEA-CBC"
+	case 3:
+		return "Blowfish-CBC"
+	case 5:
+		return "3DES-CBC"
+	case 7:
+		return "CAST-CBC"
+	case 11:
+		return "NULL"
+	case 12:
+		return "AES-CBC"
+	case 13:
+		return "AES-CTR"
+	case 18:
+		return "AES-GCM-8"
+	case 19:
+		return "AES-GCM-12"
+	case 20:
+		return "AES-GCM-16"
+	case 23:
+		return "Camellia-CBC"
+	case 28:
+		return "ChaCha20-Poly1305"
+	default:
+		return fmt.Sprintf("ENC_%d", id)
+	}
+}
+
+// getPRFName returns the name for a PRF algorithm ID
+func getPRFName(id uint16) string {
+	switch id {
+	case 1:
+		return "PRF-HMAC-MD5"
+	case 2:
+		return "PRF-HMAC-SHA1"
+	case 3:
+		return "PRF-HMAC-TIGER"
+	case 4:
+		return "PRF-AES128-XCBC"
+	case 5:
+		return "PRF-HMAC-SHA256"
+	case 6:
+		return "PRF-HMAC-SHA384"
+	case 7:
+		return "PRF-HMAC-SHA512"
+	case 8:
+		return "PRF-AES128-CMAC"
+	default:
+		return fmt.Sprintf("PRF_%d", id)
+	}
+}
+
+// getIntegrityAlgorithmName returns the name for an integrity algorithm ID
+func getIntegrityAlgorithmName(id uint16) string {
+	switch id {
+	case 0:
+		return "NONE"
+	case 1:
+		return "HMAC-MD5-96"
+	case 2:
+		return "HMAC-SHA1-96"
+	case 3:
+		return "DES-MAC"
+	case 4:
+		return "KPDK-MD5"
+	case 5:
+		return "AES-XCBC-96"
+	case 6:
+		return "HMAC-MD5-128"
+	case 7:
+		return "HMAC-SHA1-160"
+	case 8:
+		return "AES-CMAC-96"
+	case 9:
+		return "AES-128-GMAC"
+	case 10:
+		return "AES-192-GMAC"
+	case 11:
+		return "AES-256-GMAC"
+	case 12:
+		return "HMAC-SHA256-128"
+	case 13:
+		return "HMAC-SHA384-192"
+	case 14:
+		return "HMAC-SHA512-256"
+	default:
+		return fmt.Sprintf("AUTH_%d", id)
+	}
+}
+
+// getDHGroupName returns the name for a Diffie-Hellman group ID
+func getDHGroupName(id uint16) string {
+	switch id {
+	case 1:
+		return "MODP-768"
+	case 2:
+		return "MODP-1024"
+	case 5:
+		return "MODP-1536"
+	case 14:
+		return "MODP-2048"
+	case 15:
+		return "MODP-3072"
+	case 16:
+		return "MODP-4096"
+	case 17:
+		return "MODP-6144"
+	case 18:
+		return "MODP-8192"
+	case 19:
+		return "ECP-256"
+	case 20:
+		return "ECP-384"
+	case 21:
+		return "ECP-521"
+	case 22:
+		return "MODP-1024-160"
+	case 23:
+		return "MODP-2048-224"
+	case 24:
+		return "MODP-2048-256"
+	case 25:
+		return "ECP-192"
+	case 26:
+		return "ECP-224"
+	case 27:
+		return "ECP-224-BP"
+	case 28:
+		return "ECP-256-BP"
+	case 29:
+		return "ECP-384-BP"
+	case 30:
+		return "ECP-512-BP"
+	case 31:
+		return "Curve25519"
+	case 32:
+		return "Curve448"
+	default:
+		return fmt.Sprintf("DH_%d", id)
+	}
+}

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -84,8 +84,10 @@ var udpFingerprinters = map[uint16]Fingerprinter{
 	162:   &localPlugins.SNMPFingerprinter{},     // SNMP Trap
 	177:   &localPlugins.XdmcpFingerprinter{},    // XDMCP (X Display Manager Control Protocol)
 	427:   &localPlugins.SlpFingerprinter{},      // SLP (Service Location Protocol)
+	500:   &localPlugins.IKEFingerprinter{},      // IKE (Internet Key Exchange)
 	623:   &localPlugins.IPMIFingerprinter{},     // IPMI (Intelligent Platform Management Interface)
 	1900:  &localPlugins.SSDPFingerprinter{},     // SSDP (Simple Service Discovery Protocol)
+	4500:  &localPlugins.IKEFingerprinter{},      // IKE NAT-T (NAT Traversal)
 	5060:  &localPlugins.SIPFingerprinter{},      // SIP (Session Initiation Protocol)
 	10001: &localPlugins.UbiquitiFingerprinter{}, // Ubiquiti Discovery Protocol
 }


### PR DESCRIPTION
### TL;DR

Added support for IKE (Internet Key Exchange) protocol detection in the network scanner.

### What changed?

- Added IKE to the list of supported protocols in the common definitions
- Created a new IKE protocol definition with fields for version, SPI values, exchange type, flags, message ID, vendor IDs, and security association details
- Implemented an IKE fingerprinter that:
  - Targets UDP ports 500 and 4500 (standard IKE and IKE NAT-T ports)
  - Sends an IKEv2 SA_INIT request packet
  - Parses responses to extract protocol details, vendor IDs, and security parameters
  - Identifies encryption algorithms, hash algorithms, authentication methods, and DH groups

### How to test?

1. Run a network scan against a target with IKE services (VPN servers, firewalls)
2. Verify the scanner correctly identifies IKE services on ports 500 and 4500
3. Check that the response includes detailed information about the IKE service:
   - Protocol version
   - SPI values
   - Exchange type
   - Security parameters (encryption, hash, auth methods, DH groups)
   - Vendor IDs when available

### Why make this change?

Adding IKE protocol detection enhances the scanner's ability to identify VPN endpoints and security gateways. This is valuable for security assessments as IKE is commonly used in IPsec VPN implementations, and detecting these services helps identify potential network entry points that should be properly secured.