### PR TITLE
Add protocol metadata to CVE nuclei templates

### DIFF
--- a/utils/nuclei/templates/cve/2001/CVE-2001-1473.yaml
+++ b/utils/nuclei/templates/cve/2001/CVE-2001-1473.yaml
@@ -26,6 +26,7 @@ info:
     max-request: 1
     vendor: ssh
     product: ssh
+    protocol: SSH
   tags: network,cve2001,cve,ssh,openssh,tcp,vuln
 tcp:
   - host:

--- a/utils/nuclei/templates/cve/2004/CVE-2004-0437.yaml
+++ b/utils/nuclei/templates/cve/2004/CVE-2004-0437.yaml
@@ -24,6 +24,7 @@ info:
     max-request: 1
     vendor: south_river_technologies
     product: titan_ftp_server
+    protocol: FTP
     shodan-query: product:"Titan ftpd"
   tags: cve,cve2004,network,ftp,titan-ftp,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2004/CVE-2004-0656.yaml
+++ b/utils/nuclei/templates/cve/2004/CVE-2004-0656.yaml
@@ -25,6 +25,7 @@ info:
     max-request: 1
     vendor: pureftpd
     product: pureftpd
+    protocol: FTP
     shodan-query: product:"Pure-FTPd" version:"1.0.14"
   tags: cve,cve2004,network,ftp,pure-ftpd,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2004/CVE-2004-1602.yaml
+++ b/utils/nuclei/templates/cve/2004/CVE-2004-1602.yaml
@@ -26,6 +26,7 @@ info:
     max-request: 1
     vendor: proftpd
     product: proftpd
+    protocol: FTP
     shodan-query:
       - product:"proftpd"
       - cpe:"cpe:2.3:a:proftpd:proftpd"

--- a/utils/nuclei/templates/cve/2004/CVE-2004-1641.yaml
+++ b/utils/nuclei/templates/cve/2004/CVE-2004-1641.yaml
@@ -24,6 +24,7 @@ info:
     max-request: 1
     vendor: south_river_technologies
     product: titan_ftp_server
+    protocol: FTP
     shodan-query: product:"Titan ftpd"
   tags: cve,cve2004,network,ftp,titan-ftp,tcp,passive,heap-overflow,vuln
 tcp:

--- a/utils/nuclei/templates/cve/2004/CVE-2004-2687.yaml
+++ b/utils/nuclei/templates/cve/2004/CVE-2004-2687.yaml
@@ -27,6 +27,7 @@ info:
   metadata:
     verified: true
     max-request: 1
+    protocol: RPC
   tags: cve,cve2004,network,rce,distccd,vuln
 
 tcp:

--- a/utils/nuclei/templates/cve/2005/CVE-2005-0850.yaml
+++ b/utils/nuclei/templates/cve/2005/CVE-2005-0850.yaml
@@ -25,6 +25,7 @@ info:
     max-request: 1
     vendor: filezilla-project
     product: filezilla_server
+    protocol: FTP
     shodan-query: product:"FileZilla"
   tags: cve,cve2005,network,ftp,filezilla,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2005/CVE-2005-0851.yaml
+++ b/utils/nuclei/templates/cve/2005/CVE-2005-0851.yaml
@@ -25,6 +25,7 @@ info:
     max-request: 1
     vendor: filezilla-project
     product: filezilla_server
+    protocol: FTP
     shodan-query: product:"FileZilla"
   tags: cve,cve2005,network,ftp,filezilla,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2006/CVE-2006-2173.yaml
+++ b/utils/nuclei/templates/cve/2006/CVE-2006-2173.yaml
@@ -26,6 +26,7 @@ info:
     max-request: 1
     vendor: filezilla
     product: filezilla_server
+    protocol: FTP
     shodan-query: product:"FileZilla"
   tags: cve,cve2006,network,ftp,filezilla,tcp,passive,buffer-overflow,vuln
 

--- a/utils/nuclei/templates/cve/2006/CVE-2006-6565.yaml
+++ b/utils/nuclei/templates/cve/2006/CVE-2006-6565.yaml
@@ -27,6 +27,7 @@ info:
     max-request: 1
     vendor: filezilla-project
     product: filezilla_server
+    protocol: FTP
     shodan-query: product:"FileZilla"
   tags: cve,cve2006,network,ftp,filezilla,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2008/CVE-2008-0702.yaml
