### PR TITLE
CVE Flag Fix + Clean Up

### DIFF
--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -51,11 +51,7 @@ func (a *NetworkScan) InitEnumerateCommand() {
 				return
 			}
 
-			config := enumeratefern.EnumerateServiceConfig{
-				Targets: targets,
-				Service: serviceEnum,
-				Timeout: timeout,
-			}
+			config := newEnumerateServiceConfig(targets, serviceEnum, timeout)
 
 			// Generate the report
 			report, err := enumerate.RunServiceEnumerate(cmd.Context(), config)
@@ -79,4 +75,13 @@ func (a *NetworkScan) InitEnumerateCommand() {
 
 	// Add Command to 'Root' Command
 	a.RootCmd.AddCommand(enumerateCmd)
+}
+
+// newEnumerateServiceConfig creates a new EnumerateServiceConfig with the provided parameters.
+func newEnumerateServiceConfig(targets []string, serviceEnum enumeratefern.SupportedServiceType, timeout int) enumeratefern.EnumerateServiceConfig {
+	return enumeratefern.EnumerateServiceConfig{
+		Targets: targets,
+		Service: serviceEnum,
+		Timeout: timeout,
+	}
 }

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -1344,6 +1344,9 @@ Scans network services for known CVE vulnerabilities. Templates can be filtered 
 				a.OutputSignal.AddError(err)
 				return
 			}
+			if len(years) == 0 {
+				a.OutputSignal.AddError(fmt.Errorf("no years specified"))
+			}
 
 			timeout, err := cmd.Flags().GetInt("timeout")
 			if err != nil {

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -1346,6 +1346,7 @@ Scans network services for known CVE vulnerabilities. Templates can be filtered 
 			}
 			if len(years) == 0 {
 				a.OutputSignal.AddError(fmt.Errorf("no years specified"))
+				return
 			}
 
 			timeout, err := cmd.Flags().GetInt("timeout")

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -1315,6 +1315,12 @@ func (a *NetworkScan) createScanCommand(parent *cobra.Command) {
 
 // createCVECommand creates the CVE subcommand
 func (a *NetworkScan) createCVECommand(parent *cobra.Command) {
+	defaultYears := []string{
+		"2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009",
+		"2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019",
+		"2020", "2021", "2022", "2023", "2024", "2025",
+	}
+
 	cveCmd := &cobra.Command{
 		Use:   "cve",
 		Short: "Perform CVE scanning using nuclei templates",
@@ -1357,7 +1363,7 @@ Scans network services for known CVE vulnerabilities. Templates can be filtered 
 				return
 			}
 
-			rateLimit, err := cmd.Flags().GetInt("rate-limit")
+			rateLimit, err := cmd.Flags().GetInt("global-rate-limit")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -1377,12 +1383,12 @@ Scans network services for known CVE vulnerabilities. Templates can be filtered 
 	cveCmd.Flags().StringSlice("targets", []string{}, "Target hosts (IP:port or hostname:port)")
 	_ = cveCmd.MarkFlagRequired("targets")
 	// Template filtering
-	cveCmd.Flags().StringSlice("years", []string{}, "Filter CVE templates by year (e.g., 2023,2024,2025). Leave empty for all years.")
+	cveCmd.Flags().StringSlice("years", defaultYears, "Filter CVE templates by year (e.g., 2023,2024,2025)")
 	// Scan configuration
 	cveCmd.Flags().Int("timeout", 30, "Timeout in seconds for each scan")
 	cveCmd.Flags().Int("threads", 25, "Number of concurrent threads")
 	cveCmd.Flags().Bool("verbose-logs", false, "Enable verbose logging")
-	cveCmd.Flags().Int("rate-limit", 0, "Global rate limit (requests per second, 0 = use nuclei default)")
+	cveCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, default is no limit)")
 
 	parent.AddCommand(cveCmd)
 }
