### PR TITLE
Add NTLM hash and Kerberos ticket support for authentication attempts

### DIFF
--- a/fern/definition/pentest/auth.yml
+++ b/fern/definition/pentest/auth.yml
@@ -31,6 +31,8 @@ types:
     properties:
       username: string
       password: optional<string> # Optional for key-based auth
+      ntlmHash: optional<string> # NTLM hash for pass-the-hash attacks
+      kerberosTicket: optional<string> # Kerberos ticket for ticket-based auth
       domain: optional<string> # For domain authentication (SMB, LDAP, Kerberos)
       keyFile: optional<string> # For SSH key-based authentication
       success: boolean # Whether this attempt succeeded

--- a/internal/pentest/ldap/auth.go
+++ b/internal/pentest/ldap/auth.go
@@ -547,12 +547,14 @@ func performLDAPAuthAttemptsWithConnectionKeeping(ctx context.Context, target *T
 func attemptLDAPHashAuthenticationWithConnection(ctx context.Context, target *Target, username, ntlmHash string, timeout int) (*pentestfern.AuthAttempt, *ldap.Conn, error) {
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  &ntlmHash, // Store NTLM hash in password field for now
-		Domain:    &target.Domain,
-		Success:   false,
-		Message:   "Authentication in progress",
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       nil, // No password for hash auth
+		NtlmHash:       &ntlmHash,
+		Domain:         &target.Domain,
+		Success:        false,
+		Message:        "Authentication in progress",
+		Timestamp:      timestamp,
+		KerberosTicket: nil,
 	}
 
 	// Generate bind DNs based on target configuration
@@ -614,11 +616,13 @@ func attemptLDAPHashAuthenticationWithConnection(ctx context.Context, target *Ta
 func attemptLDAPAuthenticationWithConnection(ctx context.Context, target *Target, username, password string, timeout int) (*pentestfern.AuthAttempt, *ldap.Conn, error) {
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  &password,
-		Domain:    &target.Domain,
-		Success:   false,
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       &password,
+		Domain:         &target.Domain,
+		Success:        false,
+		Timestamp:      timestamp,
+		NtlmHash:       nil,
+		KerberosTicket: nil,
 	}
 
 	success, message, conn, err := AuthenticateUserKeepConnection(ctx, target, username, password, timeout)

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -400,11 +400,13 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  &password,
-		Domain:    &domain,
-		Success:   false,
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       &password,
+		Domain:         &domain,
+		Success:        false,
+		Timestamp:      timestamp,
+		NtlmHash:       nil,
+		KerberosTicket: nil,
 	}
 
 	err := client.ConnectWithContext(ctx)
@@ -486,11 +488,13 @@ func attemptHashAuthenticationWithContext(ctx context.Context, host string, port
 
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  nil, // No password for hash auth
-		Domain:    &domain,
-		Success:   false,
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       nil, // No password for hash auth
+		NtlmHash:       &ntlmHash,
+		Domain:         &domain,
+		Success:        false,
+		Timestamp:      timestamp,
+		KerberosTicket: nil,
 	}
 
 	err := client.ConnectWithContext(ctx)
@@ -540,11 +544,13 @@ func attemptSMBAuthenticationWithConnection(ctx context.Context, host string, po
 	client.SetCredentials(username, password, domain)
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  &password,
-		Domain:    &domain,
-		Success:   false,
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       &password,
+		Domain:         &domain,
+		Success:        false,
+		Timestamp:      timestamp,
+		NtlmHash:       nil,
+		KerberosTicket: nil,
 	}
 	err := client.ConnectWithContext(ctx)
 	if err != nil {
@@ -590,11 +596,13 @@ func attemptSMBHashAuthenticationWithConnection(ctx context.Context, host string
 	client.SetCredentialsWithHash(username, ntlmHash, domain)
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  nil, // No password for hash auth
-		Domain:    &domain,
-		Success:   false,
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       nil, // No password for hash auth
+		NtlmHash:       &ntlmHash,
+		Domain:         &domain,
+		Success:        false,
+		Timestamp:      timestamp,
+		KerberosTicket: nil,
 	}
 	err := client.ConnectWithContext(ctx)
 	if err != nil {

--- a/internal/pentest/ssh/auth.go
+++ b/internal/pentest/ssh/auth.go
@@ -124,11 +124,13 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*pentestfern.AuthAttempt, error) {
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  &password,
-		Success:   false,
-		Timestamp: timestamp,
-		Message:   "",
+		Username:       username,
+		Password:       &password,
+		Success:        false,
+		Timestamp:      timestamp,
+		Message:        "",
+		NtlmHash:       nil,
+		KerberosTicket: nil,
 	}
 
 	sshConfig := &ssh.ClientConfig{

--- a/internal/pentest/telnet/auth.go
+++ b/internal/pentest/telnet/auth.go
@@ -133,10 +133,12 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password string, timeout int) (*pentestfern.AuthAttempt, error) {
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  &password,
-		Success:   false,
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       &password,
+		Success:        false,
+		Timestamp:      timestamp,
+		NtlmHash:       nil,
+		KerberosTicket: nil,
 	}
 
 	targetAddr := net.JoinHostPort(host, fmt.Sprintf("%d", port))

--- a/internal/pentest/winrm/auth.go
+++ b/internal/pentest/winrm/auth.go
@@ -285,11 +285,13 @@ func generateCredentialPairs(usernames, passwords []string) []credentialPair {
 func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, config *winrmfern.PentestWinrmConfig) (*pentestfern.AuthAttempt, error) {
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  &password,
-		Domain:    &domain,
-		Success:   false,
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       &password,
+		Domain:         &domain,
+		Success:        false,
+		Timestamp:      timestamp,
+		NtlmHash:       nil,
+		KerberosTicket: nil,
 	}
 
 	// Create WinRM endpoint
@@ -342,11 +344,13 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 func attemptWinRMAuthenticationWithConnection(ctx context.Context, host string, port int, username, password, domain string, config *winrmfern.PentestWinrmConfig) (*pentestfern.AuthAttempt, *winrm.Client, error) {
 	timestamp := time.Now()
 	attempt := &pentestfern.AuthAttempt{
-		Username:  username,
-		Password:  &password,
-		Domain:    &domain,
-		Success:   false,
-		Timestamp: timestamp,
+		Username:       username,
+		Password:       &password,
+		Domain:         &domain,
+		Success:        false,
+		Timestamp:      timestamp,
+		NtlmHash:       nil,
+		KerberosTicket: nil,
 	}
 
 	// Create WinRM endpoint


### PR DESCRIPTION
### TL;DR

Added support for NTLM hash and Kerberos ticket authentication methods in the pentest module.

### What changed?

- Extended the `AuthAttempt` type in `auth.yml` to include two new optional properties:
  - `ntlmHash`: For pass-the-hash attacks
  - `kerberosTicket`: For ticket-based authentication
- Updated authentication functions across multiple protocols (LDAP, SMB, SSH, Telnet, WinRM) to properly initialize these new fields
- Modified the LDAP hash authentication to store the NTLM hash in the dedicated field instead of reusing the password field
- Ensured all authentication attempt objects properly initialize all fields, including setting null values for unused authentication methods

### How to test?

1. Test pass-the-hash authentication against an SMB or LDAP target using the new `ntlmHash` field
2. Verify that authentication attempts correctly record which authentication method was used
3. Check that the authentication attempt objects in logs and responses contain the appropriate fields

### Why make this change?

This change improves support for advanced authentication techniques commonly used in penetration testing, particularly in Windows environments. By properly separating different authentication methods (password, hash, ticket), the system can more accurately represent and track authentication attempts, making it clearer which method was used for each attempt. This is especially important for security auditing and reporting purposes.