### PR TITLE
Update SSH Discover Module

### DIFF
--- a/internal/discover/service/plugins/ssh.go
+++ b/internal/discover/service/plugins/ssh.go
@@ -17,19 +17,29 @@ type SSHFingerprinter struct{}
 
 func (SSHFingerprinter) Name() string { return "ssh" }
 
-func (SSHFingerprinter) DefaultPorts() []int { return []int{22} }
+func (SSHFingerprinter) DefaultPorts() []int { return []int{22, 2222} }
 
 func (SSHFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
 	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
 	// Use raw TCP connection to read SSH banner - the gold standard approach
-	conn, err := net.DialTimeout("tcp", addr, time.Duration(timeout)*time.Second)
+	dialer := net.Dialer{
+		Timeout: time.Duration(timeout) * time.Second,
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Set read deadline
+	// Send client version first - some SSH servers wait for client greeting before sending banner
+	clientVersion := "SSH-2.0-GoSSHScanner\r\n"
+	_, err = conn.Write([]byte(clientVersion))
+	if err != nil {
+		return nil, fmt.Errorf("failed to send SSH version string: %w", err)
+	}
+
+	// Set a lenient read deadline for banner response
 	err = conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second))
 	if err != nil {
 		return nil, err

--- a/internal/discover/service/plugins/ssh.go
+++ b/internal/discover/service/plugins/ssh.go
@@ -32,6 +32,12 @@ func (SSHFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 	}
 	defer func() { _ = conn.Close() }()
 
+	// Set write deadline before sending client version
+	err = conn.SetWriteDeadline(time.Now().Add(time.Duration(timeout) * time.Second))
+	if err != nil {
+		return nil, err
+	}
+
 	// Send client version first - some SSH servers wait for client greeting before sending banner
 	clientVersion := "SSH-2.0-GoSSHScanner\r\n"
 	_, err = conn.Write([]byte(clientVersion))
@@ -39,7 +45,7 @@ func (SSHFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		return nil, fmt.Errorf("failed to send SSH version string: %w", err)
 	}
 
-	// Set a lenient read deadline for banner response
+	// Set read deadline for banner response
 	err = conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves SSH service fingerprinting behavior and coverage.
> 
> - Adds `2222` to SSH `DefaultPorts`
> - Switches to context-aware `Dialer.DialContext` and sets explicit write/read deadlines
> - Sends SSH client version before reading to elicit server banner; reads banner, validates `SSH-` prefix, and returns version/metadata in `ServiceDetails`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9399b5b32694a1166bf40d131cef50ea918b0394. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->