### PR TITLE
Fix DCSync result handling to maintain report structure on error

### DIFF
--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -990,10 +990,12 @@ func (e *Engine) RunMSRPCPentest(ctx context.Context, config *msrpcfern.PentestM
 			dcsyncResult, err := msrpcpentest.PerformDCSync(ctx, config.DcsyncConfig)
 			if err != nil {
 				allErrors = append(allErrors, fmt.Sprintf("DCSync operation failed: %v", err))
-				continue
 			}
 
-			result = msrpcfern.NewPentestMsrpcResultFromDcSyncResult(dcsyncResult)
+			// Always create result from dcsyncResult, even on error, to maintain report structure
+			if dcsyncResult != nil {
+				result = msrpcfern.NewPentestMsrpcResultFromDcSyncResult(dcsyncResult)
+			}
 
 		default:
 			allErrors = append(allErrors, fmt.Sprintf("unsupported MSRPC action: %s", string(action)))


### PR DESCRIPTION
### TL;DR

Fix DCSync result handling to maintain report structure even when errors occur.

### What changed?

Modified the DCSync operation handling in the `RunMSRPCPentest` function to:
- Remove the `continue` statement after error detection, allowing execution to proceed
- Add a nil check before creating a result from the DCSync operation
- Create a result from the DCSync operation even when errors occur, as long as there's a non-nil result

### How to test?

1. Run a pentest with DCSync operations that may fail
2. Verify that the report structure is maintained even when errors occur
3. Confirm that partial results are still included in the report when available

### Why make this change?

The previous implementation would skip result creation entirely when a DCSync operation failed, breaking the expected report structure. This change ensures that any available data is still included in the report, maintaining a consistent structure even in error scenarios, which improves the reliability of report generation and provides more complete information to users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Maintains consistent MSRPC report structure during DCSync failures.
> 
> - In `RunMSRPCPentest`, remove early `continue` on DCSync error and create `result` from non-nil `dcsyncResult`
> - Still record the error in `Errors` while preserving any partial DCSync data in `Result`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f832ffb55af641e98fe1ff6d216d127ca6c42fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->