+++ b/utils/nuclei/templates/cve/2008/CVE-2008-0702.yaml
@@ -27,6 +27,7 @@ info:
     max-request: 1
     vendor: south_river_technologies
     product: titan_ftp_server
+    protocol: FTP
     shodan-query: product:"Titan ftpd" version:"16.00.2672"
   tags: cve,cve2008,network,ftp,titan-ftp,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2008/CVE-2008-5281.yaml
+++ b/utils/nuclei/templates/cve/2008/CVE-2008-5281.yaml
@@ -23,6 +23,7 @@ info:
     max-request: 1
     vendor: south_river_technologies
     product: titan_ftp_server
+    protocol: FTP
     shodan-query: product:"Titan FTP"
   tags: cve,cve2008,network,ftp,titan-ftp,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2009/CVE-2009-0884.yaml
+++ b/utils/nuclei/templates/cve/2009/CVE-2009-0884.yaml
@@ -27,6 +27,7 @@ info:
     max-request: 1
     vendor: filezilla-project
     product: filezilla_server
+    protocol: FTP
     shodan-query: product:"FileZilla"
   tags: cve,cve2009,network,ftp,filezilla,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2010/CVE-2010-3867.yaml
+++ b/utils/nuclei/templates/cve/2010/CVE-2010-3867.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 1
     vendor: proftpd
     product: proftpd
+    protocol: FTP
     shodan-query:
       - product:"proftpd"
       - cpe:"cpe:2.3:a:proftpd:proftpd"

--- a/utils/nuclei/templates/cve/2011/CVE-2011-0762.yaml
+++ b/utils/nuclei/templates/cve/2011/CVE-2011-0762.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 1
     vendor: vsftpd_project
     product: vsftpd
+    protocol: FTP
     shodan-query:
       - vsftpd
       - product:"vsftpd"

--- a/utils/nuclei/templates/cve/2011/CVE-2011-2523.yaml
+++ b/utils/nuclei/templates/cve/2011/CVE-2011-2523.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 2
     vendor: vsftpd_project
     product: vsftpd
+    protocol: FTP
     shodan-query: product:"vsftpd"
   tags: packetstorm,cve2011,network,cve,vsftpd,ftp,backdoor,vsftpd_project,tcp,vuln
 

--- a/utils/nuclei/templates/cve/2011/CVE-2011-3171.yaml
+++ b/utils/nuclei/templates/cve/2011/CVE-2011-3171.yaml
@@ -27,6 +27,7 @@ info:
     max-request: 1
     vendor: pureftpd
     product: pure-ftpd
+    protocol: FTP
     shodan-query:
       - product:"pure-ftpd" version:"1.0.14"
       - cpe:"cpe:2.3:a:pureftpd:pure-ftpd"

--- a/utils/nuclei/templates/cve/2014/CVE-2014-1841.yaml
+++ b/utils/nuclei/templates/cve/2014/CVE-2014-1841.yaml
@@ -25,6 +25,7 @@ info:
     max-request: 1
     vendor: southrivertech
     product: titan_ftp_server
+    protocol: FTP
     shodan-query: product:"Titan ftpd"
   tags: cve,cve2014,network,ftp,titan-ftp,tcp,passive,lfi,vuln
 

--- a/utils/nuclei/templates/cve/2014/CVE-2014-1842.yaml
+++ b/utils/nuclei/templates/cve/2014/CVE-2014-1842.yaml
@@ -23,6 +23,7 @@ info:
     max-request: 1
     vendor: southrivertech
     product: titan_ftp_server
+    protocol: FTP
     shodan-query: product:"Titan ftpd"
   tags: cve,cve2014,network,ftp,titan-ftp,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2014/CVE-2014-1843.yaml
+++ b/utils/nuclei/templates/cve/2014/CVE-2014-1843.yaml
@@ -23,6 +23,7 @@ info:
     max-request: 1
     vendor: southrivertech
     product: titan_ftp_server
+    protocol: FTP
     shodan-query: product:"Titan ftpd"
   tags: cve,cve2014,network,ftp,titan-ftp,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2015/CVE-2015-1419.yaml
+++ b/utils/nuclei/templates/cve/2015/CVE-2015-1419.yaml
@@ -22,6 +22,7 @@ info:
     max-request: 1
     vendor: opensuse
     product: opensuse
+    protocol: FTP
     shodan-query: "vsFTPd"
   tags: cve,cve2015,network,ftp,vsftpd,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2015/CVE-2015-3306.yaml