@@ -2079,14 +2085,9 @@ func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAct
 
 // getScanCVEConfig creates a configuration for CVE scanning operations with the provided parameters.
 func getScanCVEConfig(targets []string, years []string, timeout int, threads int, verbose bool, rateLimit int) *pentestfern.PentestCveConfig {
-	var yearsPtr []string
-	if len(years) > 0 {
-		yearsPtr = years
-	}
-
 	return &pentestfern.PentestCveConfig{
 		Targets:         targets,
-		Years:           yearsPtr,
+		Years:           years,
 		Timeout:         timeout,
 		Threads:         threads,
 		VerboseLogs:     verbose,

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -1060,6 +1060,333 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	a.OutputSignal.Content = report
 }
 
+// runKerberosPentest executes Kerberos pentest operations
+func (a *NetworkScan) runKerberosPentest(cmd *cobra.Command, args []string) {
+	// Get targets from flag
+	targets, err := cmd.Flags().GetStringSlice("targets")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
+		return
+	}
+
+	// Get actions from flag
+	actions, err := cmd.Flags().GetStringSlice("actions")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Convert string actions to enum
+	var kerberosActions []kerberosfern.PentestKerberosAction
+	for _, actionStr := range actions {
+		switch strings.ToUpper(actionStr) {
+		case "SERVICE_TICKET":
+			kerberosActions = append(kerberosActions, kerberosfern.PentestKerberosActionServiceTicket)
+		default:
+			a.OutputSignal.AddError(fmt.Errorf("unsupported Kerberos action: %s", actionStr))
+			return
+		}
+	}
+
+	// Build configuration
+	config := a.buildKerberosConfig(cmd, targets, kerberosActions)
+	if config == nil {
+		return
+	}
+
+	// Create engine and execute
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunKerberosPentest(cmd.Context(), config)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Use the report directly since it already has the consolidated structure
+	a.OutputSignal.Content = report
+}
+
+// createMSRPCPentestCommand creates the MSRPC pentest subcommand
+func (a *NetworkScan) createMSRPCPentestCommand(parent *cobra.Command) {
+	msrpcCmd := &cobra.Command{
+		Use:   "msrpc",
+		Short: "Perform pentest operations against MS-RPC services",
+		Long:  `Perform pentest operations against MS-RPC services including DCSync attacks via DRSUAPI.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			a.runMSRPCPentest(cmd)
+		},
+	}
+
+	// Add basic flags
+	msrpcCmd.Flags().StringSlice("targets", []string{}, "Target hosts (required)")
+	msrpcCmd.Flags().StringSliceP("usernames", "u", []string{}, "Username for authentication")
+	msrpcCmd.Flags().StringSliceP("passwords", "p", []string{}, "Password for authentication")
+	msrpcCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
+	msrpcCmd.Flags().String("kerberos-ticket", "", "Base64-encoded Kerberos ticket (TGS) for ticket-based authentication")
+	msrpcCmd.Flags().String("domain", "", "Domain name (required for DCSync)")
+	msrpcCmd.Flags().StringSlice("actions", []string{}, "Actions to perform: DCSYNC (required)")
+	msrpcCmd.Flags().Int("timeout", 10, "Connection timeout in seconds")
+
+	// Mark required flags
+	_ = msrpcCmd.MarkFlagRequired("targets")
+	_ = msrpcCmd.MarkFlagRequired("actions")
+	_ = msrpcCmd.MarkFlagRequired("domain")
+
+	parent.AddCommand(msrpcCmd)
+}
+
+// runMSRPCPentest runs the MSRPC pentest operation
+func (a *NetworkScan) runMSRPCPentest(cmd *cobra.Command) {
+	config := a.getMSRPCPentestConfig(cmd)
+	if config == nil {
+		return
+	}
+
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunMSRPCPentest(cmd.Context(), config)
+
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	a.OutputSignal.Content = report
+}
+
+// runWinRMPentest executes WinRM pentest operations
+func (a *NetworkScan) runWinRMPentest(cmd *cobra.Command, args []string) {
+	// Get targets from flag
+	targets, err := cmd.Flags().GetStringSlice("targets")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	if len(targets) == 0 {
+		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
+		return
+	}
+
+	// Parse WinRM actions
+	actionStrings, err := cmd.Flags().GetStringSlice("actions")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	actions, err := utils.GetWinRMParser().ParseActions(actionStrings)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Parse authentication options
+	usernames, err := cmd.Flags().GetStringSlice("usernames")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	passwords, err := cmd.Flags().GetStringSlice("passwords")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	usernameFile, err := cmd.Flags().GetString("username-file")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	passwordFile, err := cmd.Flags().GetString("password-file")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	domain, err := cmd.Flags().GetString("domain")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Parse command execution options
+	commands, err := cmd.Flags().GetStringSlice("execute")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	commandFile, err := cmd.Flags().GetString("command-file")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Parse connection options
+	port, err := cmd.Flags().GetInt("port")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	useHTTPS, err := cmd.Flags().GetBool("https")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	insecure, err := cmd.Flags().GetBool("insecure")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Parse behavior options
+	timeout, err := cmd.Flags().GetInt("timeout")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	stopFirstSuccess, err := cmd.Flags().GetBool("stop-on-first-success")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	successfulOnly, err := cmd.Flags().GetBool("successful-only")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Load credentials from files if specified
+	if usernameFile != "" {
+		fileUsernames, err := utils.GetEntriesFromTXTFiles([]string{usernameFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		usernames = append(usernames, fileUsernames...)
+	}
+
+	if passwordFile != "" {
+		filePasswords, err := utils.GetEntriesFromTXTFiles([]string{passwordFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		passwords = append(passwords, filePasswords...)
+	}
+
+	// Load commands from file if specified
+	if commandFile != "" {
+		fileCommands, err := utils.GetEntriesFromTXTFiles([]string{commandFile})
+		if err != nil {
+			a.OutputSignal.AddError(err)
+			return
+		}
+		commands = append(commands, fileCommands...)
+	}
+
+	// Set Config
+	config := getWinRMPentestConfig(targets, actions, usernames, passwords, commands, domain, port, useHTTPS, insecure, timeout, stopFirstSuccess, successfulOnly)
+
+	// Create engine and run pentest
+	engine := pentest_internal.NewEngine()
+	report, err := engine.RunWinRMPentest(cmd.Context(), config)
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+
+	// Use the report directly since it already has the consolidated structure
+	a.OutputSignal.Content = report
+}
+
+// createScanCommand creates the scan command and its subcommands
+func (a *NetworkScan) createScanCommand(parent *cobra.Command) {
+	scanCmd := &cobra.Command{
+		Use:   "scan",
+		Short: "Perform vulnerability scanning operations against network targets.",
+		Long:  `Perform vulnerability scanning operations against network targets using various scanning engines and templates.`,
+	}
+
+	// Create scan subcommands
+	a.createCVECommand(scanCmd)
+
+	parent.AddCommand(scanCmd)
+}
+
+// createCVECommand creates the CVE subcommand
+func (a *NetworkScan) createCVECommand(parent *cobra.Command) {
+	cveCmd := &cobra.Command{
+		Use:   "cve",
+		Short: "Perform CVE scanning using nuclei templates",
+		Long: `Perform CVE scanning against network targets using nuclei templates.
+
+Scans network services for known CVE vulnerabilities. Templates can be filtered by year.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Extract flags
+			targets, err := cmd.Flags().GetStringSlice("targets")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if len(targets) == 0 {
+				a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
+				return
+			}
+
+			years, err := cmd.Flags().GetStringSlice("years")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			threads, err := cmd.Flags().GetInt("threads")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			verbose, err := cmd.Flags().GetBool("verbose-logs")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			rateLimit, err := cmd.Flags().GetInt("rate-limit")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Set Config
+			config := getScanCVEConfig(targets, years, timeout, threads, verbose, rateLimit)
+
+			// Perform CVE scan and get complete report
+			report := pentest_internal.PerformCVEScan(cmd.Context(), config)
+
+			a.OutputSignal.Content = report
+		},
+	}
+
+	// Target configuration
+	cveCmd.Flags().StringSlice("targets", []string{}, "Target hosts (IP:port or hostname:port)")
+	_ = cveCmd.MarkFlagRequired("targets")
+	// Template filtering
+	cveCmd.Flags().StringSlice("years", []string{}, "Filter CVE templates by year (e.g., 2023,2024,2025). Leave empty for all years.")
+	// Scan configuration
+	cveCmd.Flags().Int("timeout", 30, "Timeout in seconds for each scan")
+	cveCmd.Flags().Int("threads", 25, "Number of concurrent threads")
+	cveCmd.Flags().Bool("verbose-logs", false, "Enable verbose logging")
+	cveCmd.Flags().Int("rate-limit", 0, "Global rate limit (requests per second, 0 = use nuclei default)")
+
+	parent.AddCommand(cveCmd)
+}
+
 // ============================================================================
 // CONFIG HELPER FUNCTIONS
 // ============================================================================
