### PR TITLE
Fix the CVE Fern Bug

### DIFF
--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -78,9 +78,9 @@ func addOrMergeCWE(cwes *[]*nuclei.CweDetails, cweID string) {
 
 // addOrMergeCVE adds a CVE to the slice if it doesn't exist by ID, or merges additional fields if it does
 func addOrMergeCVE(cves *[]*nuclei.CveDetails, cveID string, cvssMetrics *string, cvssScore *float64, epssScore *float64, epssPercentile *float64, cpe *string) {
-	// Check if CVE with this ID already exists
+	// Check if CVE with this ID already exists (case-insensitive)
 	for _, existing := range *cves {
-		if existing.Id == cveID {
+		if strings.EqualFold(existing.Id, cveID) {
 			// Merge additional fields if they're not already set
 			if existing.CvssMetrics == nil && cvssMetrics != nil {
 				existing.CvssMetrics = cvssMetrics
@@ -123,10 +123,7 @@ func (b *Builder) PopulateProbes(eng *nucleilib.NucleiEngine) error {
 		if _, ok := b.probeIdx[id]; ok {
 			continue
 		}
-		probe := &nuclei.NucleiProbe{
-			Payloads:       []string{},
-			MatcherDetails: &nuclei.NucleiMatcherDetails{},
-		}
+		probe := &nuclei.NucleiProbe{}
 
 		// Check if RequestsHTTP is available, otherwise use RequestsHeadless
 		if len(template.RequestsHTTP) > 0 {
@@ -287,9 +284,11 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 			addOrMergeCVE(&cves, cveID, cvssMetrics, cvssScore, epssScore, epssPercentile, cpe)
 		}
 	}
-	classificationDetails = &nuclei.ClassificationDetails{
-		Cwes: cwes,
-		Cves: cves,
+	if len(cwes) > 0 || len(cves) > 0 {
+		classificationDetails = &nuclei.ClassificationDetails{
+			Cwes: cwes,
+			Cves: cves,
+		}
 	}
 	severity := ev.Info.SeverityHolder.Severity.String()
 
@@ -327,6 +326,11 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 		}
 	}
 
+	var probeForFinding *nuclei.NucleiProbe
+	if probe != nil && (len(probe.Payloads) > 0 || probe.MatcherDetails != nil) {
+		probeForFinding = probe
+	}
+
 	attemptInfo.Finding = &nuclei.NucleiFindingInfo{
 		Name:           name,
 		Description:    description,
@@ -336,7 +340,7 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 		Classification: classificationDetails,
 		Severity:       &severity,
 		Finding:        ev.MatcherStatus,
-		Probe:          probe,
+		Probe:          probeForFinding,
 		Metadata:       metadata,
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the generated report shape by omitting empty `Classification`/`Probe` objects and deduping CVEs case-insensitively, which could affect downstream consumers expecting previous null/empty behaviors.
> 
> **Overview**
> Fixes CVE aggregation in `utils/nuclei/report/report.go` by merging/deduping CVE entries case-insensitively so template IDs and classification CVEs don’t produce duplicates.
> 
> Adjusts report output to avoid emitting empty objects: `Classification` is only set when CWEs/CVEs exist, probes are no longer pre-populated with empty fields during template load, and `Finding.Probe` is only attached when it contains payloads and/or matcher details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b871b2089161d2c44217533ecc99cba7ee115eeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->