### PR TITLE
Remove TCP_SYN and TCP_ACK host discovery scan types

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -104,7 +104,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 		},
 	}
 	discoverHostCmd.Flags().String("target", "", "Target IP address, hostname, or CIDR range to scan for live hosts")
-	discoverHostCmd.Flags().String("scan-type", "ICMP_ECHO", "Discovery scan type: TCP_SYN, TCP_ACK, ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK (not needed for stealth mode)")
+	discoverHostCmd.Flags().String("scan-type", "ICMP_ECHO", "Discovery scan type: ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK (not needed for stealth mode)")
 	discoverHostCmd.Flags().Int("sleep", 0, "Sleep delay in seconds between hosts for stealth scan (stealth mode enabled when sleep > 0)")
 	discoverHostCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delay for stealth scan")
 	discoverHostCmd.Flags().Bool("reverse-lookup", false, "Perform reverse DNS lookup sweep first to identify potential targets")

--- a/fern/definition/discover/host.yml
+++ b/fern/definition/discover/host.yml
@@ -1,8 +1,6 @@
 types:
   HostScanType:
     enum:
-      - TCP_SYN
-      - TCP_ACK
       - ICMP_ECHO
       - ICMP_TIMESTAMP
       - ARP

--- a/internal/discover/host/host.go
+++ b/internal/discover/host/host.go
@@ -81,13 +81,18 @@ func getHostDiscover(ctx context.Context, target string, scantype discoverfern.H
 		OnResult: func(hr *result.HostResult) {
 			hostDetails = append(hostDetails, parseHostDiscoverResult(*hr))
 		},
+		// Explicitly disable all probe types to prevent Naabu from enabling defaults
+		// When no probes are specified, Naabu automatically enables multiple probe types
+		// including ICMP Echo, ICMP Timestamp, and TCP probes on ports 80/443.
+		// We explicitly disable all probe types here and only enable the requested one.
+		IcmpEchoRequestProbe:        false,
+		IcmpTimestampRequestProbe:   false,
+		IcmpAddressMaskRequestProbe: false,
+		ArpPing:                     false,
+		IPv6NeighborDiscoveryPing:   false,
 	}
 
 	switch scantype {
-	case discoverfern.HostScanTypeTcpSyn:
-		hostDiscoverOpts.TcpSynPingProbes = goflags.StringSlice{"80"}
-	case discoverfern.HostScanTypeTcpAck:
-		hostDiscoverOpts.TcpAckPingProbes = goflags.StringSlice{"80"}
 	case discoverfern.HostScanTypeIcmpEcho:
 		hostDiscoverOpts.IcmpEchoRequestProbe = true
 	case discoverfern.HostScanTypeIcmpTimestamp:


### PR DESCRIPTION
### TL;DR

Removed TCP_SYN and TCP_ACK scan types from host discovery options.

### What changed?

- Removed TCP_SYN and TCP_ACK scan types from the host discovery options in both the CLI help text and the Fern definition
- Modified the host discovery implementation to explicitly disable all probe types by default and only enable the requested one
- Added comments explaining why we explicitly disable all probe types (to prevent Naabu from enabling defaults)
- Removed the code that previously handled TCP_SYN and TCP_ACK scan types

### How to test?

1. Run `./bin/nuclei discover host --help` and verify that TCP_SYN and TCP_ACK are no longer listed in the scan-type options
2. Test each remaining scan type (ICMP_ECHO, ICMP_TIMESTAMP, ARP, ICMP_ADDRESS_MASK) to ensure they work correctly
3. Verify that only the specified scan type is used during discovery and no additional probes are sent

### Why make this change?

The TCP-based scan types were removed to simplify the host discovery options and focus on more reliable ICMP and ARP-based methods. The implementation was also improved to prevent Naabu from automatically enabling multiple probe types when none are specified, ensuring that only the explicitly requested scan type is used during discovery.