+++ b/utils/nuclei/templates/cve/2015/CVE-2015-3306.yaml
@@ -26,6 +26,7 @@ info:
     max-request: 1
     vendor: proftpd
     product: proftpd
+    protocol: FTP
     shodan-query: cpe:"cpe:2.3:a:proftpd:proftpd"
   tags: cve2015,cve,network,ftp,rce,proftpd,edb,tcp,vuln
 tcp:

--- a/utils/nuclei/templates/cve/2016/CVE-2016-2004.yaml
+++ b/utils/nuclei/templates/cve/2016/CVE-2016-2004.yaml
@@ -27,6 +27,7 @@ info:
     max-request: 2
     vendor: hp
     product: data_protector
+    protocol: RPC
   tags: packetstorm,cve,cve2016,network,iot,hp,rce,edb,tcp,vuln
 
 tcp:

--- a/utils/nuclei/templates/cve/2016/CVE-2016-3510.yaml
+++ b/utils/nuclei/templates/cve/2016/CVE-2016-3510.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 2
     vendor: oracle
     product: weblogic_server
+    protocol: RPC
     shodan-query:
       - product:"oracle weblogic"
       - http.title:"oracle peoplesoft sign-in"

--- a/utils/nuclei/templates/cve/2017/CVE-2017-3881.yaml
+++ b/utils/nuclei/templates/cve/2017/CVE-2017-3881.yaml
@@ -27,6 +27,7 @@ info:
     max-request: 2
     vendor: cisco
     product: ios
+    protocol: TELNET
     shodan-query:
       - product:"cisco ios http config"
       - cpe:"cpe:2.3:o:cisco:ios"

--- a/utils/nuclei/templates/cve/2017/CVE-2017-5645.yaml
+++ b/utils/nuclei/templates/cve/2017/CVE-2017-5645.yaml
@@ -28,6 +28,7 @@ info:
     max-request: 2
     vendor: apache
     product: log4j
+    protocol: RPC
   tags: cve,cve2017,network,vulhub,apache,log4j,rce,deserialization,oast,tcp,vuln
 
 variables:

--- a/utils/nuclei/templates/cve/2018/CVE-2018-2628.yaml
+++ b/utils/nuclei/templates/cve/2018/CVE-2018-2628.yaml
@@ -27,6 +27,7 @@ info:
     max-request: 1
     vendor: oracle
     product: weblogic_server
+    protocol: RPC
     shodan-query:
       - product:"oracle weblogic"
       - http.title:"oracle peoplesoft sign-in"

--- a/utils/nuclei/templates/cve/2018/CVE-2018-2893.yaml
+++ b/utils/nuclei/templates/cve/2018/CVE-2018-2893.yaml
@@ -26,6 +26,7 @@ info:
     max-request: 2
     vendor: oracle
     product: weblogic_server
+    protocol: RPC
     shodan-query:
       - product:"oracle weblogic"
       - http.title:"oracle peoplesoft sign-in"

--- a/utils/nuclei/templates/cve/2019/CVE-2019-18217.yaml
+++ b/utils/nuclei/templates/cve/2019/CVE-2019-18217.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 1
     vendor: proftpd
     product: proftpd
+    protocol: FTP
     shodan-query:
       - product:"proftpd"
       - cpe:"cpe:2.3:a:proftpd:proftpd"

--- a/utils/nuclei/templates/cve/2019/CVE-2019-20176.yaml
+++ b/utils/nuclei/templates/cve/2019/CVE-2019-20176.yaml
@@ -26,6 +26,7 @@ info:
     max-request: 1
     vendor: pureftpd
     product: pure-ftpd
+    protocol: FTP
     shodan-query:
       - product:"pure-ftpd" version:"1.0.45"
       - cpe:"cpe:2.3:a:pureftpd:pure-ftpd"

--- a/utils/nuclei/templates/cve/2019/CVE-2019-5544.yaml
+++ b/utils/nuclei/templates/cve/2019/CVE-2019-5544.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 1
     vendor: vmware
     product: horizon_daas
+    protocol: SLP
     shodan-query: http.title:"horizon daas"
     fofa-query: title="horizon daas"
     google-query: intitle:"horizon daas"

