### PR TITLE
Fix TLS scan for legacy servers and remove --verify-tls flag

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -445,14 +445,8 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
 			// Generate the config
-			config := getDiscoverTLSConfig(targets, timeout, verifyTLS)
+			config := getDiscoverTLSConfig(targets, timeout)
 
 			// Generate the report
 			report, err := discover.GetTLSInfo(cmd.Context(), config)
@@ -465,8 +459,6 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	}
 	discoverTLSCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to analyze TLS configuration")
 	discoverTLSCmd.Flags().Int("timeout", 30, "Timeout in seconds for each TLS handshake attempt")
-	discoverTLSCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates (default: false)")
-
 	// Mark Required Flags
 	_ = discoverTLSCmd.MarkFlagRequired("targets")
 
@@ -601,12 +593,10 @@ func getDiscoverServiceConfig(target string, timeout int, serviceType string, ud
 }
 
 // getDiscoverTLSConfig creates a configuration for TLS scanning with the provided parameters.
-// It configures the targets, timeout, and TLS verification settings.
-func getDiscoverTLSConfig(targets []string, timeout int, verifyTLS bool) discoverfern.DiscoverTlsConfig {
+func getDiscoverTLSConfig(targets []string, timeout int) discoverfern.DiscoverTlsConfig {
 	config := discoverfern.DiscoverTlsConfig{
-		Targets:   targets,
-		Timeout:   timeout,
-		VerifyTls: verifyTLS,
+		Targets: targets,
+		Timeout: timeout,
 	}
 	return config
 }

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -166,7 +166,7 @@ Flags:
   -h, --help               help for tls
       --targets strings    List of target addresses (IP:port or hostname:port) to analyze TLS configuration
       --timeout int        Timeout in seconds for each TLS handshake attempt (default 30)
-      --verify-tls         Verify TLS certificates (default: false)
+
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")

--- a/fern/definition/discover/tls.yml
+++ b/fern/definition/discover/tls.yml
@@ -114,7 +114,6 @@ types:
     properties:
       targets: list<string>
       timeout: integer
-      verifyTls: boolean
   # Report Types
   DiscoverTlsReport:
     properties:

--- a/internal/discover/tls.go
+++ b/internal/discover/tls.go
@@ -119,10 +119,17 @@ func scanTLSConfiguration(ctx context.Context, targetAddress, serverName string,
 		Timeout: time.Duration(config.Timeout) * time.Second,
 	}
 
-	// First, establish a connection with default settings to get negotiated values and certificates
+	// Establish a connection with InsecureSkipVerify to always collect TLS data.
+	// We use MinVersion=TLS 1.0 so we can connect to legacy servers.
+	// Verification errors are reported separately without blocking the scan.
+	var negotiatedVersion discoverfern.TlsVersion
+	var negotiatedCipherSuite discoverfern.CipherSuite
+	var certificates []*discoverfern.Certificate
+
 	defaultConn, err := tls.DialWithDialer(dialer, "tcp", targetAddress, &tls.Config{
 		ServerName:         serverName,
-		InsecureSkipVerify: !config.VerifyTls,
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS10, //nolint:gosec
 	})
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("Failed to establish TLS connection: %v", err))
@@ -130,13 +137,13 @@ func scanTLSConfiguration(ctx context.Context, targetAddress, serverName string,
 	}
 
 	defaultState := defaultConn.ConnectionState()
-	negotiatedVersion := tlsVersionToString(defaultState.Version)
-	negotiatedCipherSuite := convertCipherSuiteToEnum(defaultState.CipherSuite)
+	negotiatedVersion = tlsVersionToString(defaultState.Version)
+	negotiatedCipherSuite = convertCipherSuiteToEnum(defaultState.CipherSuite)
+	certificates = extractCertificates(defaultState.PeerCertificates)
+	_ = defaultConn.Close()
+
 	compressionEnabled := probeCompression(targetAddress, serverName, dialer)
 	secureRenegotiation := probeSecureRenegotiation(targetAddress, serverName, dialer)
