### PR TITLE
Add --local-auth flag and fix OS version mapping

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -79,6 +79,7 @@ func (a *NetworkScan) createPasswordSprayCommand(parent *cobra.Command) {
 	passwordCmd.Flags().StringSlice("username-lists", []string{}, "Built-in username lists (SYSTEM_USERNAMES, DOMAIN_USERNAMES, SERVICE_USERNAMES)")
 	passwordCmd.Flags().StringSlice("password-lists", []string{}, "Built-in password lists (SYSTEM_PASSWORDS, DOMAIN_PASSWORDS, SERVICE_PASSWORDS)")
 	passwordCmd.Flags().StringP("domain", "d", "", "Domain for SMB/LDAP/KERBEROS authentication")
+	passwordCmd.Flags().Bool("local-auth", false, "Force authentication against local account instead of domain")
 	passwordCmd.Flags().StringSlice("ntlm-hashes", nil, "NTLM hashes for pass-the-hash authentication (32 hex chars each)")
 	passwordCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds")
 	passwordCmd.Flags().Int("sleep", 0, "Delay between password attempts in seconds")
@@ -264,6 +265,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	smbCmd.Flags().String("credentials", "", "Credentials in user:pass format")
 	smbCmd.Flags().StringP("domain", "d", "", "Domain for authentication")
 	smbCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
+	smbCmd.Flags().Bool("local-auth", false, "Force authentication against local account instead of domain")
 
 	// Command execution flags
 	smbCmd.Flags().StringSliceP("execute", "x", []string{}, "Commands to execute on successful auth")
@@ -392,6 +394,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	ldapCmd.Flags().String("credentials", "", "Credentials in user:pass format")
 	ldapCmd.Flags().StringP("domain", "d", "", "Domain for authentication")
 	ldapCmd.Flags().String("ntlm-hash", "", "NTLM hash for pass-the-hash authentication")
+	ldapCmd.Flags().Bool("local-auth", false, "Force authentication against local account instead of domain")
 
 	// Behavior flags
 	ldapCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
@@ -469,6 +472,7 @@ Supports authentication testing and command execution via WinRM protocol.`,
 	winrmCmd.Flags().String("username-file", "", "File containing usernames (one per line)")
 	winrmCmd.Flags().String("password-file", "", "File containing passwords (one per line)")
 	winrmCmd.Flags().StringP("domain", "d", "", "Domain for authentication")
+	winrmCmd.Flags().Bool("local-auth", false, "Force authentication against local account instead of domain")
 
 	// Command execution flags
 	winrmCmd.Flags().StringSliceP("execute", "x", []string{}, "Commands to execute on successful auth")
@@ -544,6 +548,11 @@ func (a *NetworkScan) runSMBPentest(cmd *cobra.Command, args []string) {
 		return
 	}
 	ntlmHash, err := cmd.Flags().GetString("ntlm-hash")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	localAuth, err := cmd.Flags().GetBool("local-auth")
 	if err != nil {
 		a.OutputSignal.AddError(err)
 		return
@@ -624,7 +633,7 @@ func (a *NetworkScan) runSMBPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, remoteFilePath, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash)
+	config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, remoteFilePath, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, localAuth)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -965,6 +974,11 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 		a.OutputSignal.AddError(err)
 		return
 	}
+	localAuth, err := cmd.Flags().GetBool("local-auth")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
 
 	// Parse behavior options
 	timeout, err := cmd.Flags().GetInt("timeout")
@@ -1046,7 +1060,7 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, sleep, jitter, maxQueries, minimalQueries)
+	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, localAuth, sleep, jitter, maxQueries, minimalQueries)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -1208,6 +1222,11 @@ func (a *NetworkScan) runWinRMPentest(cmd *cobra.Command, args []string) {
 		a.OutputSignal.AddError(err)
 		return
 	}
+	localAuth, err := cmd.Flags().GetBool("local-auth")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
 
 	// Parse command execution options
 	commands, err := cmd.Flags().GetStringSlice("execute")
@@ -1285,7 +1304,7 @@ func (a *NetworkScan) runWinRMPentest(cmd *cobra.Command, args []string) {
 	}
 
 	// Set Config
-	config := getWinRMPentestConfig(targets, actions, usernames, passwords, commands, domain, port, useHTTPS, insecure, timeout, stopFirstSuccess, successfulOnly)
+	config := getWinRMPentestConfig(targets, actions, usernames, passwords, commands, domain, localAuth, port, useHTTPS, insecure, timeout, stopFirstSuccess, successfulOnly)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -1472,6 +1491,11 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 		return nil, fmt.Errorf("failed to get ntlm-hashes: %v", err)
 	}
 
+	localAuth, err := cmd.Flags().GetBool("local-auth")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local-auth: %v", err)
+	}
+
 	// Validate NTLM hashes are not used with Kerberos
 	if len(ntlmHashes) > 0 && service == pentestfern.SprayTargetServiceKerberos {
 		return nil, fmt.Errorf("NTLM hashes cannot be used with Kerberos authentication")
@@ -1524,7 +1548,7 @@ func (a *NetworkScan) createSprayPasswordConfig(cmd *cobra.Command, targets []st
 	}
 
 	// Set Config
-	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, ntlmHashes, timeout, sleep, jitter, maxAttempts, stopFirstSuccess, successfulOnly)
+	config := getSprayPasswordConfig(targets, service, usernames, passwords, usernameFile, passwordFile, usernameListEnums, passwordListEnums, domain, ntlmHashes, localAuth, timeout, sleep, jitter, maxAttempts, stopFirstSuccess, successfulOnly)
 
 	return config, nil
 }
@@ -1623,7 +1647,7 @@ func (a *NetworkScan) createSprayUsernameConfig(cmd *cobra.Command, targets []st
 }
 
 // getSprayPasswordConfig creates a configuration for password spray operations with the provided parameters.
-func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentestfern.WordlistType, passwordLists []pentestfern.WordlistType, domain string, ntlmHashes []string, timeout int, sleep int, jitter int, maxAttempts int, stopFirstSuccess bool, successfulOnly bool) *pentestfern.PentestSprayConfig {
+func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetService, usernames []string, passwords []string, usernameFile string, passwordFile string, usernameLists []pentestfern.WordlistType, passwordLists []pentestfern.WordlistType, domain string, ntlmHashes []string, localAuth bool, timeout int, sleep int, jitter int, maxAttempts int, stopFirstSuccess bool, successfulOnly bool) *pentestfern.PentestSprayConfig {
 	// Create config
 	var usernameFilePtr, passwordFilePtr, domainPtr *string
 	if usernameFile != "" {
@@ -1658,6 +1682,11 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 		}
 	}
 
+	var localAuthPtr *bool
+	if localAuth {
+		localAuthPtr = &localAuth
+	}
+
 	return &pentestfern.PentestSprayConfig{
 		SprayMode: strings.ToLower(string(pentestfern.SprayModePassword)),
 		Password: &pentestfern.SprayPasswordConfig{
@@ -1671,6 +1700,7 @@ func getSprayPasswordConfig(targets []string, service pentestfern.SprayTargetSer
 			UsernameLists:      usernameLists,
 			PasswordLists:      passwordLists,
 			Domain:             domainPtr,
+			LocalAuth:          localAuthPtr,
 			Timeout:            timeout,
 			StopOnFirstSuccess: stopFirstSuccess,
 			SuccessfulOnly:     successfulOnly,
@@ -1720,13 +1750,17 @@ func getSprayUsernameConfig(targets []string, service pentestfern.SprayTargetSer
 }
 
 // getSMBPentestConfig creates a configuration for SMB pentest operations with the provided parameters.
-func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, remoteFilePath string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string) *smbfern.PentestSmbConfig {
+func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, remoteFilePath string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool) *smbfern.PentestSmbConfig {
 	var domainPtr, ntlmHashPtr *string
+	var localAuthPtr *bool
 	if domain != "" {
 		domainPtr = &domain
 	}
 	if ntlmHash != "" {
 		ntlmHashPtr = &ntlmHash
+	}
+	if localAuth {
+		localAuthPtr = &localAuth
 	}
 
 	// Create exec config if commands are provided
@@ -1752,6 +1786,7 @@ func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, u
 		Passwords:           passwords,
 		Domain:              domainPtr,
 		NtlmHash:            ntlmHashPtr,
+		LocalAuth:           localAuthPtr,
 		ExecConfig:          execConfig,
 		ShareDownloadConfig: shareDownloadConfig,
 		Timeout:             timeout,
@@ -1802,13 +1837,17 @@ func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnet
 }
 
 // getLDAPPentestConfig creates a configuration for LDAP pentest operations with the provided parameters.
-func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, sleep int, jitter int, maxQueries int, minimalQueries bool) *ldapfern.PentestLdapConfig {
+func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, sleep int, jitter int, maxQueries int, minimalQueries bool) *ldapfern.PentestLdapConfig {
 	var domainPtr, ntlmHashPtr *string
+	var localAuthPtr *bool
 	if domain != "" {
 		domainPtr = &domain
 	}
 	if ntlmHash != "" {
 		ntlmHashPtr = &ntlmHash
+	}
+	if localAuth {
+		localAuthPtr = &localAuth
 	}
 
 	// Create stealth config if any stealth parameters are set
@@ -1858,6 +1897,7 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 		Passwords:        passwords,
 		Domain:           domainPtr,
 		NtlmHash:         ntlmHashPtr,
+		LocalAuth:        localAuthPtr,
 		Timeout:          timeout,
 		StopFirstSuccess: &stopFirstSuccess,
 		SuccessfulOnly:   &successfulOnly,
@@ -2052,10 +2092,14 @@ func (a *NetworkScan) getDCSyncConfig(cmd *cobra.Command, targets, usernames, pa
 }
 
 // getWinRMPentestConfig creates a configuration for WinRM pentest operations with the provided parameters
-func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAction, usernames []string, passwords []string, commands []string, domain string, port int, useHTTPS bool, insecure bool, timeout int, stopFirstSuccess bool, successfulOnly bool) *winrmfern.PentestWinrmConfig {
+func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAction, usernames []string, passwords []string, commands []string, domain string, localAuth bool, port int, useHTTPS bool, insecure bool, timeout int, stopFirstSuccess bool, successfulOnly bool) *winrmfern.PentestWinrmConfig {
 	var domainPtr *string
+	var localAuthPtr *bool
 	if domain != "" {
 		domainPtr = &domain
+	}
+	if localAuth {
+		localAuthPtr = &localAuth
 	}
 
 	var portPtr *int
@@ -2077,6 +2121,7 @@ func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAct
 		Usernames:        usernames,
 		Passwords:        passwords,
 		Domain:           domainPtr,
+		LocalAuth:        localAuthPtr,
 		Port:             portPtr,
 		UseHttps:         &useHTTPS,
 		Insecure:         &insecure,

--- a/fern/definition/pentest/auth.yml
+++ b/fern/definition/pentest/auth.yml
@@ -22,6 +22,7 @@ types:
 
       # Authentication behavior
       useKerberos: optional<boolean> # Prefer Kerberos over NTLM when available
+      localAuth: optional<boolean> # Force local authentication instead of domain auth (similar to netexec --local-auth)
 
       # Legacy authentication options
       disableSigning: optional<boolean> # Disable SMB signing for older systems

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -112,6 +112,7 @@ types:
 
       # Service-specific configuration
       domain: optional<string> # SMB/LDAP/WINRM domain
+      localAuth: optional<boolean> # Force local authentication instead of domain auth
 
       # Attack configuration
       timeout: integer

--- a/internal/common/ntlm/serverinfo.go
+++ b/internal/common/ntlm/serverinfo.go
@@ -384,38 +384,43 @@ func GetSMBNetbiosDomain(serverInfo *commonprotocolfern.SmbServerInfo) string {
 	return ""
 }
 
-// WindowsBuildMapping maps Windows build numbers to human-readable versions
+// WindowsBuildMapping maps Windows build numbers to human-readable versions.
+// Some builds are shared between client and server editions (e.g., 19041 is both
+// Windows 10 2004 and Windows Server 2019 v2004). NTLM challenges cannot distinguish
+// between them, so ambiguous builds show both possibilities.
 var WindowsBuildMapping = map[string]string{
-	// Windows Server builds (prioritized for server environments)
+	// Unambiguous Windows Server builds
 	"20348": "Windows Server 2022",
-	"17763": "Windows Server 2019",
-	"14393": "Windows Server 2016",
-	"9600":  "Windows Server 2012 R2",
 	"9200":  "Windows Server 2012",
-	"7601":  "Windows Server 2008 R2 SP1",
-	"6002":  "Windows Server 2008 SP2",
-	"6001":  "Windows Server 2008 SP1",
-	"6000":  "Windows Server 2008",
+
+	// Builds shared between Server and Client (show both)
+	"17763": "Windows 10 1809 / Server 2019",
+	"14393": "Windows 10 1607 / Server 2016",
+	"9600":  "Windows 8.1 / Server 2012 R2",
+	"7601":  "Windows 7 SP1 / Server 2008 R2 SP1",
+	"6002":  "Windows Vista SP2 / Server 2008 SP2",
+	"6001":  "Windows Vista SP1 / Server 2008 SP1",
+	"6000":  "Windows Vista / Server 2008",
 
 	// Windows 11 builds
 	"22631": "Windows 11 23H2",
 	"22621": "Windows 11 22H2",
 	"22000": "Windows 11 21H2",
 
-	// Windows 10 builds (client builds that don't conflict with server)
+	// Windows 10 builds shared with Server SAC releases
 	"19045": "Windows 10 22H2",
-	"19044": "Windows 10 21H2",
+	"19044": "Windows 10 21H2 / Server 2019 21H2",
 	"19043": "Windows 10 21H1",
-	"19042": "Windows 10 20H2",
-	"19041": "Windows 10 2004",
-	"18363": "Windows 10 1909",
-	"18362": "Windows 10 1903",
-	"17134": "Windows 10 1803",
-	"16299": "Windows 10 1709",
+	"19042": "Windows 10 20H2 / Server 2019 20H2",
+	"19041": "Windows 10 2004 / Server 2019 v2004",
+	"18363": "Windows 10 1909 / Server 2019 1909",
+	"18362": "Windows 10 1903 / Server 2019 1903",
+	"17134": "Windows 10 1803 / Server 2019 1803",
+	"16299": "Windows 10 1709 / Server 2016 1709",
 	"15063": "Windows 10 1703",
 	"10586": "Windows 10 1511",
 	"10240": "Windows 10 1507",
 
 	// Older Windows versions
-	"7600": "Windows 7",
+	"7600": "Windows 7 / Server 2008 R2",
 }

--- a/internal/common/ntlm/serverinfo.go
+++ b/internal/common/ntlm/serverinfo.go
@@ -391,12 +391,12 @@ func GetSMBNetbiosDomain(serverInfo *commonprotocolfern.SmbServerInfo) string {
 var WindowsBuildMapping = map[string]string{
 	// Unambiguous Windows Server builds
 	"20348": "Windows Server 2022",
-	"9200":  "Windows Server 2012",
 
 	// Builds shared between Server and Client (show both)
 	"17763": "Windows 10 1809 / Server 2019",
 	"14393": "Windows 10 1607 / Server 2016",
 	"9600":  "Windows 8.1 / Server 2012 R2",
+	"9200":  "Windows 8 / Server 2012",
 	"7601":  "Windows 7 SP1 / Server 2008 R2 SP1",
 	"6002":  "Windows Vista SP2 / Server 2008 SP2",
 	"6001":  "Windows Vista SP1 / Server 2008 SP1",

--- a/internal/common/ntlm/serverinfo.go
+++ b/internal/common/ntlm/serverinfo.go
@@ -409,14 +409,14 @@ var WindowsBuildMapping = map[string]string{
 
 	// Windows 10 builds shared with Server SAC releases
 	"19045": "Windows 10 22H2",
-	"19044": "Windows 10 21H2 / Server 2019 21H2",
+	"19044": "Windows 10 21H2",
 	"19043": "Windows 10 21H1",
 	"19042": "Windows 10 20H2 / Server 2019 20H2",
 	"19041": "Windows 10 2004 / Server 2019 v2004",
 	"18363": "Windows 10 1909 / Server 2019 1909",
 	"18362": "Windows 10 1903 / Server 2019 1903",
-	"17134": "Windows 10 1803 / Server 2019 1803",
-	"16299": "Windows 10 1709 / Server 2016 1709",
+	"17134": "Windows 10 1803 / Server, version 1803",
+	"16299": "Windows 10 1709 / Server, version 1709",
 	"15063": "Windows 10 1703",
 	"10586": "Windows 10 1511",
 	"10240": "Windows 10 1507",

--- a/internal/pentest/ldap/auth.go
+++ b/internal/pentest/ldap/auth.go
@@ -427,6 +427,9 @@ func PerformAuthenticationWithContextAndConnection(ctx context.Context, target s
 		Target: connectionTarget,
 	}
 
+	// Check if local auth mode is enabled
+	localAuth := config.LocalAuth != nil && *config.LocalAuth
+
 	// Override domain with config domain if provided (instead of deriving from target IP)
 	if config.Domain != nil && *config.Domain != "" {
 		ldapTarget.Domain = *config.Domain
@@ -441,6 +444,12 @@ func PerformAuthenticationWithContextAndConnection(ctx context.Context, target s
 		} else {
 			ldapTarget.BaseDN = fmt.Sprintf("DC=%s", *config.Domain)
 		}
+	}
+
+	// If local auth is enabled, clear domain to force local authentication
+	if localAuth {
+		log.Info("Local auth mode enabled, clearing domain for local authentication")
+		ldapTarget.Domain = ""
 	}
 
 	// Check if auth should be performed based on credentials or explicit actions

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -164,12 +164,13 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 
 	// Get domain from config
 	domain := ""
+	localAuth := config.LocalAuth != nil && *config.LocalAuth
 	if config.Domain != nil {
 		domain = *config.Domain
 	}
 
-	// If no domain provided, attempt to discover it from server info using NTLM challenge
-	if domain == "" {
+	// If no domain provided and not using local auth, attempt to discover it from server info using NTLM challenge
+	if domain == "" && !localAuth {
 		discoveredDomain := discoverDomainFromServerChallenge(ctx, host, port, config.Timeout)
 		if discoveredDomain != "" {
 			domain = discoveredDomain
@@ -178,6 +179,8 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 			// Update the config to reflect the discovered domain
 			config.Domain = &domain
 		}
+	} else if localAuth {
+		log.Info("Local auth mode enabled, skipping domain discovery")
 	}
 
 	// Check if we should use hash-based authentication
@@ -187,7 +190,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 		log.Info("Using pass-the-hash authentication", svc1log.SafeParam("hash", "[REDACTED]"))
 
 		for _, cred := range credPairs {
-			attempt, err := attemptHashAuthenticationWithContext(ctx, host, port, cred.Username, ntlmHash, domain, config.Timeout)
+			attempt, err := attemptHashAuthenticationWithContext(ctx, host, port, cred.Username, ntlmHash, domain, localAuth, config.Timeout)
 			if err != nil {
 				errors = append(errors, err.Error())
 			}
@@ -207,7 +210,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 	} else {
 		// Use traditional password authentication
 		for _, cred := range credPairs {
-			attempt, err := attemptAuthenticationWithContext(ctx, host, port, cred.Username, cred.Password, domain, config.Timeout)
+			attempt, err := attemptAuthenticationWithContext(ctx, host, port, cred.Username, cred.Password, domain, localAuth, config.Timeout)
 			if err != nil {
 				errors = append(errors, err.Error())
 			}
@@ -281,12 +284,13 @@ func performAuthAttemptsWithConnectionKeeping(ctx context.Context, host string, 
 
 	// Get domain from config
 	domain := ""
+	localAuth := config.LocalAuth != nil && *config.LocalAuth
 	if config.Domain != nil {
 		domain = *config.Domain
 	}
 
-	// If no domain provided, attempt to discover it from server info using NTLM challenge
-	if domain == "" {
+	// If no domain provided and not using local auth, attempt to discover it from server info using NTLM challenge
+	if domain == "" && !localAuth {
 		discoveredDomain := discoverDomainFromServerChallenge(ctx, host, port, config.Timeout)
 		if discoveredDomain != "" {
 			domain = discoveredDomain
@@ -295,6 +299,8 @@ func performAuthAttemptsWithConnectionKeeping(ctx context.Context, host string, 
 			// Update the config to reflect the discovered domain
 			config.Domain = &domain
 		}
+	} else if localAuth {
+		log.Info("Local auth mode enabled, skipping domain discovery")
 	}
 
 	// Process each credential pair
@@ -311,10 +317,10 @@ func performAuthAttemptsWithConnectionKeeping(ctx context.Context, host string, 
 
 		if config.NtlmHash != nil && *config.NtlmHash != "" {
 			// Use pass-the-hash authentication
-			attempt, client, err = attemptSMBHashAuthenticationWithConnection(ctx, host, port, cred.Username, *config.NtlmHash, domain, config.Timeout)
+			attempt, client, err = attemptSMBHashAuthenticationWithConnection(ctx, host, port, cred.Username, *config.NtlmHash, domain, localAuth, config.Timeout)
 		} else {
 			// Use password authentication
-			attempt, client, err = attemptSMBAuthenticationWithConnection(ctx, host, port, cred.Username, cred.Password, domain, config.Timeout)
+			attempt, client, err = attemptSMBAuthenticationWithConnection(ctx, host, port, cred.Username, cred.Password, domain, localAuth, config.Timeout)
 		}
 
 		if err != nil {
@@ -350,11 +356,12 @@ func performAuthAttemptsWithConnectionKeeping(ctx context.Context, host string, 
 }
 
 // attemptAuthenticationWithContext performs a single authentication attempt with context
-func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*pentestfern.AuthAttempt, error) {
+func attemptAuthenticationWithContext(ctx context.Context, host string, port int, username, password, domain string, localAuth bool, timeout int) (*pentestfern.AuthAttempt, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
 	// Skip server info extraction since it's done in PROBE stage
 	client.SkipServerInfoExtraction(true)
+	client.LocalAuth = localAuth
 
 	// Use provided domain or empty string for local authentication
 	client.SetCredentials(username, password, domain)
@@ -438,11 +445,12 @@ func discoverDomainFromServerChallenge(ctx context.Context, host string, port, t
 }
 
 // attemptHashAuthenticationWithContext performs a single pass-the-hash authentication attempt with context
-func attemptHashAuthenticationWithContext(ctx context.Context, host string, port int, username, ntlmHash, domain string, timeout int) (*pentestfern.AuthAttempt, error) {
+func attemptHashAuthenticationWithContext(ctx context.Context, host string, port int, username, ntlmHash, domain string, localAuth bool, timeout int) (*pentestfern.AuthAttempt, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
 	// Skip server info extraction since it's done in PROBE stage
 	client.SkipServerInfoExtraction(true)
+	client.LocalAuth = localAuth
 
 	// Use NTLM hash for authentication
 	client.SetCredentialsWithHash(username, ntlmHash, domain)
@@ -496,11 +504,12 @@ func attemptHashAuthenticationWithContext(ctx context.Context, host string, port
 }
 
 // attemptSMBAuthenticationWithConnection performs a single SMB authentication attempt with connection keeping
-func attemptSMBAuthenticationWithConnection(ctx context.Context, host string, port int, username, password, domain string, timeout int) (*pentestfern.AuthAttempt, *smbclient.Client, error) {
+func attemptSMBAuthenticationWithConnection(ctx context.Context, host string, port int, username, password, domain string, localAuth bool, timeout int) (*pentestfern.AuthAttempt, *smbclient.Client, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
 	// Skip server info extraction since it's done in PROBE stage
 	client.SkipServerInfoExtraction(true)
+	client.LocalAuth = localAuth
 	// Use provided domain or empty string for local authentication
 	client.SetCredentials(username, password, domain)
 	timestamp := time.Now()
@@ -548,11 +557,12 @@ func attemptSMBAuthenticationWithConnection(ctx context.Context, host string, po
 }
 
 // attemptSMBHashAuthenticationWithConnection performs a single SMB hash authentication attempt with connection keeping
-func attemptSMBHashAuthenticationWithConnection(ctx context.Context, host string, port int, username, ntlmHash, domain string, timeout int) (*pentestfern.AuthAttempt, *smbclient.Client, error) {
+func attemptSMBHashAuthenticationWithConnection(ctx context.Context, host string, port int, username, ntlmHash, domain string, localAuth bool, timeout int) (*pentestfern.AuthAttempt, *smbclient.Client, error) {
 	client := smbclient.NewClient(host, port)
 	client.Timeout = time.Duration(timeout) * time.Millisecond
 	// Skip server info extraction since it's done in PROBE stage
 	client.SkipServerInfoExtraction(true)
+	client.LocalAuth = localAuth
 	// Use provided domain or empty string for local authentication
 	client.SetCredentialsWithHash(username, ntlmHash, domain)
 	timestamp := time.Now()

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -611,6 +611,7 @@ func (e *Engine) performSMBSpray(ctx context.Context, target string, cred *pente
 		Passwords: passwords,
 		NtlmHash:  cred.NtlmHash, // Pass NTLM hash for pass-the-hash authentication
 		Domain:    cred.Domain,
+		LocalAuth: config.LocalAuth,
 		Timeout:   config.Timeout,
 	}
 

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -689,6 +689,11 @@ func (e *Engine) performLDAPSpray(ctx context.Context, target string, cred *pent
 		ldapTarget.BaseDN = strings.Join(dcParts, ",")
 	}
 
+	// If local auth is requested, clear domain to force local authentication
+	if config.LocalAuth != nil && *config.LocalAuth {
+		ldapTarget.Domain = ""
+	}
+
 	// Attempt authentication (LDAP supports both password and NTLM hash auth)
 	success, message, err := ldappentest.AuthenticateUser(ctx, ldapTarget, cred.Username, getPasswordForAuth(cred), config.Timeout)
 	if err != nil {

--- a/internal/pentest/winrm/auth.go
+++ b/internal/pentest/winrm/auth.go
@@ -158,6 +158,12 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 		domain = *config.Domain
 	}
 
+	// If local auth is requested, clear domain to force local authentication
+	if config.LocalAuth != nil && *config.LocalAuth {
+		log.Info("Local auth mode enabled, clearing domain for local authentication")
+		domain = ""
+	}
+
 	var successfulCount int
 	for _, cred := range credPairs {
 		attempt, err := attemptAuthenticationWithContext(ctx, host, port, cred.Username, cred.Password, domain, config)
@@ -213,6 +219,12 @@ func performAuthAttemptsWithConnectionKeeping(ctx context.Context, host string, 
 	domain := ""
 	if config.Domain != nil {
 		domain = *config.Domain
+	}
+
+	// If local auth is requested, clear domain to force local authentication
+	if config.LocalAuth != nil && *config.LocalAuth {
+		log.Info("Local auth mode enabled, clearing domain for local authentication")
+		domain = ""
 	}
 
 	// Process each credential pair

--- a/internal/protocol/smb/client.go
+++ b/internal/protocol/smb/client.go
@@ -118,6 +118,7 @@ type Client struct {
 	Password        string
 	NTLMHash        string // NTLM hash for pass-the-hash authentication
 	Domain          string
+	LocalAuth       bool // If true, force local auth (don't use domain from server challenge)
 	UseAnonymous    bool
 	UseNullSession  bool
 	ChallengeOnly   bool // If true, only get NTLM challenge and exit without authentication
@@ -302,7 +303,7 @@ func (c *Client) ConnectWithContext(ctx context.Context) error {
 		ntlmInitiator = &spnego.NTLMInitiator{
 			User:      c.Username,
 			Domain:    c.Domain,
-			LocalUser: false, // Don't assume local user
+			LocalUser: c.LocalAuth,
 		}
 
 		// Use hash if available, otherwise use password


### PR DESCRIPTION
## Summary
- Add netexec-style `--local-auth` flag to SMB, LDAP, WinRM, and spray password commands to force authentication against local SAM database instead of using domain from NTLM server challenge
- Wire `LocalAuth` through the SMB protocol client's `spnego.NTLMInitiator.LocalUser` field so the go-smb library doesn't override the domain from the Type 2 challenge
- Fix Windows build-to-OS version mapping for ambiguous builds shared between client and server editions (e.g., 19041 → "Windows 10 2004 / Server 2019 v2004")

## Test plan
- [x] Verified `--local-auth` works against live target: local auth returns "Password expired!" (correct local account behavior) vs domain auth returning "Logon failed"
- [x] `./godelw verify` passes
- [ ] Verify LDAP `--local-auth` clears domain for local auth
- [ ] Verify spray password passes `--local-auth` through to SMB config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication behavior for SMB/LDAP/WinRM and password spraying by optionally bypassing domain discovery/usage, which could alter login outcomes across targets. Also updates OS version labeling but is low functional risk.
> 
> **Overview**
> Adds a new `--local-auth` flag to the pentest CLI (`spray password`, `service smb`, `service ldap`, `service winrm`) and wires it through the generated Fern configs so callers can force local-account authentication instead of domain-based auth.
> 
> Updates SMB/LDAP/WinRM auth flows to honor `LocalAuth` by clearing/skipping domain usage (and for SMB, skipping NTLM-challenge domain discovery) and propagates the setting into the SMB protocol client via `spnego.NTLMInitiator.LocalUser`. Also adjusts NTLM Windows build-to-version mapping to label builds shared by client/server editions as ambiguous (e.g., `19041` shows both Windows 10 and Server variants).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b44738c8a40169a5c42b54f87113f9401dee401. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->