--- a/utils/nuclei/templates/cve/2020/CVE-2020-0796.yaml
+++ b/utils/nuclei/templates/cve/2020/CVE-2020-0796.yaml
@@ -27,6 +27,7 @@ info:
   metadata:
     vendor: microsoft
     product: windows_10_1903
+    protocol: SMB
     shodan-query: cpe:"cpe:2.3:o:microsoft:windows_10_1903"
     verified: true
   tags: cve,cve2020,microsoft,smb,kev,vkev,vuln

--- a/utils/nuclei/templates/cve/2020/CVE-2020-11981.yaml
+++ b/utils/nuclei/templates/cve/2020/CVE-2020-11981.yaml
@@ -28,6 +28,7 @@ info:
     max-request: 2
     vendor: apache
     product: airflow
+    protocol: REDIS
     shodan-query:
       - product:"redis"
       - http.title:"airflow - dags" || http.html:"apache airflow"

--- a/utils/nuclei/templates/cve/2020/CVE-2020-14644.yaml
+++ b/utils/nuclei/templates/cve/2020/CVE-2020-14644.yaml
@@ -26,6 +26,7 @@ info:
   metadata:
     vendor: oracle
     product: oracle_weblogic_server
+    protocol: RPC
     affected-versions:
       - "12.2.1.3.0"
       - "12.2.1.4.0"

--- a/utils/nuclei/templates/cve/2020/CVE-2020-1938.yaml
+++ b/utils/nuclei/templates/cve/2020/CVE-2020-1938.yaml
@@ -26,6 +26,7 @@ info:
     max-request: 4
     vendor: apache
     product: geode
+    protocol: RPC
     shodan-query:
       - title:"Apache Tomcat"
       - http.title:"apache tomcat"

--- a/utils/nuclei/templates/cve/2020/CVE-2020-35359.yaml
+++ b/utils/nuclei/templates/cve/2020/CVE-2020-35359.yaml
@@ -22,6 +22,7 @@ info:
     max-request: 1
     vendor: pureftpd
     product: pure-ftpd
+    protocol: FTP
     shodan-query:
       - product:"pure-ftpd"
       - cpe:"cpe:2.3:a:pureftpd:pure-ftpd"

--- a/utils/nuclei/templates/cve/2020/CVE-2020-9274.yaml
+++ b/utils/nuclei/templates/cve/2020/CVE-2020-9274.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 1
     vendor: pureftpd
     product: pure-ftpd
+    protocol: FTP
     shodan-query:
       - product:"pure-ftpd" version:"1.0.49"
       - cpe:"cpe:2.3:a:pureftpd:pure-ftpd"

--- a/utils/nuclei/templates/cve/2020/CVE-2020-9365.yaml
+++ b/utils/nuclei/templates/cve/2020/CVE-2020-9365.yaml
@@ -14,6 +14,7 @@ info:
     verified: true
     shodan-query: product:"Pure-FTPd" version:"1.0.24"
     max-request: 1
+    protocol: FTP
   tags: cve,cve2020,network,ftp,pure-ftpd,tcp,passive,vuln
 
 tcp:

--- a/utils/nuclei/templates/cve/2021/CVE-2021-27877.yaml
+++ b/utils/nuclei/templates/cve/2021/CVE-2021-27877.yaml
@@ -23,6 +23,7 @@ info:
     verified: true
     vendor: veritas
     product: backup_exec
+    protocol: RPC
     shodan-query: product:"Veritas Backup Exec"
   tags: cve,cve2021,network,js,tcp,passive,kev,vkev
 

--- a/utils/nuclei/templates/cve/2021/CVE-2021-30047.yaml
+++ b/utils/nuclei/templates/cve/2021/CVE-2021-30047.yaml
@@ -24,6 +24,7 @@ info:
     max-request: 1
     vendor: vsftpd_project
     product: vsftpd
+    protocol: FTP
     shodan-query:
       - vsftpd
       - product:"vsftpd"

--- a/utils/nuclei/templates/cve/2021/CVE-2021-3122.yaml
+++ b/utils/nuclei/templates/cve/2021/CVE-2021-3122.yaml
@@ -28,6 +28,7 @@ info:
     verified: true
     vendor: ncr
     product: command_center_agent
+    protocol: RPC
     fofa-query: "mynodename"
     shodan-query: "mynodename"
   tags: cve,cve2021,ncr,rce,vkev,intrusive,vuln

