### PR TITLE
Trace Route: Fix Host IP Resolution

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -295,27 +295,22 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			port, err := cmd.Flags().GetInt("port")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
 			// Convert probe type string to enum
 			probeType, err := discoverfern.NewProbeTypeFromString(strings.ToUpper(probeTypeStr))
 			if err != nil {
 				a.OutputSignal.AddError(fmt.Errorf("invalid probe type: %s", probeTypeStr))
 				return
 			}
-
-			// Apply default ports based on probe type if port is 0
-			if port == 0 {
-				switch probeType {
-				case discoverfern.ProbeTypeUdp:
-					port = 33434 // Standard UDP traceroute port
-				case discoverfern.ProbeTypeIcmp:
-					port = 0 // ICMP doesn't use ports
-				}
+			port, err := cmd.Flags().GetInt("port")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			// Apply default ports based on probe type
+			if port == 0 && probeType != discoverfern.ProbeTypeIcmp {
+				port = 33434 // Standard UDP traceroute port
+			} else if probeType == discoverfern.ProbeTypeIcmp {
+				port = 0 // ICMP doesn't use ports
 			}
 
 			// Set Config

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -160,16 +160,17 @@ func resolveTarget(target string) (string, error) {
 func getOutboundIP() (string, error) {
 	// Connect to a public DNS server (Google's 8.8.8.8)
 	// This doesn't actually send any packets, just determines the local IP that would be used
-	conn, err := net.Dial("udp", "8.8.8.8:80")
+	conn, err := net.Dial("udp", "8.8.8.8:53")
 	if err != nil {
 		return "", fmt.Errorf("failed to detect outbound IP: %w", err)
 	}
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
 	err = conn.Close()
 	if err != nil {
 		return "", fmt.Errorf("failed to close connection: %w", err)
 	}
-
-	localAddr := conn.LocalAddr().(*net.UDPAddr)
 	return localAddr.IP.String(), nil
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized changes to traceroute defaults and outbound IP detection; low risk but may affect environments that relied on the prior (incorrect) `8.8.8.8:80` UDP dial behavior.
> 
> **Overview**
> Fixes traceroute host IP auto-detection by changing the outbound-IP probe to dial `8.8.8.8:53` (DNS) and by capturing `LocalAddr()` before closing the connection in `getOutboundIP()`.
> 
> Simplifies `discover route` port defaulting: if `--port` is unset/0, it now defaults to `33434` for non-ICMP probes and forces `0` for ICMP, regardless of user input order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 299ba984d233a7482e4788f80a761fc44346e0d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->