### PR TITLE
UDP + FTP Tool Fixes

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -413,7 +413,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
-	discoverServiceCmd.Flags().String("target", "", "Target address (IP:port or hostname:port for TCP, IP or hostname for UDP mode)")
+	discoverServiceCmd.Flags().String("target", "", "Target address (IP:port or hostname:port for TCP, IP/hostname/CIDR for UDP mode)")
 	discoverServiceCmd.Flags().Int("timeout", 5, "Timeout in seconds for each service fingerprinting attempt")
 	discoverServiceCmd.Flags().Int("fingerprintx-timeout", 0, "Timeout in seconds for fingerprintx attempt (default is no timeout)")
 	discoverServiceCmd.Flags().Bool("udp", false, "Enable UDP service discovery mode (scans common UDP ports like DNS, NTP, SNMP, etc.)")

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -362,22 +362,30 @@ func runUDPServiceDiscovery(ctx context.Context, config discoverfern.DiscoverSer
 	report := &discoverfern.DiscoverServiceReport{Config: &config}
 	var results []*discoverfern.ServiceDetails
 
-	// Parse target to get host (should be just IP or hostname, no port)
+	// Parse target to get host (should be just IP, hostname, or CIDR)
 	host := config.Target
 	// Strip port if someone accidentally included it
 	if strings.Contains(host, ":") {
 		host, _, _ = net.SplitHostPort(host)
 	}
 
-	ips, err := utils.GetIPs(host)
+	// Use ParseTargetHosts to handle CIDR notation, IP ranges, and hostnames
+	hostStrs, err := utils.ParseTargetHosts(host)
 	if err != nil {
 		report.Result = &discoverfern.DiscoverServiceResult{}
 		report.Errors = append(report.Errors, fmt.Sprintf("failed to resolve target %s: %v", host, err))
 		return report, nil
 	}
 
+	var ips []net.IP
+	for _, h := range hostStrs {
+		ips = append(ips, net.ParseIP(h))
+	}
+
 	// Scan each IP
 	for _, ip := range ips {
+		ipStr := ip.String()
+
 		// Collect all UDP fingerprinters with their ports
 		type udpFingerprintTask struct {
 			port          int
@@ -397,7 +405,7 @@ func runUDPServiceDiscovery(ctx context.Context, config discoverfern.DiscoverSer
 
 		for _, task := range tasks {
 			go func(t udpFingerprintTask) {
-				detection, err := t.fingerprinter.Detect(ctx, ip, t.port, host, config.Timeout)
+				detection, err := t.fingerprinter.Detect(ctx, ip, t.port, ipStr, config.Timeout)
 				if err == nil && detection != nil {
 					select {
 					case resultChan <- detection:

--- a/internal/enumerate/ftp/helpers.go
+++ b/internal/enumerate/ftp/helpers.go
@@ -59,28 +59,31 @@ func grabBanner(ctx context.Context, conn net.Conn) (string, error) {
 
 // Function to check for anonymous login with retry on failure
 func checkAnonymousLoginWithRetry(ctx context.Context, target string, conn net.Conn, details *ftp.EnumerateFtpDetails) []string {
-	// Initialize
 	log := svc1log.FromContext(ctx)
 
 	errors := []string{}
 	if err := checkAnonymousLogin(ctx, conn, details); err != nil {
 		log.Warn("Error checking anonymous login, retrying...", svc1log.SafeParam("error", err.Error()))
 
-		// Reconnect and retry
 		conn, err = attemptConnection(ctx, target)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to reconnect: %v", err))
 			return errors
 		}
 
-		// Retry checking anonymous login after reconnect
+		// Consume the banner from the new connection before retrying
+		if _, bannerErr := grabBanner(ctx, conn); bannerErr != nil {
+			errors = append(errors, fmt.Sprintf("failed to read banner after reconnect: %v", bannerErr))
+			_ = conn.Close()
+			return errors
+		}
+
 		err = checkAnonymousLogin(ctx, conn, details)
 		if err != nil {
-			errors = append(errors, fmt.Sprintf("failed to reconnect: %v", err))
+			errors = append(errors, fmt.Sprintf("anonymous login check failed after retry: %v", err))
 		}
-		err = conn.Close()
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("failed to close connection: %v", err))
+		if closeErr := conn.Close(); closeErr != nil {
+			errors = append(errors, fmt.Sprintf("failed to close connection: %v", closeErr))
 		}
 	}
 
@@ -89,18 +92,23 @@ func checkAnonymousLoginWithRetry(ctx context.Context, target string, conn net.C
 
 // Function to check for anonymous login
 func checkAnonymousLogin(ctx context.Context, conn net.Conn, details *ftp.EnumerateFtpDetails) error {
-	// Initialize
 	log := svc1log.FromContext(ctx)
 
 	log.Info("Checking for anonymous login...")
 
-	// Send the USER anonymous command
-	_, err := conn.Write([]byte("USER anonymous\r\n"))
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return fmt.Errorf("failed to set read deadline: %v", err)
+	}
+	err := conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		return fmt.Errorf("failed to set read deadline: %v", err)
+	}
+
+	_, err = conn.Write([]byte("USER anonymous\r\n"))
 	if err != nil {
 		return fmt.Errorf("failed to send USER command: %v", err)
 	}
 
-	// Read the response from the server
 	response := make([]byte, bufferSize)
 	n, err := conn.Read(response)
 	if err != nil {
@@ -111,13 +119,12 @@ func checkAnonymousLogin(ctx context.Context, conn net.Conn, details *ftp.Enumer
 		responseStr := string(response[:n])
 		log.Info("Anonymous login response received", svc1log.SafeParam("response", responseStr))
 
-		if strings.HasPrefix(responseStr, "331") {
+		if containsFTPCode(responseStr, "331") {
 			_, err = conn.Write([]byte("PASS anonymous\r\n"))
 			if err != nil {
 				return fmt.Errorf("failed to send PASS command: %v", err)
 			}
 
-			// Read the response from the server after sending the password
 			n, err = conn.Read(response)
 			if err != nil {
 				return fmt.Errorf("error reading response after sending password: %v", err)
@@ -127,12 +134,11 @@ func checkAnonymousLogin(ctx context.Context, conn net.Conn, details *ftp.Enumer
 				responseStr = string(response[:n])
 				log.Info("Password response received", svc1log.SafeParam("response", responseStr))
 
-				// Check for response indicating anonymous login status
-				if strings.HasPrefix(responseStr, "530") {
+				if containsFTPCode(responseStr, "530") {
 					details.AllowsAnonymousLogin = new(bool)
 					*details.AllowsAnonymousLogin = false
 					log.Info("Anonymous login not supported (530 response)")
-				} else if strings.HasPrefix(responseStr, "230") {
+				} else if containsFTPCode(responseStr, "230") {
 					details.AllowsAnonymousLogin = new(bool)
 					*details.AllowsAnonymousLogin = true
 					log.Info("Anonymous login supported")
@@ -152,9 +158,18 @@ func checkAnonymousLogin(ctx context.Context, conn net.Conn, details *ftp.Enumer
 	return nil
 }
 
+// containsFTPCode checks if any line in a multi-line FTP response starts with the given code.
+func containsFTPCode(response string, code string) bool {
+	for _, line := range strings.Split(response, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), code) {
+			return true
+		}
+	}
+	return false
+}
+
 // Function to check if TLS is implemented (supported) using the FEAT command
 func checkTLSImplemented(ctx context.Context, conn net.Conn, details *ftp.EnumerateFtpDetails) error {
-	// Initialize
 	log := svc1log.FromContext(ctx)
 
 	log.Info("Sending FEAT command to check if TLS is implemented...")
@@ -165,35 +180,31 @@ func checkTLSImplemented(ctx context.Context, conn net.Conn, details *ftp.Enumer
 
 	var featResponse string
 	response := make([]byte, bufferSize)
-	timeout := time.After(5 * time.Second)
 
-readLoop: // Label for the outer loop
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return fmt.Errorf("failed to set read deadline: %v", err)
+	}
+	err = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		return fmt.Errorf("failed to set read deadline: %v", err)
+	}
+
 	for {
-		select {
-		case <-timeout:
-			log.Error("Timeout while reading FEAT response.")
-			return fmt.Errorf("timeout while reading FEAT response")
-		default:
-			err = conn.SetReadDeadline(time.Now().Add(5 * time.Second)) // Set a read deadline
-			if err != nil {
-				log.Error("failed to set read deadline", svc1log.SafeParam("error", err.Error()))
-				return fmt.Errorf("failed to set read deadline: %v", err)
+		n, err := conn.Read(response)
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				log.Error("Timeout while reading FEAT response.")
+				return fmt.Errorf("timeout while reading FEAT response")
 			}
-			n, err := conn.Read(response)
-			if err != nil {
-				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-					continue
-				}
-				if err.Error() == "EOF" {
-					log.Info("EOF encountered: TLS not implemented (no response from server).")
-					return nil
-				}
-				return fmt.Errorf("error reading FEAT response: %v", err)
+			if err.Error() == "EOF" {
+				log.Info("EOF encountered: TLS not implemented (no response from server).")
+				return nil
 			}
-			featResponse += string(response[:n])
-			if strings.Contains(featResponse, "211 End") || n == 0 {
-				break readLoop
-			}
+			return fmt.Errorf("error reading FEAT response: %v", err)
+		}
+		featResponse += string(response[:n])
+		if strings.Contains(featResponse, "211 End") || n == 0 {
+			break
 		}
 	}
 
@@ -215,7 +226,6 @@ readLoop: // Label for the outer loop
 
 // Function to check if TLS is forced (i.e., required by the server)
 func checkTLSForced(ctx context.Context, conn net.Conn, details *ftp.EnumerateFtpDetails) []string {
-	// Initialize
 	log := svc1log.FromContext(ctx)
 
 	log.Info("Sending TLS commands to check if TLS is forced...")
@@ -228,7 +238,16 @@ func checkTLSForced(ctx context.Context, conn net.Conn, details *ftp.EnumerateFt
 			errors = append(errors, fmt.Sprintf("error sending STARTTLS command: %v", err))
 			return errors
 		}
+	}
 
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		errors = append(errors, fmt.Sprintf("failed to set read deadline: %v", err))
+		return errors
+	}
+	err = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("failed to set read deadline: %v", err))
+		return errors
 	}
 
 	response := make([]byte, bufferSize)

--- a/internal/enumerate/ftp/helpers.go
+++ b/internal/enumerate/ftp/helpers.go
@@ -34,17 +34,22 @@ func attemptConnection(ctx context.Context, target string) (net.Conn, error) {
 
 // Function to grab the FTP banner
 func grabBanner(ctx context.Context, conn net.Conn) (string, error) {
-	// Initialize
 	log := svc1log.FromContext(ctx)
+
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return "", fmt.Errorf("failed to set read deadline: %v", err)
+	}
 
 	var bannerStr string
 	response := make([]byte, bufferSize)
 	for {
 		n, err := conn.Read(response)
 		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				return "", fmt.Errorf("timeout reading FTP banner")
+			}
 			return "", fmt.Errorf("error reading initial banner: %v", err)
 		}
-		// Safely append raw bytes without assuming ASCII encoding
 		bannerStr += string(response[:n])
 
 		log.Info("Reading banner, current content (partial)", svc1log.SafeParam("content", string(response[:n])))
@@ -53,6 +58,12 @@ func grabBanner(ctx context.Context, conn net.Conn) (string, error) {
 			break
 		}
 	}
+
+	err := conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		return "", fmt.Errorf("failed to clear read deadline: %v", err)
+	}
+
 	log.Info("Final banner", svc1log.SafeParam("banner", strings.TrimSpace(bannerStr)))
 	return bannerStr, nil
 }
@@ -99,12 +110,8 @@ func checkAnonymousLogin(ctx context.Context, conn net.Conn, details *ftp.Enumer
 	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		return fmt.Errorf("failed to set read deadline: %v", err)
 	}
-	err := conn.SetReadDeadline(time.Time{})
-	if err != nil {
-		return fmt.Errorf("failed to set read deadline: %v", err)
-	}
 
-	_, err = conn.Write([]byte("USER anonymous\r\n"))
+	_, err := conn.Write([]byte("USER anonymous\r\n"))
 	if err != nil {
 		return fmt.Errorf("failed to send USER command: %v", err)
 	}
@@ -155,6 +162,10 @@ func checkAnonymousLogin(ctx context.Context, conn net.Conn, details *ftp.Enumer
 		}
 	}
 
+	if err = conn.SetReadDeadline(time.Time{}); err != nil {
+		return fmt.Errorf("failed to clear read deadline: %v", err)
+	}
+
 	return nil
 }
 
@@ -184,10 +195,6 @@ func checkTLSImplemented(ctx context.Context, conn net.Conn, details *ftp.Enumer
 	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		return fmt.Errorf("failed to set read deadline: %v", err)
 	}
-	err = conn.SetReadDeadline(time.Time{})
-	if err != nil {
-		return fmt.Errorf("failed to set read deadline: %v", err)
-	}
 
 	for {
 		n, err := conn.Read(response)
@@ -206,6 +213,11 @@ func checkTLSImplemented(ctx context.Context, conn net.Conn, details *ftp.Enumer
 		if strings.Contains(featResponse, "211 End") || n == 0 {
 			break
 		}
+	}
+
+	err = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		return fmt.Errorf("failed to clear read deadline: %v", err)
 	}
 
 	log.Debug("FEAT response received", svc1log.SafeParam("response", featResponse))
@@ -244,16 +256,17 @@ func checkTLSForced(ctx context.Context, conn net.Conn, details *ftp.EnumerateFt
 		errors = append(errors, fmt.Sprintf("failed to set read deadline: %v", err))
 		return errors
 	}
-	err = conn.SetReadDeadline(time.Time{})
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("failed to set read deadline: %v", err))
-		return errors
-	}
 
 	response := make([]byte, bufferSize)
 	n, err := conn.Read(response)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("error reading TLS response: %v", err))
+		return errors
+	}
+
+	err = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("failed to clear read deadline: %v", err))
 		return errors
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands UDP service discovery to accept CIDR/ranges, increasing scan scope and potential performance impact. FTP enumeration now uses stricter read deadlines and multi-line code parsing, which may change behavior against quirky FTP servers.
> 
> **Overview**
> Improves `discover service --udp` to accept broader target formats (IP/hostname/CIDR and other expansions via `utils.ParseTargetHosts`) and updates the CLI help text accordingly.
> 
> Hardens FTP enumeration networking by adding read deadlines/timeout errors for banner reads and TLS/anonymous-login probes, correctly handling multi-line FTP responses via `containsFTPCode`, and ensuring reconnect retries consume the new banner before re-attempting anonymous login.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c911dba9ab666768923ee14cbae528591d775af0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->