--- a/utils/nuclei/templates/cve/2021/CVE-2021-40524.yaml
+++ b/utils/nuclei/templates/cve/2021/CVE-2021-40524.yaml
@@ -23,6 +23,7 @@ info:
     max-request: 1
     vendor: pureftpd
     product: pure-ftpd
+    protocol: FTP
     shodan-query:
       - product:"pure-ftpd" version:"1.0.45"
       - cpe:"cpe:2.3:a:pureftpd:pure-ftpd"

--- a/utils/nuclei/templates/cve/2021/CVE-2021-44521.yaml
+++ b/utils/nuclei/templates/cve/2021/CVE-2021-44521.yaml
@@ -27,6 +27,7 @@ info:
     max-request: 2
     vendor: apache
     product: cassandra
+    protocol: RPC
     shodan-query: cpe:"cpe:2.3:a:apache:cassandra"
   tags: cve,cve2021,network,rce,apache,cassandra,tcp,vuln
 

--- a/utils/nuclei/templates/cve/2022/CVE-2022-0543.yaml
+++ b/utils/nuclei/templates/cve/2022/CVE-2022-0543.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 2
     vendor: redis
     product: redis
+    protocol: REDIS
     shodan-query:
       - redis_version
       - redis

--- a/utils/nuclei/templates/cve/2022/CVE-2022-24706.yaml
+++ b/utils/nuclei/templates/cve/2022/CVE-2022-24706.yaml
@@ -29,6 +29,7 @@ info:
     max-request: 2
     vendor: apache
     product: couchdb
+    protocol: RPC
     shodan-query:
       - product:"CouchDB"
       - product:"couchdb"

--- a/utils/nuclei/templates/cve/2022/CVE-2022-31793.yaml
+++ b/utils/nuclei/templates/cve/2022/CVE-2022-31793.yaml
@@ -28,6 +28,7 @@ info:
     max-request: 1
     vendor: inglorion
     product: muhttpd
+    protocol: HTTP
   tags: network,cve,cve2022,muhttpd,lfi,unauth,inglorion,tcp,vkev,vuln
 tcp:
   - host:

--- a/utils/nuclei/templates/cve/2023/CVE-2023-22629.yaml
+++ b/utils/nuclei/templates/cve/2023/CVE-2023-22629.yaml
@@ -26,6 +26,7 @@ info:
     max-request: 1
     vendor: southrivertech
     product: titan_ftp_server
+    protocol: FTP
     shodan-query: product:"Titan ftpd"
   tags: cve,cve2023,network,ftp,titan-ftp,tcp,passive,vuln
 

--- a/utils/nuclei/templates/cve/2023/CVE-2023-33246.yaml
+++ b/utils/nuclei/templates/cve/2023/CVE-2023-33246.yaml
@@ -28,6 +28,7 @@ info:
     max-request: 1
     vendor: apache
     product: rocketmq
+    protocol: RPC
     shodan-query:
       - title:"RocketMQ"
       - http.title:"rocketmq-console-ng"

--- a/utils/nuclei/templates/cve/2023/CVE-2023-37582.yaml
+++ b/utils/nuclei/templates/cve/2023/CVE-2023-37582.yaml
@@ -28,6 +28,7 @@ info:
     max-request: 1
     vendor: apache
     product: rocketmq
+    protocol: RPC
     shodan-query: rocketmq port:"9876"
   tags: cve,cve2023,apache,rocketmq,network,intrusive,vkev,vuln
 

--- a/utils/nuclei/templates/cve/2023/CVE-2023-48788.yaml
+++ b/utils/nuclei/templates/cve/2023/CVE-2023-48788.yaml
@@ -23,6 +23,7 @@ info:
     max-request: 1
     vendor: fortinet
     product: forticlient_enterprise_management_server
+    protocol: RPC
   tags: cve,cve2023,sqli,fortinet,kev,vkev,vuln
 
 tcp:

--- a/utils/nuclei/templates/cve/2023/CVE-2023-51713.yaml
+++ b/utils/nuclei/templates/cve/2023/CVE-2023-51713.yaml
@@ -25,6 +25,7 @@ info:
     max-request: 1
     vendor: proftpd
     product: proftpd
+    protocol: FTP
     shodan-query:
       - product:"proftpd"
       - cpe:"cpe:2.3:a:proftpd:proftpd"

--- a/utils/nuclei/templates/cve/2024/CVE-2024-23108.yaml
+++ b/utils/nuclei/templates/cve/2024/CVE-2024-23108.yaml
@@ -28,6 +28,7 @@ info:
     max-request: 1
     vendor: fortinet
     product: fortisiem
