### PR TITLE
Add LOCAL_ADMIN collection to LDAP domain dump

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -406,6 +406,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	ldapCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delays")
 	ldapCmd.Flags().Int("max-queries", 0, "Maximum total LDAP queries to perform (0 = unlimited)")
 	ldapCmd.Flags().Bool("minimal-queries", false, "Use minimal query sets and essential attributes only")
+	ldapCmd.Flags().StringSlice("collection-methods", []string{}, "Collection methods for domain dump (GROUP, TRUSTS, OBJECTPROPS, CONTAINER, LOCAL_ADMIN). Defaults to GROUP,CONTAINER,TRUSTS")
 
 	parent.AddCommand(ldapCmd)
 }
@@ -1059,8 +1060,24 @@ func (a *NetworkScan) runLDAPPentest(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// Parse collection methods
+	collectionMethodStrs, err := cmd.Flags().GetStringSlice("collection-methods")
+	if err != nil {
+		a.OutputSignal.AddError(err)
+		return
+	}
+	var collectionMethods []ldapfern.CollectionMethod
+	for _, m := range collectionMethodStrs {
+		cm, err := ldapfern.NewCollectionMethodFromString(strings.ToUpper(strings.TrimSpace(m)))
+		if err != nil {
+			a.OutputSignal.AddError(fmt.Errorf("invalid collection method %q: %v", m, err))
+			return
+		}
+		collectionMethods = append(collectionMethods, cm)
+	}
+
 	// Set Config
-	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, localAuth, sleep, jitter, maxQueries, minimalQueries)
+	config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, localAuth, sleep, jitter, maxQueries, minimalQueries, collectionMethods)
 
 	// Create engine and run pentest
 	engine := pentest_internal.NewEngine()
@@ -1837,7 +1854,7 @@ func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnet
 }
 
 // getLDAPPentestConfig creates a configuration for LDAP pentest operations with the provided parameters.
-func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, sleep int, jitter int, maxQueries int, minimalQueries bool) *ldapfern.PentestLdapConfig {
+func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, sleep int, jitter int, maxQueries int, minimalQueries bool, collectionMethods []ldapfern.CollectionMethod) *ldapfern.PentestLdapConfig {
 	var domainPtr, ntlmHashPtr *string
 	var localAuthPtr *bool
 	if domain != "" {
@@ -1883,6 +1900,9 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 		if action == ldapfern.PentestLdapActionDomaindump {
 			domainDumpConfig = &ldapfern.DomainDumpConfig{
 				Stealth: stealthConfig,
+			}
+			if len(collectionMethods) > 0 {
+				domainDumpConfig.CollectionMethods = collectionMethods
 			}
 			break
 		}

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -406,7 +406,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	ldapCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delays")
 	ldapCmd.Flags().Int("max-queries", 0, "Maximum total LDAP queries to perform (0 = unlimited)")
 	ldapCmd.Flags().Bool("minimal-queries", false, "Use minimal query sets and essential attributes only")
-	ldapCmd.Flags().StringSlice("collection-methods", []string{}, "Collection methods for domain dump (GROUP, TRUSTS, OBJECTPROPS, CONTAINER, LOCAL_ADMIN). Defaults to GROUP,CONTAINER,TRUSTS")
+	ldapCmd.Flags().StringSlice("collection-methods", []string{"GROUP", "CONTAINER", "TRUSTS"}, "Collection methods for domain dump (GROUP, TRUSTS, OBJECTPROPS, CONTAINER, LOCAL_ADMIN)")
 
 	parent.AddCommand(ldapCmd)
 }

--- a/fern/definition/pentest/ldap/domaindump.yml
+++ b/fern/definition/pentest/ldap/domaindump.yml
@@ -12,13 +12,14 @@ types:
       maxQueries: optional<integer> # Maximum total LDAP queries to perform
       minimalQueries: optional<boolean> # Use minimal query sets and essential attributes only
 
-  # Collection Methods - only the ones we currently implement
+  # Collection Methods
   CollectionMethod:
     enum:
       - GROUP
       - TRUSTS
       - OBJECTPROPS
       - CONTAINER
+      - LOCAL_ADMIN
 
   # Domain Object Types
   DomainObjectType:
@@ -114,6 +115,14 @@ types:
       trustedToAuth: optional<boolean>
       resourceBasedConstrainedDelegation: optional<boolean>
       resourceBasedConstrainedDelegationPrincipals: optional<list<string>>
+      localAdmins: optional<list<LocalGroupMember>> # Members of local Administrators group (via SAM-R)
+
+  # Local Group Member (SAM-R enumerated)
+  LocalGroupMember:
+    properties:
+      sid: optional<string>
+      name: optional<string>
+      objectType: optional<string>
 
   # Domain Controller Objects
   DomainController:

--- a/go.mod
+++ b/go.mod
@@ -393,7 +393,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a // indirect
 	gopkg.in/djherbis/times.v1 v1.3.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 replace github.com/zmap/zcrypto => github.com/zmap/zcrypto v0.0.0-20241218205341-e47c4f4da3a4

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -1809,11 +1809,20 @@ func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn 
 			collectionMethods := l.getCollectionMethods(config)
 			maxResults := l.getMaxResults(config)
 
+			// Process LOCAL_ADMIN last since it depends on computers from CONTAINER
+			hasLocalAdmin := false
 			for _, method := range collectionMethods {
+				if method == ldapfern.CollectionMethodLocalAdmin {
+					hasLocalAdmin = true
+					continue
+				}
 				if !stealthCtx.ShouldContinue() {
 					break
 				}
 				l.processCollectionMethod(ctx, conn, baseDN, method, maxResults, stealthCtx, config, domainResult, &errors)
+			}
+			if hasLocalAdmin {
+				l.processCollectionMethod(ctx, conn, baseDN, ldapfern.CollectionMethodLocalAdmin, maxResults, stealthCtx, config, domainResult, &errors)
 			}
 		}
 	}

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -2020,37 +2020,6 @@ func (l *LibraryPentestLdap) processLocalAdminCollection(ctx context.Context, co
 		domain = *config.Domain
 	}
 
