### PR TITLE
Update Port Validation

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -159,6 +159,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			var validateHostname *string
 			var validateAttemptTimeout *int
 			var validateThreads *int
+			var maxOpenPortsValidationThreshold *int
 			if validate {
 				// Validate hostname
 				validateHostnameString, err := cmd.Flags().GetString("validate-hostname")
@@ -183,6 +184,12 @@ func (a *NetworkScan) InitDiscoverCommand() {
 					return
 				}
 				validateThreads = &validateThreadsInt
+				maxOpenPortsValidationThresholdInt, err := cmd.Flags().GetInt("max-open-ports-validation-threshold")
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
+				}
+				maxOpenPortsValidationThreshold = &maxOpenPortsValidationThresholdInt
 			}
 
 			// Stealth flags
@@ -208,7 +215,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPortConfig(target, ports, topPorts, threads, packetsPerSecond, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, sleep, jitter)
+			config := getDiscoverPortConfig(target, ports, topPorts, threads, packetsPerSecond, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, maxOpenPortsValidationThreshold, sleep, jitter)
 
 			// Generate the report
 			report, err := discoverport.RunPortScan(cmd.Context(), config)
@@ -229,6 +236,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverPortCmd.Flags().String("validate-hostname", "", "Hostname to validate against (e.g., example.com)")
 	discoverPortCmd.Flags().Int("validate-attempt-timeout", 10, "Timeout in seconds for each service detection attempt")
 	discoverPortCmd.Flags().Int("validate-threads", 0, "Number of concurrent threads to use during service detection")
+	discoverPortCmd.Flags().Int("max-open-ports-validation-threshold", 50, "Trigger validation warning when more than this many ports are open (default: 50)")
 	discoverPortCmd.Flags().Int("sleep", 0, "Sleep delay in seconds between port scans for stealth scan (stealth mode enabled when sleep > 0)")
 	discoverPortCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delay for stealth scan")
 
@@ -397,7 +405,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 
 // getDiscoverPortConfig creates a configuration for port scanning with the provided parameters.
 // It handles both specific port ranges and top ports scanning modes.
-func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, packetsPerSecond int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, sleep int, jitter int) discoverfern.DiscoverPortConfig {
+func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, packetsPerSecond int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, maxOpenPortsValidationThreshold *int, sleep int, jitter int) discoverfern.DiscoverPortConfig {
 	// Start with common fields that apply to both stealth and regular scans
 	config := discoverfern.DiscoverPortConfig{
 		Target:           target,
@@ -431,6 +439,10 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 		}
 		if validateThreads != nil {
 			config.ValidateThreads = validateThreads
+		}
+		if maxOpenPortsValidationThreshold != nil {
+			threshold := max(0, *maxOpenPortsValidationThreshold)
+			config.MaxOpenPortsValidationThreshold = &threshold
 		}
 	}
 

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -31,12 +31,13 @@ types:
       ports: optional<string>
       topPorts: optional<string>
       threads: integer
-      packetsPerSecond: integer # Packets per second to send (default: 10)
+      packetsPerSecond: integer
       scanType: PortScanType
       validate: boolean
       validateHostname: optional<string>
       validateAttemptTimeout: optional<integer>
       validateThreads: optional<integer>
+      maxOpenPortsValidationThreshold: optional<integer>
       stealth: optional<PortStealthConfig>
   # Final report
   DiscoverPortReport:

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -30,23 +30,23 @@ import (
 var requiredPorts = []string{
 	"1",
 	"2",
-	"3",
-	"9",
-	"19",
-	"32768",
-	"49998",
-	"49999",
-	"52673",
-	"52822",
-	"52848",
-	"52869",
-	"54045",
-	"58080",
-	"54320",
+	"4873",
+	"9127",
+	"10439",
+	"15872",
+	"21345",
+	"27654",
+	"31987",
+	"35841",
+	"40129",
+	"44762",
+	"48991",
+	"51234",
 	"54321",
-	"60000",
-	"60001",
-	"61095",
+	"57689",
+	"60321",
+	"62844",
+	"64998",
 	"65535",
 }
 
@@ -83,18 +83,34 @@ func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*
 		errors = append(errors, err.Error())
 	}
 
-	// Filter ports by service validation if requested
+	// Port validation checks:
+	// 1. Check if open ports exceed threshold
+	// 2. Verify required validation ports are open
 	if config.Validate {
-		// Check if either of the required ports are open
-		if !hasOpenRequiredPorts(portscanResult, requiredPorts) {
+		shouldValidate := false
+
+		// Step 1: Check if the number of open ports exceeds the validation threshold
+		if config.MaxOpenPortsValidationThreshold != nil && *config.MaxOpenPortsValidationThreshold > 0 {
+			openPortCount := countOpenPorts(portscanResult)
+			if openPortCount > *config.MaxOpenPortsValidationThreshold {
+				log.Warn("Number of open ports exceeds validation threshold, triggering validation",
+					svc1log.SafeParam("openPorts", openPortCount),
+					svc1log.SafeParam("threshold", *config.MaxOpenPortsValidationThreshold))
+				errors = append(errors, fmt.Sprintf("validation warning: %d open ports exceeds threshold of %d", openPortCount, *config.MaxOpenPortsValidationThreshold))
+				shouldValidate = true
+			}
+		}
+		// Step 2: Check if required validation ports are ope
+		shouldValidate = shouldValidate || hasOpenRequiredPorts(portscanResult, requiredPorts)
+
+		// If neither condition is met, skip validation
+		if !shouldValidate {
 			log.Info("Required validation ports are closed, skipping validation", svc1log.SafeParam("requiredPorts", requiredPorts))
-			// Required ports are not open, consider everything validated (skip validation)
 			return &discoverfern.DiscoverPortReport{
 				Config: &config, Result: &discoverfern.DiscoverPortResult{Sockets: portscanResult}, Errors: errors}, nil
 		}
-		log.Info("Required validation ports are open, proceeding with validation", svc1log.SafeParam("requiredPorts", requiredPorts))
 
-		// Required ports are open, proceed with validation
+		// If either condition is met, proceed with validation
 		validatedPorts, validationErrors := validatePortScan(ctx, config, portscanResult)
 		portscanResult = validatedPorts
 		errors = append(errors, validationErrors...)
@@ -267,6 +283,17 @@ func hasOpenRequiredPorts(scanResults []*discoverfern.SocketDetails, requiredPor
 	}
 
 	return false
+}
+
+// countOpenPorts counts the total number of open ports across all hosts in the scan results
+func countOpenPorts(scanResults []*discoverfern.SocketDetails) int {
+	count := 0
+	for _, socket := range scanResults {
+		if socket != nil && socket.Ports != nil {
+			count += len(socket.Ports)
+		}
+	}
+	return count
 }
 
 // hideOsArgsFromNaabu prevents Naabu from processing command line arguments.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the conditions under which port scan results are post-validated and adds new config surfaced via the CLI/schema, which could alter output and performance characteristics on large scans.
> 
> **Overview**
> Updates `discover port` validation behavior so service validation runs only when either (a) at least one *required validation port* is open **or** (b) the scan finds more open ports than a new configurable threshold, emitting a warning/error string when the threshold is exceeded.
> 
> Adds `--max-open-ports-validation-threshold` (default `50`) and threads it through `DiscoverPortConfig`/Fern schema; the threshold is clamped to `>= 0`. Also refreshes the hardcoded `requiredPorts` list and introduces `countOpenPorts` to support the new gating logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f2a54e641101a88e3b5113b052e6deb08d76115. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->