### PR TITLE
Add DCERPC/MSRPC protocol detection and improve PCOM fingerprinting accuracy

### DIFF
--- a/internal/discover/service/plugins/pcom.go
+++ b/internal/discover/service/plugins/pcom.go
@@ -401,9 +401,6 @@ func hasValidPcomIndicators(response string, binaryResponse []byte) bool {
 		return true
 	}
 
-	// REMOVED: Weak heuristic based on non-printable character ratio
-	// This was causing false positives with DCERPC and other binary protocols
-
 	return false
 }
 

--- a/internal/discover/service/plugins/pcom.go
+++ b/internal/discover/service/plugins/pcom.go
@@ -355,6 +355,21 @@ func isFalsePositive(response string, rawResponse []byte) bool {
 		}
 	}
 
+	// DCERPC/MSRPC responses (Windows RPC Endpoint Mapper on port 135, 139, etc.)
+	// DCERPC version 5 responses: 0x05 0x00-0x01 [packet_type]
+	if len(rawResponse) >= 3 && rawResponse[0] == 0x05 {
+		// Check if second byte is reasonable version minor (0x00 or 0x01)
+		if rawResponse[1] <= 0x01 {
+			// Check if third byte is a valid DCERPC packet type
+			packetType := rawResponse[2]
+			// Common DCERPC packet types: 0x00-0x13
+			// 0x00=Request, 0x02=Response, 0x0b=Bind, 0x0c=Bind_ack, 0x0d=Bind_nak, etc.
+			if packetType <= 0x13 {
+				return true
+			}
+		}
+	}
+
 	// Other false positives
 	if contains(response, "Bad Request") || contains(response, "Internal Server Error") {
 		return true
@@ -371,32 +386,23 @@ func hasValidPcomIndicators(response string, binaryResponse []byte) bool {
 	// NOTE: Empty response check moved to caller context where port is available
 	// Empty responses should ONLY be considered valid PCOM indicators on port 20256
 
-	// Check for specific binary patterns
+	// Check for specific PCOM binary patterns only
+	// These are known PCOM protocol signatures
 	if len(binaryResponse) >= 6 {
+		// PCOM protocol-specific patterns
 		if (binaryResponse[0] == 0x02 && binaryResponse[1] == 0x09) ||
-			(binaryResponse[0] == 0x00 && binaryResponse[1] == 0x5B) ||
-			(binaryResponse[0] == 0x00 && binaryResponse[1] == 0x00) {
+			(binaryResponse[0] == 0x00 && binaryResponse[1] == 0x5B) {
 			return true
 		}
 	}
 
-	// VMware authentication responses might still be on PCOM ports
-	if contains(response, "VMware Authentication Daemon") {
+	// PCOM ASCII response pattern: /A<data><CR>
+	if len(response) >= 2 && response[0] == '/' && response[1] == 'A' {
 		return true
 	}
 
-	// Short binary responses with non-printable characters
-	if len(binaryResponse) > 0 && len(binaryResponse) < 50 {
-		nonPrintableCount := 0
-		for _, b := range binaryResponse {
-			if b < 32 || b > 126 {
-				nonPrintableCount++
-			}
-		}
-		if float64(nonPrintableCount)/float64(len(binaryResponse)) > 0.5 {
-			return true
-		}
-	}
+	// REMOVED: Weak heuristic based on non-printable character ratio
+	// This was causing false positives with DCERPC and other binary protocols
 
 	return false
 }


### PR DESCRIPTION
### TL;DR

Improved PCOM protocol detection by adding DCERPC/MSRPC response filtering and refining PCOM signature detection.

### What changed?

- Added detection for DCERPC/MSRPC responses (Windows RPC Endpoint Mapper) to the `isFalsePositive` function to prevent false positives on ports 135, 139, etc.
- Refined the `hasValidPcomIndicators` function to focus on specific PCOM protocol signatures:
  - Removed the generic binary response heuristic based on non-printable character ratio
  - Added detection for PCOM ASCII response pattern: `/A<data><CR>`
  - Kept only the most reliable PCOM binary patterns

### How to test?

1. Run discovery against systems with both PCOM services and Windows RPC services
2. Verify that Windows RPC services on ports 135, 139 are no longer falsely identified as PCOM
3. Confirm that legitimate PCOM services are still correctly identified

### Why make this change?

The previous implementation was causing false positives by incorrectly identifying DCERPC/MSRPC responses as PCOM protocol traffic. The weak heuristic based on non-printable character ratio was too broad and matched many binary protocols. This change makes the detection more precise by focusing on specific protocol signatures and filtering out known non-PCOM responses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds DCERPC/MSRPC response filtering and narrows PCOM signatures (including ASCII `/A...\r`) to reduce false positives.
> 
> - **Detection updates in `internal/discover/service/plugins/pcom.go`**:
>   - **False-positive filtering**:
>     - Recognize DCERPC/MSRPC responses (`0x05 0x00/0x01 [0x00-0x13]`) in `isFalsePositive` to avoid misclassification (e.g., ports 135/139).
>   - **PCOM signature refinement**:
>     - `hasValidPcomIndicators`: keep only reliable binary patterns (`0x02 0x09`, `0x00 0x5B`); add ASCII pattern detection (`/A...\r`); remove broad non-printable heuristic and drop `0x00 0x00` pattern.
>     - `isPcomResponse`: respect ASCII `/A` and valid indicator checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8fa116750add45792cd19cdf13fae70f027c1b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->