### PR TITLE
Remove Host Discover Over Cautious Check

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	// Standard
-	"errors"
 	"fmt"
 	"strings"
 
@@ -81,13 +80,6 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			// Validate jitter range
 			if jitter < 0 || jitter > 100 {
 				a.OutputSignal.AddError(fmt.Errorf("jitter must be between 0 and 100 (percentage), got %d", jitter))
-				return
-			}
-
-			// Check privileges for stealth scan (after other validations)
-			// Use our custom privilege check that works properly on Windows
-			if !utils.IsPrivilegedForNetworkScanning() {
-				a.OutputSignal.AddError(errors.New("stealth host discovery requires administrator/root privileges for ICMP ping"))
 				return
 			}
 

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -8,12 +8,10 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
-	permissionutil "github.com/projectdiscovery/utils/permission"
 )
 
 // GetEntriesFromTXTFiles reads and combines entries from multiple text files.
@@ -241,20 +239,4 @@ func GetIPs(host string) ([]net.IP, error) {
 	}
 
 	return ips, nil
-}
-
-// IsPrivilegedForNetworkScanning checks if the current process has the necessary privileges
-// for network scanning operations that require raw sockets (like ICMP ping).
-// On Windows, this checks if the process is running with Administrator privileges.
-// On Unix-like systems, this checks for root privileges or CAP_NET_RAW capability.
-func IsPrivilegedForNetworkScanning() bool {
-	if runtime.GOOS == "windows" {
-		// On Windows, use the permission utility to check for Administrator privileges
-		// The permissionutil.IsRoot checks for elevated privileges on Windows
-		return permissionutil.IsRoot
-	}
-
-	// On Unix-like systems, fall back to the naabu privilege check
-	// This handles both root privileges and CAP_NET_RAW capability
-	return os.Geteuid() == 0
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the privilege requirement that blocked stealth host discovery and cleans up the related utility.
> 
> - Eliminates the privilege check in `discover.go` for stealth host discovery (no longer errors when not root/admin)
> - Deletes `utils.IsPrivilegedForNetworkScanning` and its imports from `helpers.go`
> - Retains jitter/sleep validation and all other discovery logic unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cafa326c35bcc2065b2882f6271bde97c83cafb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->