+    protocol: RPC
     shodan-query:
       - port:"7900"
       - http.favicon.hash:"-1341442175"

--- a/utils/nuclei/templates/cve/2024/CVE-2024-48208.yaml
+++ b/utils/nuclei/templates/cve/2024/CVE-2024-48208.yaml
@@ -24,6 +24,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: product:"Pure-FTPd"
+    protocol: FTP
   tags: cve,cve2024,network,ftp,pure-ftpd,tcp,passive,vuln
 
 tcp:

--- a/utils/nuclei/templates/cve/2024/CVE-2024-48651.yaml
+++ b/utils/nuclei/templates/cve/2024/CVE-2024-48651.yaml
@@ -24,6 +24,7 @@ info:
     verified: true
     max-request: 1
     shodan-query: product:"ProFTPD"
+    protocol: FTP
   tags: cve,cve2024,network,ftp,proftpd,tcp,passive,priv-esc,vuln
 
 tcp:

--- a/utils/nuclei/templates/cve/2025/CVE-2025-25256.yaml
+++ b/utils/nuclei/templates/cve/2025/CVE-2025-25256.yaml
@@ -21,6 +21,7 @@ info:
   metadata:
     vendor: fortinet
     product: fortisiem
+    protocol: RPC
     shodan-query:
       - http.favicon.hash:-1341442175
       - http.html:"var hst = location.hostname"

--- a/utils/nuclei/templates/cve/2025/CVE-2025-47188.yaml
+++ b/utils/nuclei/templates/cve/2025/CVE-2025-47188.yaml
@@ -20,6 +20,7 @@ info:
     vendor: mitel
     max-request: 2
     fofa-query: icon_hash="-1940372141" || icon_hash="-447557905"
+    protocol: HTTP
   tags: cve,cve2025,rce,network,mitel,oast,oob,vkev
 
 variables:

--- a/utils/nuclei/templates/cve/2025/CVE-2025-8286.yaml
+++ b/utils/nuclei/templates/cve/2025/CVE-2025-8286.yaml
@@ -24,6 +24,7 @@ info:
     verified: true
     vendor: guralp_systems
     product: fmus_series_seismic_monitoring_devices
+    protocol: TELNET
     shodan-query: '"Welcome to " "list of available commands" port:4244'
     fofa-query: '"Welcome to " && "list of available commands" && port="4244"'
   tags: cve,cve2025,tcp,network,telnet,guralp,ics,vuln


### PR DESCRIPTION
## Summary
- Adds `protocol` field to the `metadata` section of all 57 CVE nuclei templates
- Protocol values are drawn from the existing `ProtocolType` Fern enum in `common/common.yml`
- Enables the ontology processor to create properly typed `NetworkApplication` objects from scan results by reading `metadata.protocol` from the output

**Protocol distribution:**
| Protocol | Count | Services |
|----------|-------|----------|
| FTP | 31 | ProFTPD, Pure-FTPd, vsftpd, FileZilla, Titan FTP |
| RPC | 17 | WebLogic T3, AJP, Cassandra, CouchDB, RocketMQ, Log4j, distcc, FortiSIEM, etc. |
| TELNET | 2 | Cisco IOS, Güralp FMUS |
| REDIS | 2 | Redis |
| HTTP | 2 | muhttpd, Mitel |
| SSH | 1 | OpenSSH |
| SMB | 1 | Microsoft SMBv3 |
| SLP | 1 | VMware ESXi OpenSLP |

## Test plan
- [ ] Verify templates still pass nuclei validation
- [ ] Run `pentest scan cve` and confirm `metadata.protocol` appears in output JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive metadata changes across many YAML templates; main risk is template validation/consumers being sensitive to the new `protocol` key or incorrect protocol classification.
> 
> **Overview**
> Adds a new `metadata.protocol` field to a large set of CVE Nuclei templates under `utils/nuclei/templates/cve/**`, populating it with the expected network protocol (e.g., `FTP`, `RPC`, `SSH`, `SMB`, `TELNET`, `HTTP`, `REDIS`, `SLP`).
> 
> This is a metadata-only change intended to make scan outputs carry protocol context for downstream processing/typing, without altering request payloads, matchers, or exploitation logic in the templates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f5cf189387b316bdf9eb9dd96032731afba9384. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->