### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -23,14 +23,6 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo docker system prune -af
-          df -h
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -71,11 +63,6 @@ jobs:
             goreleaser build --single-target --clean --snapshot --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
 
-      - name: Cleanup Docker images
-        run: |
-          docker rmi armbuilder || true
-          docker system prune -f
-
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-dist
@@ -89,14 +76,6 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo docker system prune -af
-          df -h
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -136,11 +115,6 @@ jobs:
             --rm amdbuilder \
             goreleaser build --single-target --clean --snapshot --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
-
-      - name: Cleanup Docker images
-        run: |
-          docker rmi amdbuilder || true
-          docker system prune -f
 
       - uses: actions/upload-artifact@v4
         with:
@@ -226,30 +200,6 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
-          remove-android: "true"
-          remove-docker-images: "true"
-          remove-dotnet: "true"
-          remove-haskell: "true"
-          remove-codeql: "true"
-          remove-swapfile: "true"
-
-      - name: Clean up disk space
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          sudo docker image prune --all --force
-          sudo apt-get clean
-          echo "Disk space after cleanup:"
-          df -h
-
       - name: Install Dependences
         run: sudo apt install libpcap-dev
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that mainly deletes cleanup steps; risk is limited to potential workflow failures if disk space becomes insufficient on runners.
> 
> **Overview**
> Removes multiple disk-space reclamation steps from `.github/workflows/reusable-build.yml`, including runner cleanup (deleting preinstalled toolchains, pruning Docker images) and the `easimon/maximize-build-space` action.
> 
> The build now relies on the default runner environment for `prepare-linux-*` and `build` jobs while keeping the same Docker/GoReleaser build and artifact upload flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fd85e8331f0e4e98cbaaab5ed2a0c41da123cb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->