-	// Use the first computer's hostname to establish auth target
-	var firstHost string
-	for _, computer := range domainResult.Computers {
-		if computer.DnsHostName != nil && *computer.DnsHostName != "" {
-			firstHost = *computer.DnsHostName
-			break
-		}
-	}
-	if firstHost == "" {
-		*errors = append(*errors, "LOCAL_ADMIN collection skipped: no computers with DNS hostnames found")
-		return
-	}
-
-	adauthOpts, err := msrpcProto.SetupAdauthOptions(username, domain, "", firstHost, nil, password, config.NtlmHash)
-	if err != nil {
-		*errors = append(*errors, fmt.Sprintf("LOCAL_ADMIN auth setup failed: %v", err))
-		return
-	}
-
-	credential, target, err := adauthOpts.WithTarget(ctx, "cifs", firstHost)
-	if err != nil {
-		*errors = append(*errors, fmt.Sprintf("LOCAL_ADMIN credential setup failed: %v", err))
-		return
-	}
-
-	authOptions, err := dcerpcauth.AuthenticationOptions(ctx, credential, target, &dcerpcauth.Options{})
-	if err != nil {
-		*errors = append(*errors, fmt.Sprintf("LOCAL_ADMIN dcerpc auth setup failed: %v", err))
-		return
-	}
-
 	gssapi.AddMechanism(ssp.SPNEGO)
 	gssapi.AddMechanism(ssp.NTLM)
 	gssapi.AddMechanism(ssp.KRB5)
@@ -2070,6 +2039,35 @@ func (l *LibraryPentestLdap) processLocalAdminCollection(ctx context.Context, co
 		}
 
 		host := *computer.DnsHostName
