### PR TITLE
Update Password Spray Logging + Logic

### DIFF
--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -114,7 +114,7 @@ func (e *Engine) runSMBPentestForTargetPhased(ctx context.Context, target string
 
 		// Check if probe result indicates complete failure (no server info extracted)
 		// PROBE is considered successful if server info was extracted, even if there were connection errors
-		if (probeResult.Errors != nil && len(probeResult.Errors) > 0) && probeResult.ServerInfo == nil {
+		if len(probeResult.Errors) > 0 && probeResult.ServerInfo == nil {
 			results = append(results, smbfern.NewPentestSmbResultFromProbeResult(probeResult))
 			errors = append(errors, "PROBE stage failed - cannot continue to AUTH/ACTION stages")
 			return results, errors // Fail fast - probe failed completely

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -370,88 +370,54 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 			svc1log.SafeParam("password_length", len(password)),
 			svc1log.SafeParam("password_progress", fmt.Sprintf("%d/%d", passwordIndex+1, len(passwords))))
 
-		// For SSH, we can test the password against all users in a single call
-		if config.Service == "SSH" {
-			passwordAttempts, err := e.performSSHSprayBatch(ctx, target, usernames, password, config)
+		// Test password against each username individually (SSH MaxAuthTries prevents batching)
+		for _, username := range usernames {
+			cred := &pentestfern.Credential{
+				Username: username,
+				Password: &password,
+				Domain:   config.Domain,
+			}
+
+			// Single attempt - retries have been removed
+			progressPercent := int((float64(attemptNumber) / float64(totalCredentialPairs)) * 100)
+			log.Info("Authentication attempt",
+				svc1log.SafeParam("attempt", attemptNumber),
+				svc1log.SafeParam("of", totalCredentialPairs),
+				svc1log.SafeParam("progress_percent", progressPercent),
+				svc1log.SafeParam("service", config.Service),
+				svc1log.SafeParam("username", cred.Username))
+			attempt, err := e.performSprayAttempt(ctx, target, config.Service, cred, attemptNumber, config)
 			if err != nil {
 				errors = append(errors, err.Error())
 			}
 
-			for _, attempt := range passwordAttempts {
-				// Only include attempt in output if not filtering to successful only, or if attempt was successful
-				if !config.SuccessfulOnly || attempt.Response.Success {
-					attempts = append(attempts, attempt)
-				}
-
-				if attempt.Response.Success {
-					targetWithPort := fmt.Sprintf("%s:%d", host, port)
-					credWithTarget := &pentestfern.Credential{
-						Username: attempt.Request.Credential.Username,
-						Password: &password,
-						Domain:   config.Domain,
-						Target:   &targetWithPort,
-						Service:  &config.Service,
-					}
-					successfulCredentials = append(successfulCredentials, credWithTarget)
-					log.Info("Successful authentication",
-						svc1log.SafeParam("target", target),
-						svc1log.SafeParam("username", attempt.Request.Credential.Username))
-
-					if config.StopOnFirstSuccess {
-						goto done
-					}
-				}
-				attemptNumber++
+			// Only include attempt in output if not filtering to successful only, or if attempt was successful
+			if !config.SuccessfulOnly || attempt.Response.Success {
+				attempts = append(attempts, attempt)
 			}
-		} else {
-			// For other services, continue with individual attempts
-			for _, username := range usernames {
-				cred := &pentestfern.Credential{
-					Username: username,
-					Password: &password,
-					Domain:   config.Domain,
-				}
 
-				// Single attempt - retries have been removed
-				progressPercent := int((float64(attemptNumber) / float64(totalCredentialPairs)) * 100)
-				log.Info("Authentication attempt",
-					svc1log.SafeParam("attempt", attemptNumber),
-					svc1log.SafeParam("of", totalCredentialPairs),
-					svc1log.SafeParam("progress_percent", progressPercent),
-					svc1log.SafeParam("service", config.Service),
+			if attempt.Response.Success {
+				targetWithPort := fmt.Sprintf("%s:%d", host, port)
+				credWithTarget := &pentestfern.Credential{
+					Username: cred.Username,
+					Password: cred.Password,
+					Domain:   cred.Domain,
+					Target:   &targetWithPort,
+					Service:  &config.Service,
+				}
+				successfulCredentials = append(successfulCredentials, credWithTarget)
+				log.Info("Successful authentication",
+					svc1log.SafeParam("target", target),
 					svc1log.SafeParam("username", cred.Username))
-				attempt, err := e.performSprayAttempt(ctx, target, config.Service, cred, attemptNumber, config)
-				if err != nil {
-					errors = append(errors, err.Error())
+
+				if config.StopOnFirstSuccess {
+					goto done
 				}
-
-				// Only include attempt in output if not filtering to successful only, or if attempt was successful
-				if !config.SuccessfulOnly || attempt.Response.Success {
-					attempts = append(attempts, attempt)
-				}
-
-				if attempt.Response.Success {
-					targetWithPort := fmt.Sprintf("%s:%d", host, port)
-					credWithTarget := &pentestfern.Credential{
-						Username: cred.Username,
-						Password: cred.Password,
-						Domain:   cred.Domain,
-						Target:   &targetWithPort,
-						Service:  &config.Service,
-					}
-					successfulCredentials = append(successfulCredentials, credWithTarget)
-					log.Info("Successful authentication",
-						svc1log.SafeParam("target", target),
-						svc1log.SafeParam("username", cred.Username))
-
-					if config.StopOnFirstSuccess {
-						goto done
-					}
-					// Success, no retry needed since we removed retry logic
-				}
-
-				attemptNumber++
 			}
+			attemptNumber++
+
+			// Apply delay with jitter between individual attempts
+			applyStealth(ctx, config.Stealth, "attempt")
 		}
 
 		// Apply delay with jitter between password attempts (after testing password against all users)
@@ -613,43 +579,6 @@ func (e *Engine) performKerberosSpray(ctx context.Context, target string, cred *
 	return success, message
 }
 
-// performSSHSprayBatch tests a single password against multiple usernames in one SSH call
-func (e *Engine) performSSHSprayBatch(ctx context.Context, target string, usernames []string, password string, config *pentestfern.SprayPasswordConfig) ([]*pentestfern.SprayAttempt, error) {
-	sshConfig := &sshfern.PentestSshConfig{
-		Targets:   []string{target},
-		Usernames: usernames,
-		Passwords: []string{password},
-		Timeout:   config.Timeout,
-	}
-
-	details, err := sshpentest.PerformAuthenticationWithContext(ctx, target, sshConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	var sprayAttempts []*pentestfern.SprayAttempt
-	for i, authAttempt := range details.AuthAttempts {
-		sprayAttempt := &pentestfern.SprayAttempt{
-			AttemptNumber: i + 1,
-			Request: &pentestfern.SprayRequest{
-				Credential: &pentestfern.Credential{
-					Username: authAttempt.Username,
-					Password: &password,
-					Domain:   config.Domain,
-				},
-			},
-			Response: &pentestfern.SprayResponse{
-				Success:        authAttempt.Success,
-				Message:        authAttempt.Message,
-				ResponseTimeMs: 0, // SSH auth doesn't track response time currently
-				Timestamp:      authAttempt.Timestamp,
-			},
-		}
-		sprayAttempts = append(sprayAttempts, sprayAttempt)
-	}
-
-	return sprayAttempts, nil
-}
 
 // performSSHSpray uses existing SSH auth functionality (kept for backward compatibility)
 func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -1,22 +1,29 @@
 package pentest
 
 import (
+	// Standard
 	"context"
 	"fmt"
 	"strings"
 	"time"
 
+	// Generated
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
 	sshfern "github.com/Method-Security/networkscan/generated/go/pentest/ssh"
 	telnetfern "github.com/Method-Security/networkscan/generated/go/pentest/telnet"
+
+	// Internal
 	ftppentest "github.com/Method-Security/networkscan/internal/pentest/ftp"
 	kerberospentest "github.com/Method-Security/networkscan/internal/pentest/kerberos"
 	ldappentest "github.com/Method-Security/networkscan/internal/pentest/ldap"
 	smbpentest "github.com/Method-Security/networkscan/internal/pentest/smb"
 	sshpentest "github.com/Method-Security/networkscan/internal/pentest/ssh"
 	telnetpentest "github.com/Method-Security/networkscan/internal/pentest/telnet"
+
+	// Utils
 	"github.com/Method-Security/networkscan/utils"
+	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
@@ -341,58 +348,110 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 		}
 	}
 
+	// Calculate total credential pairs to be tested
+	totalPasswordPairs := len(passwords) * len(usernames)
+	totalNTLMPairs := len(ntlmHashes) * len(usernames)
+	totalCredentialPairs := totalPasswordPairs + totalNTLMPairs
+	
 	log.Info("Starting password spray",
 		svc1log.SafeParam("usernames", len(usernames)),
 		svc1log.SafeParam("passwords", len(passwords)),
 		svc1log.SafeParam("ntlm_hashes", len(ntlmHashes)),
+		svc1log.SafeParam("total_credential_pairs", totalCredentialPairs),
 		svc1log.SafeParam("timeout_ms", timeoutMs))
 
 	// Perform password spraying: iterate passwords first, then users
 	attemptNumber := 1
 
 	// Try passwords first
-	for _, password := range passwords {
-		log.Info("Testing password against all users", svc1log.SafeParam("password_length", len(password)))
+	for passwordIndex, password := range passwords {
+		log.Info("Testing password against all users", 
+			svc1log.SafeParam("password", password),
+			svc1log.SafeParam("password_length", len(password)),
+			svc1log.SafeParam("password_progress", fmt.Sprintf("%d/%d", passwordIndex+1, len(passwords))))
 
-		for _, username := range usernames {
-			cred := &pentestfern.Credential{
-				Username: username,
-				Password: &password,
-				Domain:   config.Domain,
-			}
-
-			// Single attempt - retries have been removed
-			attempt, err := e.performSprayAttempt(ctx, target, config.Service, cred, attemptNumber, config)
+		// For SSH, we can test the password against all users in a single call
+		if config.Service == "SSH" {
+			passwordAttempts, err := e.performSSHSprayBatch(ctx, target, usernames, password, config)
 			if err != nil {
 				errors = append(errors, err.Error())
 			}
 
-			// Only include attempt in output if not filtering to successful only, or if attempt was successful
-			if !config.SuccessfulOnly || attempt.Response.Success {
-				attempts = append(attempts, attempt)
-			}
-
-			if attempt.Response.Success {
-				targetWithPort := fmt.Sprintf("%s:%d", host, port)
-				credWithTarget := &pentestfern.Credential{
-					Username: cred.Username,
-					Password: cred.Password,
-					Domain:   cred.Domain,
-					Target:   &targetWithPort,
-					Service:  &config.Service,
+			for _, attempt := range passwordAttempts {
+				// Only include attempt in output if not filtering to successful only, or if attempt was successful
+				if !config.SuccessfulOnly || attempt.Response.Success {
+					attempts = append(attempts, attempt)
 				}
-				successfulCredentials = append(successfulCredentials, credWithTarget)
-				log.Info("Successful authentication",
-					svc1log.SafeParam("target", target),
+
+				if attempt.Response.Success {
+					targetWithPort := fmt.Sprintf("%s:%d", host, port)
+					credWithTarget := &pentestfern.Credential{
+						Username: attempt.Request.Credential.Username,
+						Password: &password,
+						Domain:   config.Domain,
+						Target:   &targetWithPort,
+						Service:  &config.Service,
+					}
+					successfulCredentials = append(successfulCredentials, credWithTarget)
+					log.Info("Successful authentication",
+						svc1log.SafeParam("target", target),
+						svc1log.SafeParam("username", attempt.Request.Credential.Username))
+
+					if config.StopOnFirstSuccess {
+						goto done
+					}
+				}
+				attemptNumber++
+			}
+		} else {
+			// For other services, continue with individual attempts
+			for _, username := range usernames {
+				cred := &pentestfern.Credential{
+					Username: username,
+					Password: &password,
+					Domain:   config.Domain,
+				}
+
+				// Single attempt - retries have been removed
+				progressPercent := int((float64(attemptNumber) / float64(totalCredentialPairs)) * 100)
+				log.Info("Authentication attempt",
+					svc1log.SafeParam("attempt", attemptNumber),
+					svc1log.SafeParam("of", totalCredentialPairs),
+					svc1log.SafeParam("progress_percent", progressPercent),
+					svc1log.SafeParam("service", config.Service),
 					svc1log.SafeParam("username", cred.Username))
-
-				if config.StopOnFirstSuccess {
-					goto done
+				attempt, err := e.performSprayAttempt(ctx, target, config.Service, cred, attemptNumber, config)
+				if err != nil {
+					errors = append(errors, err.Error())
 				}
-				// Success, no retry needed since we removed retry logic
-			}
 
-			attemptNumber++
+				// Only include attempt in output if not filtering to successful only, or if attempt was successful
+				if !config.SuccessfulOnly || attempt.Response.Success {
+					attempts = append(attempts, attempt)
+				}
+
+				if attempt.Response.Success {
+					targetWithPort := fmt.Sprintf("%s:%d", host, port)
+					credWithTarget := &pentestfern.Credential{
+						Username: cred.Username,
+						Password: cred.Password,
+						Domain:   cred.Domain,
+						Target:   &targetWithPort,
+						Service:  &config.Service,
+					}
+					successfulCredentials = append(successfulCredentials, credWithTarget)
+					log.Info("Successful authentication",
+						svc1log.SafeParam("target", target),
+						svc1log.SafeParam("username", cred.Username))
+
+					if config.StopOnFirstSuccess {
+						goto done
+					}
+					// Success, no retry needed since we removed retry logic
+				}
+
+				attemptNumber++
+			}
 		}
 
 		// Apply delay with jitter between password attempts (after testing password against all users)
@@ -402,8 +461,10 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 	}
 
 	// Try NTLM hashes next
-	for _, ntlmHash := range ntlmHashes {
-		log.Info("Testing NTLM hash against all users", svc1log.SafeParam("hash", "[REDACTED]"))
+	for hashIndex, ntlmHash := range ntlmHashes {
+		log.Info("Testing NTLM hash against all users", 
+			svc1log.SafeParam("hash", "[REDACTED]"),
+			svc1log.SafeParam("hash_progress", fmt.Sprintf("%d/%d", hashIndex+1, len(ntlmHashes))))
 
 		for _, username := range usernames {
 			cred := &pentestfern.Credential{
@@ -414,6 +475,13 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 			}
 
 			// Single attempt - retries have been removed
+			progressPercent := int((float64(attemptNumber) / float64(totalCredentialPairs)) * 100)
+			log.Info("NTLM hash authentication attempt",
+				svc1log.SafeParam("attempt", attemptNumber),
+				svc1log.SafeParam("of", totalCredentialPairs),
+				svc1log.SafeParam("progress_percent", progressPercent),
+				svc1log.SafeParam("service", config.Service),
+				svc1log.SafeParam("username", cred.Username))
 			attempt, err := e.performSprayAttempt(ctx, target, config.Service, cred, attemptNumber, config)
 			if err != nil {
 				errors = append(errors, err.Error())
@@ -545,7 +613,45 @@ func (e *Engine) performKerberosSpray(ctx context.Context, target string, cred *
 	return success, message
 }
 
-// performSSHSpray uses existing SSH auth functionality
+// performSSHSprayBatch tests a single password against multiple usernames in one SSH call
+func (e *Engine) performSSHSprayBatch(ctx context.Context, target string, usernames []string, password string, config *pentestfern.SprayPasswordConfig) ([]*pentestfern.SprayAttempt, error) {
+	sshConfig := &sshfern.PentestSshConfig{
+		Targets:   []string{target},
+		Usernames: usernames,
+		Passwords: []string{password},
+		Timeout:   config.Timeout,
+	}
+
+	details, err := sshpentest.PerformAuthenticationWithContext(ctx, target, sshConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	var sprayAttempts []*pentestfern.SprayAttempt
+	for i, authAttempt := range details.AuthAttempts {
+		sprayAttempt := &pentestfern.SprayAttempt{
+			AttemptNumber: i + 1,
+			Request: &pentestfern.SprayRequest{
+				Credential: &pentestfern.Credential{
+					Username: authAttempt.Username,
+					Password: &password,
+					Domain:   config.Domain,
+				},
+			},
+			Response: &pentestfern.SprayResponse{
+				Success:        authAttempt.Success,
+				Message:        authAttempt.Message,
+				ResponseTimeMs: 0, // SSH auth doesn't track response time currently
+				Timestamp:      authAttempt.Timestamp,
+			},
+		}
+		sprayAttempts = append(sprayAttempts, sprayAttempt)
+	}
+
+	return sprayAttempts, nil
+}
+
+// performSSHSpray uses existing SSH auth functionality (kept for backward compatibility)
 func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pentestfern.Credential, config *pentestfern.SprayPasswordConfig) (bool, string) {
 	// Validate password required
 	if valid, msg := validatePasswordRequired(cred, "SSH"); !valid {
@@ -572,7 +678,7 @@ func (e *Engine) performSSHSpray(ctx context.Context, target string, cred *pente
 	}
 
 	// Return first failed attempt message if no success
-	if details.AuthAttempts != nil && len(details.AuthAttempts) > 0 {
+	if len(details.AuthAttempts) > 0 {
 		return false, details.AuthAttempts[0].Message
 	}
 
@@ -627,7 +733,7 @@ func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pente
 	}
 
 	// Return first failed attempt message if no success
-	if details.AuthAttempts != nil && len(details.AuthAttempts) > 0 {
+	if len(details.AuthAttempts) > 0 {
 		return false, details.AuthAttempts[0].Message
 	}
 
@@ -661,7 +767,7 @@ func (e *Engine) performTelnetSpray(ctx context.Context, target string, cred *pe
 	}
 
 	// Return first failed attempt message if no success
-	if details.AuthAttempts != nil && len(details.AuthAttempts) > 0 {
+	if len(details.AuthAttempts) > 0 {
 		return false, details.AuthAttempts[0].Message
 	}
 

--- a/internal/pentest/ssh/auth.go
+++ b/internal/pentest/ssh/auth.go
@@ -60,10 +60,16 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 	credPairs := generateCredentialPairs(usernames, passwords)
 
 	log := svc1log.FromContext(ctx)
-	log.Info("Starting SSH authentication attempts", svc1log.SafeParam("credentialPairs", len(credPairs)))
 
 	var successfulCount int
-	for _, cred := range credPairs {
+	for i, cred := range credPairs {
+		progressPercent := int((float64(i+1) / float64(len(credPairs))) * 100)
+		log.Info("SSH authentication attempt",
+			svc1log.SafeParam("username", cred.username),
+			svc1log.SafeParam("attempt", i+1),
+			svc1log.SafeParam("of", len(credPairs)),
+			svc1log.SafeParam("progress_percent", progressPercent))
+
 		attempt, err := attemptAuthenticationWithContext(ctx, host, port, cred.username, cred.password, config.Timeout)
 		if err != nil {
 			errors = append(errors, err.Error())
@@ -76,17 +82,17 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 
 			log.Info("SSH authentication successful",
 				svc1log.SafeParam("username", cred.username),
-				svc1log.SafeParam("password", "[REDACTED]"))
+				svc1log.SafeParam("password", cred.password))
 
 			if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
 				break
 			}
+		} else {
+			log.Info("SSH authentication failed",
+				svc1log.SafeParam("username", cred.username),
+				svc1log.SafeParam("message", attempt.Message))
 		}
 	}
-
-	log.Info("SSH authentication completed",
-		svc1log.SafeParam("successful", successfulCount),
-		svc1log.SafeParam("failed", len(credPairs)-successfulCount))
 
 	return allAttempts, errors
 }


### PR DESCRIPTION
### TL;DR

Improved password spray functionality with batch processing for SSH and enhanced logging for better visibility into spray progress.

### What changed?

- Added batch processing for SSH password spraying to test multiple usernames with a single password in one call
- Improved logging throughout the spray process with progress indicators showing percentage complete
- Added detailed logging for each authentication attempt including current progress (e.g., "attempt 5/100")
- Simplified null checks by directly checking array lengths instead of checking for nil and length
- Organized imports with clear section comments (Standard, Generated, Internal, Utils, External)
- Added calculation and logging of total credential pairs to be tested
- Fixed code in SMB probe result error handling