@@ -1529,56 +1856,6 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 	}
 }
 
-// runKerberosPentest executes Kerberos pentest operations
-func (a *NetworkScan) runKerberosPentest(cmd *cobra.Command, args []string) {
-	// Get targets from flag
-	targets, err := cmd.Flags().GetStringSlice("targets")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	if len(targets) == 0 {
-		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
-		return
-	}
-
-	// Get actions from flag
-	actions, err := cmd.Flags().GetStringSlice("actions")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	// Convert string actions to enum
-	var kerberosActions []kerberosfern.PentestKerberosAction
-	for _, actionStr := range actions {
-		switch strings.ToUpper(actionStr) {
-		case "SERVICE_TICKET":
-			kerberosActions = append(kerberosActions, kerberosfern.PentestKerberosActionServiceTicket)
-		default:
-			a.OutputSignal.AddError(fmt.Errorf("unsupported Kerberos action: %s", actionStr))
-			return
-		}
-	}
-
-	// Build configuration
-	config := a.buildKerberosConfig(cmd, targets, kerberosActions)
-	if config == nil {
-		return
-	}
-
-	// Create engine and execute
-	engine := pentest_internal.NewEngine()
-	report, err := engine.RunKerberosPentest(cmd.Context(), config)
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	// Use the report directly since it already has the consolidated structure
-	a.OutputSignal.Content = report
-}
-
 // buildKerberosConfig builds the Kerberos configuration from CLI flags
 func (a *NetworkScan) buildKerberosConfig(cmd *cobra.Command, targets []string, actions []kerberosfern.PentestKerberosAction) *kerberosfern.PentestKerberosConfig {
 	// Get authentication flags
@@ -1658,53 +1935,6 @@ func (a *NetworkScan) buildKerberosConfig(cmd *cobra.Command, targets []string, 
 		Timeout:             timeout,
 		ServiceTicketConfig: serviceTicketConfig,
 	}
-}
-
-// createMSRPCPentestCommand creates the MSRPC pentest subcommand
-func (a *NetworkScan) createMSRPCPentestCommand(parent *cobra.Command) {
-	msrpcCmd := &cobra.Command{
-		Use:   "msrpc",
-		Short: "Perform pentest operations against MS-RPC services",
-		Long:  `Perform pentest operations against MS-RPC services including DCSync attacks via DRSUAPI.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			a.runMSRPCPentest(cmd)
-		},
-	}
-
-	// Add basic flags
-	msrpcCmd.Flags().StringSlice("targets", []string{}, "Target hosts (required)")
-	msrpcCmd.Flags().StringSliceP("usernames", "u", []string{}, "Username for authentication")
-	msrpcCmd.Flags().StringSliceP("passwords", "p", []string{}, "Password for authentication")
-	msrpcCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
-	msrpcCmd.Flags().String("kerberos-ticket", "", "Base64-encoded Kerberos ticket (TGS) for ticket-based authentication")
-	msrpcCmd.Flags().String("domain", "", "Domain name (required for DCSync)")
-	msrpcCmd.Flags().StringSlice("actions", []string{}, "Actions to perform: DCSYNC (required)")
-	msrpcCmd.Flags().Int("timeout", 10, "Connection timeout in seconds")
-
-	// Mark required flags
-	_ = msrpcCmd.MarkFlagRequired("targets")
-	_ = msrpcCmd.MarkFlagRequired("actions")
-	_ = msrpcCmd.MarkFlagRequired("domain")
-
-	parent.AddCommand(msrpcCmd)
-}
-
-// runMSRPCPentest runs the MSRPC pentest operation
-func (a *NetworkScan) runMSRPCPentest(cmd *cobra.Command) {
-	config := a.getMSRPCPentestConfig(cmd)
-	if config == nil {
-		return
-	}
-
-	engine := pentest_internal.NewEngine()
-	report, err := engine.RunMSRPCPentest(cmd.Context(), config)
-
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	a.OutputSignal.Content = report
 }
 
 // getMSRPCPentestConfig extracts MSRPC pentest configuration from command flags
@@ -1811,148 +2041,6 @@ func (a *NetworkScan) getDCSyncConfig(cmd *cobra.Command, targets, usernames, pa
 	}
 }
 
-// runWinRMPentest executes WinRM pentest operations
-func (a *NetworkScan) runWinRMPentest(cmd *cobra.Command, args []string) {
-	// Get targets from flag
-	targets, err := cmd.Flags().GetStringSlice("targets")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	if len(targets) == 0 {
-		a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
-		return
-	}
-
-	// Parse WinRM actions
-	actionStrings, err := cmd.Flags().GetStringSlice("actions")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	actions, err := utils.GetWinRMParser().ParseActions(actionStrings)
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	// Parse authentication options
-	usernames, err := cmd.Flags().GetStringSlice("usernames")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	passwords, err := cmd.Flags().GetStringSlice("passwords")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	usernameFile, err := cmd.Flags().GetString("username-file")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	passwordFile, err := cmd.Flags().GetString("password-file")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	domain, err := cmd.Flags().GetString("domain")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	// Parse command execution options
-	commands, err := cmd.Flags().GetStringSlice("execute")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	commandFile, err := cmd.Flags().GetString("command-file")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	// Parse connection options
-	port, err := cmd.Flags().GetInt("port")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	useHTTPS, err := cmd.Flags().GetBool("https")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	insecure, err := cmd.Flags().GetBool("insecure")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	// Parse behavior options
-	timeout, err := cmd.Flags().GetInt("timeout")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	stopFirstSuccess, err := cmd.Flags().GetBool("stop-on-first-success")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-	successfulOnly, err := cmd.Flags().GetBool("successful-only")
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	// Load credentials from files if specified
-	if usernameFile != "" {
-		fileUsernames, err := utils.GetEntriesFromTXTFiles([]string{usernameFile})
-		if err != nil {
-			a.OutputSignal.AddError(err)
-			return
-		}
-		usernames = append(usernames, fileUsernames...)
-	}
-
-	if passwordFile != "" {
-		filePasswords, err := utils.GetEntriesFromTXTFiles([]string{passwordFile})
-		if err != nil {
-			a.OutputSignal.AddError(err)
-			return
-		}
-		passwords = append(passwords, filePasswords...)
-	}
-
-	// Load commands from file if specified
-	if commandFile != "" {
-		fileCommands, err := utils.GetEntriesFromTXTFiles([]string{commandFile})
-		if err != nil {
-			a.OutputSignal.AddError(err)
-			return
-		}
-		commands = append(commands, fileCommands...)
-	}
-
-	// Set Config
-	config := getWinRMPentestConfig(targets, actions, usernames, passwords, commands, domain, port, useHTTPS, insecure, timeout, stopFirstSuccess, successfulOnly)
-
-	// Create engine and run pentest
-	engine := pentest_internal.NewEngine()
-	report, err := engine.RunWinRMPentest(cmd.Context(), config)
-	if err != nil {
-		a.OutputSignal.AddError(err)
-		return
-	}
-
-	// Use the report directly since it already has the consolidated structure
-	a.OutputSignal.Content = report
-}
-
 // getWinRMPentestConfig creates a configuration for WinRM pentest operations with the provided parameters
 func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAction, usernames []string, passwords []string, commands []string, domain string, port int, useHTTPS bool, insecure bool, timeout int, stopFirstSuccess bool, successfulOnly bool) *winrmfern.PentestWinrmConfig {
 	var domainPtr *string
@@ -2004,94 +2092,4 @@ func getScanCVEConfig(targets []string, years []string, timeout int, threads int
 		VerboseLogs:     verbose,
 		GlobalRateLimit: rateLimit,
 	}
-}
-
-// createScanCommand creates the scan command and its subcommands
-func (a *NetworkScan) createScanCommand(parent *cobra.Command) {
-	scanCmd := &cobra.Command{
-		Use:   "scan",
-		Short: "Perform vulnerability scanning operations against network targets.",
-		Long:  `Perform vulnerability scanning operations against network targets using various scanning engines and templates.`,
-	}
-
-	// Create scan subcommands
-	a.createCVECommand(scanCmd)
-
-	parent.AddCommand(scanCmd)
-}
-
-// createCVECommand creates the CVE subcommand
-func (a *NetworkScan) createCVECommand(parent *cobra.Command) {
-	cveCmd := &cobra.Command{
-		Use:   "cve",
-		Short: "Perform CVE scanning using nuclei templates",
-		Long: `Perform CVE scanning against network targets using nuclei templates.
-
-Scans network services for known CVE vulnerabilities. Templates can be filtered by year.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// Extract flags
-			targets, err := cmd.Flags().GetStringSlice("targets")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			if len(targets) == 0 {
-				a.OutputSignal.AddError(fmt.Errorf("no targets specified"))
-				return
-			}
-
-			years, err := cmd.Flags().GetStringSlice("years")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			timeout, err := cmd.Flags().GetInt("timeout")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			threads, err := cmd.Flags().GetInt("threads")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			verbose, err := cmd.Flags().GetBool("verbose")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			rateLimit, err := cmd.Flags().GetInt("rate-limit")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			// Set Config
-			config := getScanCVEConfig(targets, years, timeout, threads, verbose, rateLimit)
-
-			// Perform CVE scan and get complete report
-			report := pentest_internal.PerformCVEScan(cmd.Context(), config)
-
-			a.OutputSignal.Content = report
-		},
-	}
-
-	// Target configuration
-	cveCmd.Flags().StringSlice("targets", []string{}, "Target hosts (IP:port or hostname:port)")
-	_ = cveCmd.MarkFlagRequired("targets")
-
-	// Template filtering
-	cveCmd.Flags().StringSlice("years", []string{}, "Filter CVE templates by year (e.g., 2023,2024,2025). Leave empty for all years.")
-
-	// Scan configuration
-	cveCmd.Flags().Int("timeout", 30, "Timeout in seconds for each scan")
-	cveCmd.Flags().Int("threads", 25, "Number of concurrent threads")
-	cveCmd.Flags().Bool("verbose", false, "Enable verbose logging")
-	cveCmd.Flags().Int("rate-limit", 0, "Global rate limit (requests per second, 0 = use nuclei default)")
-
-	parent.AddCommand(cveCmd)
 }