+
+		// Set up auth per host so the Kerberos SPN targets the correct computer
+		adauthOpts, err := msrpcProto.SetupAdauthOptions(username, domain, "", host, nil, password, config.NtlmHash)
+		if err != nil {
+			failCount++
+			log.Info("SAM-R auth setup failed",
+				svc1log.SafeParam("host", host),
+				svc1log.SafeParam("error", err.Error()))
+			continue
+		}
+
+		credential, target, err := adauthOpts.WithTarget(ctx, "cifs", host)
+		if err != nil {
+			failCount++
+			log.Info("SAM-R credential setup failed",
+				svc1log.SafeParam("host", host),
+				svc1log.SafeParam("error", err.Error()))
+			continue
+		}
+
+		authOptions, err := dcerpcauth.AuthenticationOptions(ctx, credential, target, &dcerpcauth.Options{})
+		if err != nil {
+			failCount++
+			log.Info("SAM-R dcerpc auth setup failed",
+				svc1log.SafeParam("host", host),
+				svc1log.SafeParam("error", err.Error()))
+			continue
+		}
+
 		samrClient := msrpcProto.NewSAMRClient(host, authOptions)
 		members, err := samrClient.EnumerateLocalGroupMembers(ctx, msrpcProto.AdministratorsRID)
 		if err != nil {

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -14,10 +14,14 @@ import (
 
 	// Internal
 	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	msrpcProto "github.com/Method-Security/networkscan/internal/protocol/msrpc"
 	"github.com/Method-Security/networkscan/utils"
 
 	// External
+	"github.com/RedTeamPentesting/adauth/dcerpcauth"
 	"github.com/go-ldap/ldap/v3"
+	"github.com/oiweiwei/go-msrpc/ssp"
+	"github.com/oiweiwei/go-msrpc/ssp/gssapi"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
@@ -1809,7 +1813,7 @@ func (l *LibraryPentestLdap) processDomainDumpActions(ctx context.Context, conn 
 				if !stealthCtx.ShouldContinue() {
 					break
 				}
-				l.processCollectionMethod(ctx, conn, baseDN, method, maxResults, stealthCtx, domainResult, &errors)
+				l.processCollectionMethod(ctx, conn, baseDN, method, maxResults, stealthCtx, config, domainResult, &errors)
 			}
 		}
 	}
@@ -1873,7 +1877,7 @@ func (l *LibraryPentestLdap) getMaxResults(config ldapfern.PentestLdapConfig) *i
 }
 
 // processCollectionMethod processes a single collection method
