### PR TITLE
Better support for IPv6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/projectdiscovery/retryabledns v1.0.94 // indirect
 	github.com/projectdiscovery/retryablehttp-go v1.0.101 // indirect
 	github.com/projectdiscovery/uncover v1.0.9 // indirect
-	github.com/projectdiscovery/utils v0.4.18
+	github.com/projectdiscovery/utils v0.4.18 // indirect
 	github.com/projectdiscovery/wappalyzergo v0.2.41 // indirect
 	github.com/rbetts/go-ntlm v0.0.0-20130522135510-f22198915663
 	github.com/refraction-networking/utls v1.8.0 // indirect

--- a/internal/discover/host/host.go
+++ b/internal/discover/host/host.go
@@ -9,6 +9,8 @@ import (
 
 	// Generated
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	// Internal
+	"github.com/Method-Security/networkscan/utils"
 	// External
 	goflags "github.com/projectdiscovery/goflags"
 	gologger "github.com/projectdiscovery/gologger"
@@ -61,6 +63,14 @@ func getHostDiscover(ctx context.Context, target string, scantype discoverfern.H
 	originalWriter := writer.NewCLI() // Create a new CLI writer to restore later
 	gologger.DefaultLogger.SetWriter(&stderrWriter{})
 
+	// Parse target to detect IP versions
+	targetHosts, err := utils.ParseTargetHosts(target)
+	if err != nil {
+		gologger.DefaultLogger.SetWriter(originalWriter)
+		return nil, fmt.Errorf("failed to parse target hosts: %w", err)
+	}
+	ipVersions := utils.DetectIPVersions(targetHosts)
+
 	hostDetails := []*discoverfern.HostDetails{}
 	hostDiscoverOpts := &runner.Options{
 		Silent:            true,
@@ -74,6 +84,7 @@ func getHostDiscover(ctx context.Context, target string, scantype discoverfern.H
 		StatsInterval:     5,
 		Timeout:           runner.DefaultPortTimeoutSynScan,
 		Host:              goflags.StringSlice{target},
+		IPVersion:         goflags.StringSlice(ipVersions),
 		OnlyHostDiscovery: true,
 		SkipHostDiscovery: false,
 		InputReadTimeout:  3,

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -122,6 +122,9 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 		return nil, fmt.Errorf("failed to parse target hosts: %w", err)
 	}
 
+	// Detect IP versions present in targets
+	ipVersions := utils.DetectIPVersions(targetHosts)
+
 	output := result.HostResult{}
 	hosts := []*discoverfern.SocketDetails{}
 	// These settings mimic naabu's default settings with hardcoded slower rate
@@ -137,6 +140,7 @@ func getPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) ([
 		Threads:           config.Threads,
 		Timeout:           runner.DefaultPortTimeoutConnectScan,
 		Host:              goflags.StringSlice(targetHosts), // Use resolved IPs
+		IPVersion:         goflags.StringSlice(ipVersions),
 		SkipHostDiscovery: true,
 		WarmUpTime:        2,
 		InputReadTimeout:  180000000000, // This is their default

--- a/internal/discover/port/stealth.go
+++ b/internal/discover/port/stealth.go
@@ -293,7 +293,7 @@ func parsePortList(portStr string) ([]int, error) {
 // isPortOpen checks if a specific port is open using a simple TCP connection
 func isPortOpen(host string, port int) bool {
 	timeout := 3 * time.Second
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), timeout)
+	conn, err := net.DialTimeout("tcp", utils.FormatHostPort(host, port), timeout)
 	if err != nil {
 		return false
 	}

--- a/internal/discover/port/validate.go
+++ b/internal/discover/port/validate.go
@@ -85,9 +85,9 @@ func validatePortScan(ctx context.Context, config discoverfern.DiscoverPortConfi
 					// Use pre-resolved IP to avoid repeated DNS lookups
 					var targetStr string
 					if resolvedValidationIP != "" {
-						targetStr = fmt.Sprintf("%s:%d", resolvedValidationIP, port.Port)
+						targetStr = utils.FormatHostPort(resolvedValidationIP, port.Port)
 					} else {
-						targetStr = fmt.Sprintf("%s:%d", socket.Ip, port.Port)
+						targetStr = utils.FormatHostPort(socket.Ip, port.Port)
 					}
 					serviceConfig := discoverfern.DiscoverServiceConfig{
 						Target:  targetStr,

--- a/internal/discover/service/plugins/bgp.go
+++ b/internal/discover/service/plugins/bgp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
 )
 
 type BGPFingerprinter struct{}
@@ -20,7 +21,7 @@ func (BGPFingerprinter) Name() string { return "bgp" }
 func (BGPFingerprinter) DefaultPorts() []int { return []int{179} }
 
 func (BGPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip.String(), port), time.Duration(timeout)*time.Second)
+	conn, err := net.DialTimeout("tcp", utils.FormatHostPort(ip.String(), port), time.Duration(timeout)*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/discover/service/plugins/dcerpc.go
+++ b/internal/discover/service/plugins/dcerpc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
 )
 
 type DCERPCFingerprinter struct{}
@@ -20,7 +21,7 @@ func (DCERPCFingerprinter) Name() string { return "dcerpc" }
 func (DCERPCFingerprinter) DefaultPorts() []int { return []int{135} }
 
 func (DCERPCFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip.String(), port), time.Duration(timeout)*time.Second)
+	conn, err := net.DialTimeout("tcp", utils.FormatHostPort(ip.String(), port), time.Duration(timeout)*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/discover/service/plugins/ipmi.go
+++ b/internal/discover/service/plugins/ipmi.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
 )
 
 type IPMIFingerprinter struct{}
@@ -19,7 +20,7 @@ func (IPMIFingerprinter) Name() string { return "ipmi" }
 func (IPMIFingerprinter) DefaultPorts() []int { return []int{623} }
 
 func (IPMIFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := utils.FormatHostPort(ip.String(), port)
 
 	// IPMI "Get Channel Authentication Capabilities" request
 	// Based on IPMI v1.5/2.0 RMCP specification

--- a/internal/discover/service/plugins/mongodb.go
+++ b/internal/discover/service/plugins/mongodb.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -26,7 +27,7 @@ func (MongoDBFingerprinter) DefaultPorts() []int { return []int{27017} }
 
 func (MongoDBFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
 	// Create MongoDB connection string
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := utils.FormatHostPort(ip.String(), port)
 	uri := fmt.Sprintf("mongodb://%s", addr)
 
 	// Create context with timeout

--- a/internal/discover/service/plugins/sip.go
+++ b/internal/discover/service/plugins/sip.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
 )
 
 type SIPFingerprinter struct{}
@@ -20,7 +21,7 @@ func (SIPFingerprinter) Name() string { return "sip" }
 func (SIPFingerprinter) DefaultPorts() []int { return []int{5060} }
 
 func (SIPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := utils.FormatHostPort(ip.String(), port)
 
 	// Create SIP OPTIONS request
 	sipRequest := fmt.Sprintf(

--- a/internal/discover/service/plugins/ssdp.go
+++ b/internal/discover/service/plugins/ssdp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
 )
 
 type SSDPFingerprinter struct{}
@@ -20,7 +21,7 @@ func (SSDPFingerprinter) Name() string { return "ssdp" }
 func (SSDPFingerprinter) DefaultPorts() []int { return []int{1900} }
 
 func (SSDPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := utils.FormatHostPort(ip.String(), port)
 
 	// SSDP M-SEARCH discovery request
 	msearchRequest := "M-SEARCH * HTTP/1.1\r\n" +

--- a/internal/discover/service/plugins/ssh.go
+++ b/internal/discover/service/plugins/ssh.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
 )
 
 type SSHFingerprinter struct{}
@@ -66,7 +67,7 @@ func (SSHFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 	}
 
 	// Extract version from banner (e.g., "SSH-2.0-OpenSSH_8.9" -> "SSH-2.0-OpenSSH_8.9")
-	target := fmt.Sprintf("%s:%d", host, port)
+	target := utils.FormatHostPort(host, port)
 	metadata := &protocol.SshServerInfo{
 		ServerVersion: &banner,
 		Target:        &target,

--- a/internal/discover/service/plugins/tftp.go
+++ b/internal/discover/service/plugins/tftp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
 )
 
 type TFTPFingerprinter struct{}
@@ -20,7 +21,7 @@ func (TFTPFingerprinter) Name() string { return "tftp" }
 func (TFTPFingerprinter) DefaultPorts() []int { return []int{69} }
 
 func (TFTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	addr := fmt.Sprintf("%s:%d", ip, port)
+	addr := utils.FormatHostPort(ip.String(), port)
 
 	// Create TFTP Read Request (RRQ) packet
 	// Opcode: 1 (RRQ), Filename: "test", Mode: "octet"

--- a/internal/enumerate/ldap/ldap.go
+++ b/internal/enumerate/ldap/ldap.go
@@ -323,7 +323,7 @@ func (l *LibraryEnumerateLDAP) EnumerateTarget(ctx context.Context, target strin
 
 	host, port := utils.ParseHostPort(target, 389)
 	// Set the actual connection target (ip:port)
-	details.Target = fmt.Sprintf("%s:%d", host, port)
+	details.Target = utils.FormatHostPort(host, port)
 
 	// Perform all authentication tests
 	authState := l.performAuthentication(ctx, host, port, target)

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -264,7 +264,7 @@ func (s *LibraryEnumerateSMB) EnumerateTarget(ctx context.Context, target string
 	log.Info("Starting SMB enumeration for target", svc1log.SafeParam("target", target))
 
 	host, port := utils.ParseHostPort(target, 445)
-	details.Target = fmt.Sprintf("%s:%d", host, port)
+	details.Target = utils.FormatHostPort(host, port)
 
 	// Create SMB client using shared protocol library
 	client := smbclient.NewClient(host, port)

--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -384,7 +384,7 @@ func (e *Engine) createAuthenticatedLDAPSession(ctx context.Context, target stri
 	}
 
 	// Establish connection
-	address := fmt.Sprintf("%s:%d", parsedTarget.Host, parsedTarget.Port)
+	address := utils.FormatHostPort(parsedTarget.Host, parsedTarget.Port)
 	var conn *ldap.Conn
 
 	if parsedTarget.UseSSL {

--- a/internal/pentest/ftp/auth.go
+++ b/internal/pentest/ftp/auth.go
@@ -19,7 +19,7 @@ func AuthenticateUser(ctx context.Context, target, username, password string, ti
 
 	// Parse target to handle default port (21) if not specified
 	host, port := utils.ParseHostPort(target, 21)
-	ftpTarget := fmt.Sprintf("%s:%d", host, port)
+	ftpTarget := utils.FormatHostPort(host, port)
 
 	log.Info("Attempting FTP authentication",
 		svc1log.SafeParam("target", ftpTarget),

--- a/internal/pentest/kerberos/auth.go
+++ b/internal/pentest/kerberos/auth.go
@@ -57,7 +57,7 @@ func EnumerateUsers(ctx context.Context, target *Target, usernames []string, tim
 	cfg.Realms = []config.Realm{
 		{
 			Realm: target.Domain,
-			KDC:   []string{fmt.Sprintf("%s:%d", target.Host, target.Port)},
+			KDC:   []string{utils.FormatHostPort(target.Host, target.Port)},
 		},
 	}
 	cfg.DomainRealm = map[string]string{
@@ -132,7 +132,7 @@ func AuthenticateUser(ctx context.Context, target *Target, username, password st
 	cfg.Realms = []config.Realm{
 		{
 			Realm: target.Domain,
-			KDC:   []string{fmt.Sprintf("%s:%d", target.Host, target.Port)},
+			KDC:   []string{utils.FormatHostPort(target.Host, target.Port)},
 		},
 	}
 	cfg.DomainRealm = map[string]string{

--- a/internal/pentest/ldap/auth.go
+++ b/internal/pentest/ldap/auth.go
@@ -362,7 +362,7 @@ func TestConnection(ctx context.Context, target *Target, timeout int) error {
 
 // createLDAPConnection creates an LDAP connection based on target configuration
 func createLDAPConnection(target *Target, timeout int) (*ldap.Conn, error) {
-	address := fmt.Sprintf("%s:%d", target.Host, target.Port)
+	address := utils.FormatHostPort(target.Host, target.Port)
 
 	// Convert timeout from milliseconds to time.Duration
 	timeoutDuration := time.Duration(timeout) * time.Millisecond
@@ -415,7 +415,7 @@ func PerformAuthenticationWithContextAndConnection(ctx context.Context, target s
 	}
 
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", ldapTarget.Host, ldapTarget.Port)
+	connectionTarget := utils.FormatHostPort(ldapTarget.Host, ldapTarget.Port)
 
 	result := &pentestfern.AuthResult{
 		Target: connectionTarget,

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -252,7 +252,7 @@ func (l *LibraryPentestLdap) connectToLDAP(ctx context.Context, config ldapfern.
 
 // establishConnection creates the initial LDAP connection based on target settings
 func (l *LibraryPentestLdap) establishConnection(target *Target) (*ldap.Conn, error) {
-	address := fmt.Sprintf("%s:%d", target.Host, target.Port)
+	address := utils.FormatHostPort(target.Host, target.Port)
 
 	if target.UseSSL {
 		return ldap.DialTLS("tcp", address, &tls.Config{
@@ -2027,7 +2027,7 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 	connectionTarget := config.Targets[0] // default fallback
 	if len(config.Targets) > 0 {
 		if target, parseErr := ParseTarget(config.Targets[0]); parseErr == nil {
-			connectionTarget = fmt.Sprintf("%s:%d", target.Host, target.Port)
+			connectionTarget = utils.FormatHostPort(target.Host, target.Port)
 		}
 	}
 

--- a/internal/pentest/ldap/probe.go
+++ b/internal/pentest/ldap/probe.go
@@ -8,6 +8,7 @@ import (
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	ldapfern "github.com/Method-Security/networkscan/generated/go/pentest/ldap"
 	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	"github.com/Method-Security/networkscan/utils"
 	"github.com/go-ldap/ldap/v3"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -29,7 +30,7 @@ func PerformProbe(ctx context.Context, target string, config *ldapfern.PentestLd
 	}
 
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", ldapTarget.Host, ldapTarget.Port)
+	connectionTarget := utils.FormatHostPort(ldapTarget.Host, ldapTarget.Port)
 
 	result := &ldapfern.ProbeResult{
 		Target: connectionTarget,

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -41,7 +41,7 @@ func PerformAuthenticationWithContextAndConnection(ctx context.Context, target s
 
 	host, port := utils.ParseHostPort(target, 445)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &smbfern.AuthResult{
 		Target: connectionTarget,
@@ -92,7 +92,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 	host, port := utils.ParseHostPort(target, 445)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &smbfern.AuthResult{
 		Target: connectionTarget,

--- a/internal/pentest/smb/exec.go
+++ b/internal/pentest/smb/exec.go
@@ -16,7 +16,7 @@ import (
 func PerformCommandExecution(ctx context.Context, target string, config *smbfern.PentestSmbConfig) (*smbfern.ExecResult, error) {
 	log := svc1log.FromContext(ctx)
 	host, port := utils.ParseHostPort(target, 445)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	// Initialize result structure
 	result := &smbfern.ExecResult{

--- a/internal/pentest/smb/probe.go
+++ b/internal/pentest/smb/probe.go
@@ -2,7 +2,6 @@ package smb
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
@@ -19,7 +18,7 @@ func PerformProbe(ctx context.Context, target string, config *smbfern.PentestSmb
 
 	host, port := utils.ParseHostPort(target, 445)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &smbfern.ProbeResult{
 		Target: connectionTarget,

--- a/internal/pentest/smb/sharedownload.go
+++ b/internal/pentest/smb/sharedownload.go
@@ -18,7 +18,7 @@ func PerformShareDownload(ctx context.Context, target string, config *smbfern.Pe
 
 	host, port := utils.ParseHostPort(target, 445)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &smbfern.ShareDownloadResult{
 		Target:     connectionTarget,

--- a/internal/pentest/smb/sharesmap.go
+++ b/internal/pentest/smb/sharesmap.go
@@ -22,7 +22,7 @@ func PerformSharesMap(ctx context.Context, target string, config *smbfern.Pentes
 
 	host, port := utils.ParseHostPort(target, 445)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &smbfern.SharesMapResult{
 		Target: connectionTarget,

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -143,7 +143,7 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 	if len(usernames) == 0 {
 		errors = append(errors, "No usernames provided for enumeration")
 		return &pentestfern.SprayTargetResult{
-			Target:  fmt.Sprintf("%s:%d", host, port),
+			Target:  utils.FormatHostPort(host, port),
 			Service: config.Service,
 			Errors:  errors,
 		}, nil
@@ -182,7 +182,7 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 			}
 
 			if attempt.Response.Success {
-				targetWithPort := fmt.Sprintf("%s:%d", host, port)
+				targetWithPort := utils.FormatHostPort(host, port)
 				validUsernames = append(validUsernames, &pentestfern.Credential{
 					Username: username,
 					Domain:   &config.Domain,
@@ -207,7 +207,7 @@ func (e *Engine) runSprayUsernameForTarget(ctx context.Context, target string, c
 	statistics := generateUsernameEnumStatistics(attempts, usernames, startTime, endTime)
 
 	return &pentestfern.SprayTargetResult{
-		Target:                fmt.Sprintf("%s:%d", host, port),
+		Target:                utils.FormatHostPort(host, port),
 		Service:               config.Service,
 		Attempts:              attempts,
 		Statistics:            statistics,
@@ -373,7 +373,7 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 			}
 
 			if attempt.Response.Success {
-				targetWithPort := fmt.Sprintf("%s:%d", host, port)
+				targetWithPort := utils.FormatHostPort(host, port)
 				credWithTarget := &pentestfern.Credential{
 					Username: cred.Username,
 					Password: cred.Password,
@@ -425,7 +425,7 @@ func (e *Engine) runSprayPasswordForTarget(ctx context.Context, target string, c
 			}
 
 			if attempt.Response.Success {
-				targetWithPort := fmt.Sprintf("%s:%d", host, port)
+				targetWithPort := utils.FormatHostPort(host, port)
 				credWithTarget := &pentestfern.Credential{
 					Username: cred.Username,
 					Password: cred.Password,
@@ -459,7 +459,7 @@ done:
 	statistics := generateStatistics(attempts, len(usernames), len(passwords)+len(ntlmHashes), startTime, endTime)
 
 	return &pentestfern.SprayTargetResult{
-		Target:                fmt.Sprintf("%s:%d", host, port),
+		Target:                utils.FormatHostPort(host, port),
 		Service:               config.Service,
 		Attempts:              attempts,
 		Statistics:            statistics,

--- a/internal/pentest/ssh/auth.go
+++ b/internal/pentest/ssh/auth.go
@@ -26,7 +26,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 	host, port := utils.ParseHostPort(target, 22)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &sshfern.AuthResult{
 		Target: connectionTarget,
@@ -140,7 +140,7 @@ func attemptAuthenticationWithContext(ctx context.Context, host string, port int
 		Timeout:         time.Duration(timeout) * time.Millisecond,
 	}
 
-	targetAddr := fmt.Sprintf("%s:%d", host, port)
+	targetAddr := utils.FormatHostPort(host, port)
 	conn, err := ssh.Dial("tcp", targetAddr, sshConfig)
 
 	if err != nil {

--- a/internal/pentest/ssh/exec.go
+++ b/internal/pentest/ssh/exec.go
@@ -16,7 +16,7 @@ import (
 func PerformCommandExecution(ctx context.Context, target string, config *sshfern.PentestSshConfig) (*sshfern.ExecResult, error) {
 	log := svc1log.FromContext(ctx)
 	host, port := utils.ParseHostPort(target, 22)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	// Initialize result structure
 	result := &sshfern.ExecResult{
@@ -116,7 +116,7 @@ func ExecuteCommandsWithCredentials(ctx context.Context, host string, port int, 
 		Timeout:         time.Duration(timeout) * time.Millisecond,
 	}
 
-	targetAddr := fmt.Sprintf("%s:%d", host, port)
+	targetAddr := utils.FormatHostPort(host, port)
 	conn, err := ssh.Dial("tcp", targetAddr, sshConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %v", err)

--- a/internal/pentest/telnet/auth.go
+++ b/internal/pentest/telnet/auth.go
@@ -28,7 +28,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 	host, port := utils.ParseHostPort(target, 23)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &telnetfern.AuthResult{
 		Target: connectionTarget,

--- a/internal/pentest/winrm/auth.go
+++ b/internal/pentest/winrm/auth.go
@@ -40,7 +40,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 
 	host, port := utils.ParseHostPort(target, defaultPort)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &winrmfern.AuthResult{
 		Target: connectionTarget,
@@ -95,7 +95,7 @@ func PerformAuthenticationWithContextAndConnection(ctx context.Context, target s
 
 	host, port := utils.ParseHostPort(target, defaultPort)
 	// Set the actual connection target (ip:port)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	result := &winrmfern.AuthResult{
 		Target: connectionTarget,

--- a/internal/pentest/winrm/exec.go
+++ b/internal/pentest/winrm/exec.go
@@ -29,7 +29,7 @@ func PerformCommandExecution(ctx context.Context, target string, config *winrmfe
 	}
 
 	host, port := utils.ParseHostPort(target, defaultPort)
-	connectionTarget := fmt.Sprintf("%s:%d", host, port)
+	connectionTarget := utils.FormatHostPort(host, port)
 
 	// Initialize result structure
 	result := &winrmfern.ExecResult{

--- a/internal/protocol/kerberos/client.go
+++ b/internal/protocol/kerberos/client.go
@@ -7,6 +7,7 @@ import (
 
 	kerberosfern "github.com/Method-Security/networkscan/generated/go/pentest/kerberos"
 	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	"github.com/Method-Security/networkscan/utils"
 	"github.com/jfjallid/gokrb5/v8/client"
 	"github.com/jfjallid/gokrb5/v8/config"
 	"github.com/jfjallid/gokrb5/v8/iana/etypeID"
@@ -43,7 +44,7 @@ func (kcm *ClientManager) CreateConfiguration() *config.Config {
 	cfg.Realms = []config.Realm{
 		{
 			Realm: strings.ToUpper(kcm.Target.Domain),
-			KDC:   []string{fmt.Sprintf("%s:%d", kcm.Target.Host, kcm.Target.Port)},
+			KDC:   []string{utils.FormatHostPort(kcm.Target.Host, kcm.Target.Port)},
 		},
 	}
 	cfg.DomainRealm = map[string]string{

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -240,3 +240,51 @@ func GetIPs(host string) ([]net.IP, error) {
 
 	return ips, nil
 }
+
+// FormatHostPort formats a host (IP address or hostname) and port into a valid address string.
+// For IPv6 addresses, it wraps them in square brackets. For IPv4 and hostnames, it uses simple colon notation.
+// This ensures compatibility with services expecting properly formatted network addresses.
+func FormatHostPort(host string, port int) string {
+	return net.JoinHostPort(host, fmt.Sprintf("%d", port))
+}
+
+// DetectIPVersions analyzes a list of IP addresses and returns which IP versions are present.
+// Returns a slice containing "4" for IPv4 and/or "6" for IPv6.
+// This is used to configure scanners to support the appropriate IP versions.
+func DetectIPVersions(hosts []string) []string {
+	hasIPv4 := false
+	hasIPv6 := false
+
+	for _, host := range hosts {
+		ip := net.ParseIP(host)
+		if ip == nil {
+			continue
+		}
+
+		if ip.To4() != nil {
+			hasIPv4 = true
+		} else {
+			hasIPv6 = true
+		}
+
+		// Short circuit if we've found both
+		if hasIPv4 && hasIPv6 {
+			break
+		}
+	}
+
+	var versions []string
+	if hasIPv4 {
+		versions = append(versions, "4")
+	}
+	if hasIPv6 {
+		versions = append(versions, "6")
+	}
+
+	// Default to IPv4 if no valid IPs found
+	if len(versions) == 0 {
+		versions = []string{"4"}
+	}
+
+	return versions
+}


### PR DESCRIPTION
* use net.JoinHostPort to create host:port strings
* tell Naabu if address is v6

Using host:port doesn't work as v6 addresses need the address part inside square brackets `[]`; net.JoinHostPort does the right thing for v4, v6 and hostnames in this context. Naabu for some reason also needed to be told for it to function.

Did some local testing using IPv6 IPs directly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves IPv6 compatibility and correctness for all network operations by standardizing address formatting and making scanners IPv6-aware.
> 
> - Add `utils.FormatHostPort` (wraps `net.JoinHostPort`) and `utils.DetectIPVersions`
> - Host discovery/port scan: detect IP versions from targets and set `runner.Options.IPVersion`; keep output clean via stderr writer; use parsed targets
> - Replace manual `host:port` formatting with `utils.FormatHostPort` across discovery, service plugins (`bgp`, `dcerpc`, `ipmi`, `mongodb`, `sip`, `ssdp`, `ssh`, `tftp`), enumeration (LDAP/SMB), and pentest modules (FTP, Kerberos, LDAP, SMB, SSH, Telnet, WinRM), including stealth scans
> - go.mod: mark `projectdiscovery/utils` as indirect
> 
> These changes ensure correct bracketed IPv6 literals and consistent dialing across protocols and scanners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c04c9584b54ddb456f105f3642a2704be785ac0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->