### PR TITLE
Update Error Metrics for DD

### DIFF
--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -96,7 +96,7 @@ func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*
 				log.Warn("Number of open ports exceeds validation threshold, triggering validation",
 					svc1log.SafeParam("openPorts", openPortCount),
 					svc1log.SafeParam("threshold", *config.MaxOpenPortsValidationThreshold))
-				errors = append(errors, fmt.Sprintf("validation triggered due to count of open ports exceed (%d > %d)", openPortCount, *config.MaxOpenPortsValidationThreshold)) // Note: DD Metrics is generated off of this error line. Please update with caution
+				errors = append(errors, fmt.Sprintf("validation triggered due to count of open ports exceeding threshold (%d > %d)", openPortCount, *config.MaxOpenPortsValidationThreshold)) // Note: DD Metrics is generated off of this error line. Please update with caution
 				shouldValidate = true
 			}
 		}

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -85,7 +85,7 @@ func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*
 
 	// Port validation checks:
 	// 1. Check if open ports exceed threshold
-	// 2. Verify required validation ports are open
+	// 2. Check if required validation ports are open
 	if config.Validate {
 		shouldValidate := false
 
@@ -96,16 +96,21 @@ func RunPortScan(ctx context.Context, config discoverfern.DiscoverPortConfig) (*
 				log.Warn("Number of open ports exceeds validation threshold, triggering validation",
 					svc1log.SafeParam("openPorts", openPortCount),
 					svc1log.SafeParam("threshold", *config.MaxOpenPortsValidationThreshold))
-				errors = append(errors, fmt.Sprintf("validation warning: %d open ports exceeds threshold of %d", openPortCount, *config.MaxOpenPortsValidationThreshold))
+				errors = append(errors, fmt.Sprintf("validation triggered due to open ports exceed (%d >%d)", openPortCount, *config.MaxOpenPortsValidationThreshold))
 				shouldValidate = true
 			}
 		}
 		// Step 2: Check if required validation ports are ope
-		shouldValidate = shouldValidate || hasOpenRequiredPorts(portscanResult, requiredPorts)
+		hasOpenRequiredPorts := hasOpenRequiredPorts(portscanResult, requiredPorts)
+		if hasOpenRequiredPorts {
+			log.Warn("Required validation ports are open, triggering validation", svc1log.SafeParam("requiredPorts", requiredPorts))
+			errors = append(errors, fmt.Sprintf("validation triggered due to open ports"))
+			shouldValidate = true
+		}
 
 		// If neither condition is met, skip validation
 		if !shouldValidate {
-			log.Info("Required validation ports are closed, skipping validation", svc1log.SafeParam("requiredPorts", requiredPorts))
+			log.Info("Skipping validation, no condition met")
 			return &discoverfern.DiscoverPortReport{
 				Config: &config, Result: &discoverfern.DiscoverPortResult{Sockets: portscanResult}, Errors: errors}, nil
 		}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior is largely unchanged aside from logging and error string contents; main risk is downstream consumers/alerts that parse these exact error messages.
> 
> **Overview**
> Updates port-scan validation to emit **explicit, metric-friendly error strings** when validation is triggered, distinguishing between (a) exceeding the open-port threshold and (b) detecting any required validation ports open.
> 
> Also tweaks validation logging/flow by adding a warning log on required-port triggers and simplifying the skip-validation log message; `validatePortScan` only changes comments/documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 402803627b5ee7c2f7504a9fa191372a66781455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->