### PR TITLE
Bump Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.20.0"
+  "version": "3.78.1"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -13,7 +13,7 @@ groups:
   pypi-local:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         output:
           location: local-file-system
           path: ../generated/python
@@ -21,7 +21,7 @@ groups:
   pypi-test:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         config:
           package_name: methodnetworkscan
         output:
@@ -33,7 +33,7 @@ groups:
   pypi:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         config:
           package_name: methodnetworkscan
         output:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version bumps to code generation tooling/config only; risk is limited to potential regenerated client/model diffs when the generators are run.
> 
> **Overview**
> Bumps the Fern configuration version from `3.20.0` to `3.78.1`.
> 
> Updates the Python `fernapi/fern-pydantic-model` generator from `1.11.1` to `1.11.2` across local, test PyPI, and PyPI generation groups (no other generator settings changed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 152e206a63e73d1e5792fa185967f2228e3de513. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->