### PR TITLE
Clean Up Trace Route Tool

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -313,8 +313,6 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				switch probeType {
 				case discoverfern.ProbeTypeUdp:
 					port = 33434 // Standard UDP traceroute port
-				case discoverfern.ProbeTypeTcpSyn:
-					port = 80 // Default to HTTP port for TCP
 				case discoverfern.ProbeTypeIcmp:
 					port = 0 // ICMP doesn't use ports
 				}
@@ -339,8 +337,8 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverRouteCmd.Flags().Int("probe-delay", 100, "Delay in milliseconds between probes (default: 100)")
 	discoverRouteCmd.Flags().Int("max-hops", 30, "Maximum number of hops to trace (default: 30)")
 	discoverRouteCmd.Flags().Int("timeout", 5, "Timeout in seconds for each probe (default: 5)")
-	discoverRouteCmd.Flags().String("probe-type", "UDP", "Probe packet type: UDP, ICMP, or TCP_SYN (default: UDP)")
-	discoverRouteCmd.Flags().Int("port", 0, "Port number for TCP/UDP probes (default: 33434 for UDP, 80 for TCP)")
+	discoverRouteCmd.Flags().String("probe-type", "UDP", "Probe packet type: UDP or ICMP (default: UDP)")
+	discoverRouteCmd.Flags().Int("port", 33434, "Port number for UDP probes (default: 33434 for UDP)")
 	discoverRouteCmd.Flags().Int("packet-size", 0, "Packet size in bytes (default: varies by probe type)")
 
 	// Mark Required Flags

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -4,7 +4,6 @@ types:
     enum:
       - UDP
       - ICMP
-      - TCP_SYN
   # Structs
   TracerouteHop:
     properties:

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -168,10 +168,6 @@ func performTraceroute(ctx context.Context, target, targetIP string, maxHops int
 		tr, err = newICMPTracer(destIP)
 	case discoverfern.ProbeTypeUdp:
 		tr, err = newUDPTracer(destIP, port)
-	default:
-		// TCP SYN is complex without raw sockets, fallback to UDP
-		log.Info("TCP SYN not supported, falling back to UDP")
-		tr, err = newUDPTracer(destIP, port)
 	}
 
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is a user-facing and API-breaking change for anyone relying on `TCP_SYN` probe type or previous `--port` default behavior; runtime risk is otherwise limited to the traceroute path.
> 
> **Overview**
> Removes TCP SYN traceroute support end-to-end: `ProbeType` no longer includes `TCP_SYN`, the tracer initialization in `internal/discover/route` no longer falls back from TCP to UDP, and the `discover route` CLI now only advertises/accepts `UDP` and `ICMP`.
> 
> Adjusts CLI port handling by making `--port` default to `33434` (UDP) and removing the implicit TCP default, simplifying how ports are applied for probe types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c464c75d5fa4e58eda1da4f5690d575bb8092ac0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->