-func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *ldap.Conn, baseDN string, method ldapfern.CollectionMethod, maxResults *int, stealthCtx *StealthContext, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *ldap.Conn, baseDN string, method ldapfern.CollectionMethod, maxResults *int, stealthCtx *StealthContext, config ldapfern.PentestLdapConfig, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
 	switch method {
 	case ldapfern.CollectionMethodGroup:
 		l.processGroupCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
@@ -1883,6 +1887,8 @@ func (l *LibraryPentestLdap) processCollectionMethod(ctx context.Context, conn *
 		l.processObjectPropsCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
 	case ldapfern.CollectionMethodContainer:
 		l.processContainerCollection(ctx, conn, baseDN, maxResults, stealthCtx, domainResult, errors)
+	case ldapfern.CollectionMethodLocalAdmin:
+		l.processLocalAdminCollection(ctx, config, domainResult, errors)
 	default:
 		logger := svc1log.FromContext(ctx)
 		logger.Info("Collection method not yet implemented", svc1log.SafeParam("method", string(method)))
@@ -1984,6 +1990,114 @@ func (l *LibraryPentestLdap) processContainerCollection(ctx context.Context, con
 		*domainResult.TotalObjects += len(*containers)
 	}
 	*errors = append(*errors, errs...)
+}
+
+// processLocalAdminCollection enumerates local Administrators group membership on each
+// discovered computer via SAM-R. Requires local admin on each target to succeed;
+// ACCESS_DENIED failures are expected and logged as info, not errors.
+func (l *LibraryPentestLdap) processLocalAdminCollection(ctx context.Context, config ldapfern.PentestLdapConfig, domainResult *ldapfern.DomainDumpResult, errors *[]string) {
+	log := svc1log.FromContext(ctx)
+
+	if len(domainResult.Computers) == 0 {
+		log.Warn("LOCAL_ADMIN collection requires computers to be enumerated first (include CONTAINER in collection methods)")
+		*errors = append(*errors, "LOCAL_ADMIN collection skipped: no computers enumerated (include CONTAINER collection method)")
+		return
+	}
+
+	if len(config.Usernames) == 0 {
+		*errors = append(*errors, "LOCAL_ADMIN collection requires authentication credentials")
+		return
+	}
+
+	// Setup SAM-R authentication (same pattern as DCSync)
+	username := config.Usernames[0]
+	password := ""
+	if len(config.Passwords) > 0 {
+		password = config.Passwords[0]
+	}
+	domain := ""
+	if config.Domain != nil {
+		domain = *config.Domain
+	}
+
+	// Use the first computer's hostname to establish auth target
+	var firstHost string
+	for _, computer := range domainResult.Computers {
+		if computer.DnsHostName != nil && *computer.DnsHostName != "" {
+			firstHost = *computer.DnsHostName
+			break
+		}
+	}
+	if firstHost == "" {
+		*errors = append(*errors, "LOCAL_ADMIN collection skipped: no computers with DNS hostnames found")
+		return
+	}
+
+	adauthOpts, err := msrpcProto.SetupAdauthOptions(username, domain, "", firstHost, nil, password, config.NtlmHash)
+	if err != nil {
+		*errors = append(*errors, fmt.Sprintf("LOCAL_ADMIN auth setup failed: %v", err))
+		return
+	}
+
+	credential, target, err := adauthOpts.WithTarget(ctx, "cifs", firstHost)
+	if err != nil {
+		*errors = append(*errors, fmt.Sprintf("LOCAL_ADMIN credential setup failed: %v", err))
+		return
+	}
+
+	authOptions, err := dcerpcauth.AuthenticationOptions(ctx, credential, target, &dcerpcauth.Options{})
+	if err != nil {
+		*errors = append(*errors, fmt.Sprintf("LOCAL_ADMIN dcerpc auth setup failed: %v", err))
+		return
+	}
+
+	gssapi.AddMechanism(ssp.SPNEGO)
+	gssapi.AddMechanism(ssp.NTLM)
+	gssapi.AddMechanism(ssp.KRB5)
+
+	log.Info("Starting LOCAL_ADMIN collection via SAM-R",
+		svc1log.SafeParam("computerCount", len(domainResult.Computers)))
+
+	successCount := 0
+	failCount := 0
+
+	for _, computer := range domainResult.Computers {
+		if computer.DnsHostName == nil || *computer.DnsHostName == "" {
+			continue
+		}
+		if computer.Enabled != nil && !*computer.Enabled {
+			continue
+		}
+
+		host := *computer.DnsHostName
+		samrClient := msrpcProto.NewSAMRClient(host, authOptions)
+		members, err := samrClient.EnumerateLocalGroupMembers(ctx, msrpcProto.AdministratorsRID)
+		if err != nil {
+			failCount++
+			log.Info("SAM-R local admin enumeration failed (expected if not local admin)",
+				svc1log.SafeParam("host", host),
+				svc1log.SafeParam("error", err.Error()))
+			continue
+		}
+
+		var localAdmins []*ldapfern.LocalGroupMember
+		for _, member := range members {
+			sid := member.SID
+			localAdmins = append(localAdmins, &ldapfern.LocalGroupMember{
+				Sid: &sid,
+			})
+		}
+		computer.LocalAdmins = localAdmins
+		successCount++
+
+		log.Info("Enumerated local admins",
+			svc1log.SafeParam("host", host),
+			svc1log.SafeParam("memberCount", len(localAdmins)))
+	}
+
+	log.Info("LOCAL_ADMIN collection completed",
+		svc1log.SafeParam("successful", successCount),
+		svc1log.SafeParam("failed", failCount))
 }
 
 // performAuthAction performs LDAP authentication testing

--- a/internal/protocol/msrpc/samr.go
+++ b/internal/protocol/msrpc/samr.go
@@ -14,6 +14,18 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+const (
+	// BuiltinDomainName is the well-known SAM domain for local groups (aliases)
+	BuiltinDomainName = "Builtin"
+	// AdministratorsRID is the RID of the local Administrators alias (S-1-5-32-544)
+	AdministratorsRID = uint32(544)
+)
+
+// LocalGroupMemberInfo represents a member of a local group discovered via SAM-R
+type LocalGroupMemberInfo struct {
+	SID string
+}
+
 // UserEntry represents a domain user with RID information for SID construction
 type UserEntry struct {
 	Username string
@@ -136,4 +148,90 @@ func (c *SAMRClient) EnumerateDomainUsers(ctx context.Context, domain string) (*
 	}
 
 	return domainInfo, nil
+}
+
+// EnumerateLocalGroupMembers connects to SAM-R on the target host and enumerates
+// members of a local group (alias) by RID. Use AdministratorsRID (544) for the
+// local Administrators group. Returns member SIDs.
+func (c *SAMRClient) EnumerateLocalGroupMembers(ctx context.Context, aliasRID uint32) ([]LocalGroupMemberInfo, error) {
+	log := svc1log.FromContext(ctx)
+
+	secCtx := gssapi.NewSecurityContext(ctx)
+
+	endpointOpts := append(c.AuthOptions, epm.EndpointMapper(secCtx, c.Host))
+	conn, err := dcerpc.Dial(secCtx, c.Host, endpointOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to SAMR service on %s: %w", c.Host, err)
+	}
+	defer func() {
+		if closeErr := conn.Close(ctx); closeErr != nil {
+			log.Warn("Failed to close SAMR connection", svc1log.SafeParam("error", closeErr.Error()))
+		}
+	}()
+
+	samrClient, err := samr.NewSamrClient(secCtx, conn, dcerpc.WithSeal())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SAMR client: %w", err)
+	}
+
+	serverHandle, err := samrClient.Connect(secCtx, &samr.ConnectRequest{
+		DesiredAccess: dtyp.AccessMaskGenericRead | dtyp.AccessMaskGenericExecute,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to SAM server: %w", err)
+	}
+
+	// Look up the Builtin domain (contains local groups/aliases)
+	builtinLookup, err := samrClient.LookupDomainInSAMServer(secCtx, &samr.LookupDomainInSAMServerRequest{
+		Server: serverHandle.Server,
+		Name:   &dtyp.UnicodeString{Buffer: BuiltinDomainName},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup Builtin domain: %w", err)
+	}
+
+	builtinHandle, err := samrClient.OpenDomain(secCtx, &samr.OpenDomainRequest{
+		Server:        serverHandle.Server,
+		DesiredAccess: dtyp.AccessMaskGenericRead | dtyp.AccessMaskGenericExecute,
+		DomainID:      builtinLookup.DomainID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open Builtin domain: %w", err)
+	}
+
+	// Open the alias (local group) by RID
+	aliasHandle, err := samrClient.OpenAlias(secCtx, &samr.OpenAliasRequest{
+		Domain:        builtinHandle.Domain,
+		DesiredAccess: dtyp.AccessMaskGenericRead,
+		AliasID:       aliasRID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open alias RID %d: %w", aliasRID, err)
+	}
+
+	// Get members of the alias
+	membersResp, err := samrClient.GetMembersInAlias(secCtx, &samr.GetMembersInAliasRequest{
+		AliasHandle: aliasHandle.AliasHandle,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get members in alias RID %d: %w", aliasRID, err)
+	}
+
+	var members []LocalGroupMemberInfo
+	if membersResp.Members != nil {
+		for _, sidInfo := range membersResp.Members.SIDs {
+			if sidInfo.SIDPointer != nil {
+				members = append(members, LocalGroupMemberInfo{
+					SID: sidInfo.SIDPointer.String(),
+				})
+			}
+		}
+	}
+
+	log.Info("Enumerated local group members via SAM-R",
+		svc1log.SafeParam("host", c.Host),
+		svc1log.SafeParam("aliasRID", aliasRID),
+		svc1log.SafeParam("memberCount", len(members)))
+
+	return members, nil
 }


### PR DESCRIPTION
## Summary
- Add SAM-R based local Administrators group enumeration to the LDAP domain dump tool
- New `LOCAL_ADMIN` collection method enumerates members of Builtin\Administrators (RID 544) on each discovered computer via SAM-R
- Produces BloodHound-style AdminTo edge data — requires local admin on targets; ACCESS_DENIED failures are gracefully skipped
- New `--collection-methods` CLI flag to control which collection methods run (defaults unchanged: GROUP, CONTAINER, TRUSTS)

## Test plan
- [x] `./godelw verify` passes
- [x] Tested against range with `intern_adams` credentials — SAM-R enumeration works on WIN-SQL01 where user has local admin
- [ ] Verify ACCESS_DENIED on machines where user lacks local admin produces graceful skip
- [ ] Verify omitting LOCAL_ADMIN from collection methods produces no SAM-R traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new SAM-R/DCERPC enumeration path during LDAP domain dumps and new CLI-configurable collection method selection, which can change network behavior and auth requirements. Failures are handled gracefully, but the new cross-protocol logic increases integration risk.
> 
> **Overview**
> Adds a new `LOCAL_ADMIN` domain-dump collection method that enumerates each discovered computer’s local Administrators group membership via SAM-R (DCERPC) and attaches the resulting member SIDs to `DomainComputer.localAdmins`.
> 
> Introduces a new LDAP CLI flag `--collection-methods` (defaulting to existing behavior) to control which domain-dump collection methods run, wires it through `PentestLdapConfig`/`DomainDumpConfig`, and ensures `LOCAL_ADMIN` runs last (after `CONTAINER`) since it depends on discovered computers. Also extends the Fern schema to include `LOCAL_ADMIN` and the `LocalGroupMember` type, and promotes `gopkg.in/yaml.v3` to a direct dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56fce32e3e8ff31fcf9c8f1ebb7989b66dcf43ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->