-	certificates := extractCertificates(defaultState.PeerCertificates)
-
-	_ = defaultConn.Close()
 
 	// Probe SSL versions using raw socket handshake (Go's crypto/tls doesn't support these)
 	ssl2Supported := probeSSLv2(targetAddress, dialer)
@@ -203,7 +210,7 @@ func probeTLSVersion(ctx context.Context, targetAddress, serverName string, vers
 	if version == tls.VersionTLS13 {
 		tlsConfig := &tls.Config{
 			ServerName:         serverName,
-			InsecureSkipVerify: !config.VerifyTls,
+			InsecureSkipVerify: true,
 			MinVersion:         version,
 			MaxVersion:         version,
 		}
@@ -223,7 +230,8 @@ func probeTLSVersion(ctx context.Context, targetAddress, serverName string, vers
 		return supportedCipherSuites
 	}
 
-	// For TLS 1.2 and below, probe each cipher suite
+	// For TLS 1.2 and below, probe each cipher suite.
+	// Always use InsecureSkipVerify here since we're probing for cipher support, not validating certs.
 	for _, cipherID := range allCipherSuites {
 		if seenCiphers[cipherID] {
 			continue
@@ -231,8 +239,8 @@ func probeTLSVersion(ctx context.Context, targetAddress, serverName string, vers
 
 		tlsConfig := &tls.Config{
 			ServerName:         serverName,
-			InsecureSkipVerify: !config.VerifyTls,
-			MinVersion:         version,
+			InsecureSkipVerify: true,
+			MinVersion:         version, //nolint:gosec
 			MaxVersion:         version,
 			CipherSuites:       []uint16{cipherID},
 		}


### PR DESCRIPTION
## Summary
- **Fixed TLS 1.0/1.1 scanning**: The initial TLS connection now uses `MinVersion=TLS 1.0` so hosts that only support legacy TLS versions (e.g. `tls-v1-0.badssl.com:1010`) can be scanned. Previously Go's default minimum of TLS 1.2 caused the entire scan to fail before version-specific probes were reached.
- **Removed `--verify-tls` flag**: Certificate validation doesn't belong in an enumeration tool. The full cert chain (with validity dates, issuer, SANs, etc.) is already in the output for consumers to evaluate. This removes unnecessary complexity and a redundant second TLS connection.
- **Always use `InsecureSkipVerify` during cipher probing**: Individual cipher suite probes are testing protocol support, not cert validity — verification was interfering with enumeration.

## Test plan
- [x] Verified `tls-v1-0.badssl.com:1010` now returns full TLS 1.0 scan data (was: error, no data)
- [x] Verified `tls-v1-1.badssl.com:1011` now returns full TLS 1.1 scan data (was: error, no data)
- [x] Verified `tls-v1-2.badssl.com:1012` still works correctly
- [x] Verified `--verify-tls` flag is removed from CLI help
- [x] Regression tested against `badssl.com:443`, `ecc256.badssl.com:443`, `self-signed.badssl.com:443`, `expired.badssl.com:443`, `rsa4096.badssl.com:443`, `1000-sans.badssl.com:443`
- [x] `./godelw verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TLS handshake parameters and removes a public config/CLI option, which can affect scan results and downstream consumers relying on the previous `verifyTls` field.
> 
> **Overview**
> TLS discovery now always performs its initial handshake with `MinVersion=TLS 1.0` and `InsecureSkipVerify=true`, so enumeration can proceed even on legacy or cert-invalid endpoints.
> 
> The `--verify-tls` CLI flag and `verifyTls` config field were removed (CLI, docs, and `fern` schema), and cipher-suite/version probing was updated to always skip verification to avoid cert-validation failures blocking capability detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 452318d08a42e240f43b9bf7a0dc5048a02349f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->