### PR TITLE
Fix SSH Detection

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -292,8 +292,15 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				return
 			}
 
+			// Fingerprintx timeout flag
+			fingerprintxTimeout, err := cmd.Flags().GetInt("fingerprintx-timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Set Config
-			config := getDiscoverServiceConfig(target, timeout, serviceType, udp)
+			config := getDiscoverServiceConfig(target, timeout, serviceType, udp, fingerprintxTimeout)
 
 			// Generate the report
 			report, err := discoverservice.RunServiceFingerprint(cmd.Context(), config)
@@ -306,6 +313,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	}
 	discoverServiceCmd.Flags().String("target", "", "Target address (IP:port or hostname:port for TCP, IP or hostname for UDP mode)")
 	discoverServiceCmd.Flags().Int("timeout", 5, "Timeout in seconds for each service fingerprinting attempt")
+	discoverServiceCmd.Flags().Int("fingerprintx-timeout", 0, "Timeout in seconds for fingerprintx attempt (default is no timeout)")
 	discoverServiceCmd.Flags().Bool("udp", false, "Enable UDP service discovery mode (scans common UDP ports like DNS, NTP, SNMP, etc.)")
 	discoverServiceCmd.Flags().String("service-type", "", "Service type to fingerprint for stealth mode: SSH, HTTP, GRPC, KERBEROS, LDAP, SMB (stealth mode enabled when specified)")
 
@@ -439,10 +447,11 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 
 // getDiscoverServiceConfig creates a configuration for service fingerprinting with the provided parameters.
 // It sets up the target (in IP:port format for TCP, or just IP for UDP), timeout, UDP mode, and stealth-specific options.
-func getDiscoverServiceConfig(target string, timeout int, serviceType string, udp bool) discoverfern.DiscoverServiceConfig {
+func getDiscoverServiceConfig(target string, timeout int, serviceType string, udp bool, fingerprintxTimeout int) discoverfern.DiscoverServiceConfig {
 	config := discoverfern.DiscoverServiceConfig{
-		Target:  target,
-		Timeout: timeout,
+		Target:              target,
+		Timeout:             timeout,
+		FingerprintxTimeout: fingerprintxTimeout,
 	}
 	if udp {
 		config.Udp = &udp

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -123,6 +123,7 @@ types:
     properties:
       target: string # Format: IP:port or hostname:port for TCP, IP or hostname for UDP mode
       timeout: integer
+      fingerprintxTimeout: integer # Timeout in seconds for fingerprintx attempt
       stealth: optional<ServiceStealthConfig>
       udp: optional<boolean> # Enable UDP service discovery mode (scans common UDP ports)
   # Final report

--- a/internal/discover/service/plugins/ssh.go
+++ b/internal/discover/service/plugins/ssh.go
@@ -18,6 +18,8 @@ type SSHFingerprinter struct{}
 
 func (SSHFingerprinter) Name() string { return "ssh" }
 
+func (SSHFingerprinter) DefaultPorts() []int { return []int{22} }
+
 func (SSHFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
 	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -46,6 +46,7 @@ type Fingerprinter interface {
 // Custom fingerprinters for protocols that need specialized detection
 // These run BEFORE fingerprintx to provide more specific detection
 var customFingerprintModules = []Fingerprinter{
+	&localPlugins.SSHFingerprinter{},       // SSH (Secure Shell)
 	&localPlugins.GrpcFingerprinter{},      // gRPC can run on any port
 	&localPlugins.MongoDBFingerprinter{},   // MongoDB driver manages its own connections
 	&localPlugins.BGPFingerprinter{},       // BGP protocol detection
@@ -125,7 +126,7 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 
 	// Standard fingerprinting path
 	fingerprintConfig := scan.Config{
-		FastMode:       false,
+		FastMode:       true,
 		DefaultTimeout: time.Duration(config.Timeout) * time.Second,
 		UDP:            false,
 		Verbose:        true,
@@ -168,10 +169,47 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 
 		/* --- Phase 2: Run fingerprintx (has its own port priority) --------- */
 		if !serviceFound {
-			if fxResult, fingerprintError := fingerprintConfig.SimpleScanTarget(fingerprintTarget); fingerprintError == nil && fxResult != nil && fxResult.Protocol != "" {
-				fingerprintResult = fxResult
-				results = append(results, fxToServiceDetails(fingerprintResult))
-				serviceFound = true
+			// Wrap fingerprintx in context timeout to prevent hanging (if timeout > 0)
+			var fxCtx context.Context
+			var cancel context.CancelFunc
+
+			if config.FingerprintxTimeout > 0 {
+				fxCtx, cancel = context.WithTimeout(ctx, time.Duration(config.FingerprintxTimeout)*time.Second)
+			} else {
+				fxCtx, cancel = context.WithCancel(ctx)
+			}
+			defer cancel()
+
+			resultChan := make(chan *plugins.Service, 1)
+			errChan := make(chan error, 1)
+
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						errChan <- fmt.Errorf("fingerprintx panic: %v", r)
+					}
+				}()
+
+				result, err := fingerprintConfig.SimpleScanTarget(fingerprintTarget)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				resultChan <- result
+			}()
+
+			select {
+			case <-fxCtx.Done():
+				// fingerprintx timed out or context cancelled - move to Phase 3
+			case fxResult := <-resultChan:
+				if fxResult != nil && fxResult.Protocol != "" {
+					fingerprintResult = fxResult
+					results = append(results, fxToServiceDetails(fingerprintResult))
+					serviceFound = true
+				}
+			case err := <-errChan:
+				// fingerprintx failed - continue to Phase 3
+				_ = err
 			}
 		}
 


### PR DESCRIPTION
## Fix SSH service discovery hanging on non-standard ports

### Problem

The service discovery tool was hanging when scanning SSH services running on non-standard ports (e.g., port 7218). The issue
occurred because:

1. SSH fingerprinter wasn't registered - The existing SSHFingerprinter wasn't included in the customFingerprintModules list, so
it was never called during the 3-phase fingerprinting process
2. fingerprintx HTTP plugin conflict - When scanning port 7218, fingerprintx's HTTP plugin attempted an HTTP request but
received an SSH banner (SSH-2.0-CradlepointSSHService), causing a malformed HTTP response error
3. Process hung during the SSH detection phase because no SSH-specific handler was available to process the SSH protocol
properly