--- a/fern/definition/pentest/cve.yml
+++ b/fern/definition/pentest/cve.yml
@@ -1,22 +1,19 @@
 imports:
   nuclei: ../common/nuclei/report.yml
-
 types:
   # Config Struct
   PentestCveConfig:
     properties:
       targets: list<string> # Network targets (IP:port or hostname:port)
-      years: optional<list<string>> # Filter templates by year (e.g., ["2023", "2024", "2025"])
+      years: list<string> # Filter templates by year (e.g., ["2023", "2024", "2025"])
       timeout: integer
       threads: integer
       verboseLogs: boolean
       globalRateLimit: integer
-
   # Result Struct
   PentestCveResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>> # List of scan results per target
-
   # Report Struct
   PentestCveReport:
     properties:

--- a/internal/pentest/cve.go
+++ b/internal/pentest/cve.go
@@ -63,11 +63,6 @@ func PerformCVEScan(ctx context.Context, config *pentestfern.PentestCveConfig) *
 
 // buildTemplatePaths constructs template paths based on year filtering
 func buildTemplatePaths(years []string) ([]string, error) {
-	if len(years) == 0 {
-		// No filter - return all years
-		return []string{"cve"}, nil
-	}
-
 	var paths []string
 	for _, year := range years {
 		// Validate year format


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CLI flag names/defaults and makes `years` required in the CVE scan config, which can break existing scripts and alters template selection behavior.
> 
> **Overview**
> Updates CVE scanning to treat `years` as a required, non-optional config field: the Fern schema and `getScanCVEConfig` now always pass a concrete year list, `buildTemplatePaths` no longer supports an empty-years “scan all” mode, and the `pentest scan cve` command defaults `--years` to a populated year range and errors if it is empty.
> 
> Also renames CVE scan CLI flags to `--verbose-logs` and `--global-rate-limit` (replacing `--verbose`/`--rate-limit`) and does minor CLI cleanup/refactoring (e.g., extracting `newEnumerateServiceConfig` and reorganizing some pentest helpers without changing their behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91ffd32fcd6db61dd9e0fd576c58fd26d9fea236. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->