### PR TITLE
ike cli setup

### DIFF
--- a/fern/definition/common/protocol/ike.yml
+++ b/fern/definition/common/protocol/ike.yml
@@ -18,3 +18,12 @@ types:
       hashAlgorithms: optional<list<string>>
       authenticationMethods: optional<list<string>>
       dhGroups: optional<list<string>>
+
+      # Security assessment fields
+      aggressiveModeEnabled: optional<boolean>
+      ikev1Supported: optional<boolean>
+      ikev2Supported: optional<boolean>
+      natTraversalSupported: optional<boolean>
+      deadPeerDetectionSupported: optional<boolean>
+      weakAlgorithmsDetected: optional<list<string>>
+      vendorIdentification: optional<string>

--- a/fern/definition/enumerate/enumerate.yml
+++ b/fern/definition/enumerate/enumerate.yml
@@ -5,6 +5,7 @@ imports:
   grpc: ./grpc/grpc.yml
   smb: ./smb/smb.yml
   ldap: ./ldap/ldap.yml
+  ike: ./ike/ike.yml
 types:
   # ENUMs
   SupportedServiceType:
@@ -15,6 +16,7 @@ types:
       - GRPC
       - SMB
       - LDAP
+      - IKE
   # Report structs
   EnumerateServiceDetails:
     union:
@@ -24,6 +26,7 @@ types:
       EnumerateGrpcDetails: grpc.EnumerateGrpcDetails
       EnumerateSmbDetails: smb.EnumerateSmbDetails
       EnumerateLdapDetails: ldap.EnumerateLdapDetails
+      EnumerateIkeDetails: ike.EnumerateIkeDetails
   EnumerateServiceResult:
     properties:
       details: optional<list<EnumerateServiceDetails>>

--- a/fern/definition/enumerate/ike/ike.yml
+++ b/fern/definition/enumerate/ike/ike.yml
@@ -1,0 +1,8 @@
+imports:
+  ikeProtocol: ../../common/protocol/ike.yml
+types:
+  EnumerateIkeDetails:
+    properties:
+      target: string
+      port: integer
+      serverInfo: optional<ikeProtocol.IkeServerInfo>

--- a/internal/discover/service/plugins/ike.go
+++ b/internal/discover/service/plugins/ike.go
@@ -3,7 +3,6 @@ package plugins
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -12,6 +11,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	ikeprotocol "github.com/Method-Security/networkscan/internal/protocol/ike"
 )
 
 type IKEFingerprinter struct{}
@@ -23,57 +23,46 @@ func (IKEFingerprinter) DefaultPorts() []int { return []int{500, 4500} }
 func (IKEFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
 	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
 
-	// Create UDP connection
 	conn, err := net.DialTimeout("udp", addr, time.Duration(timeout)*time.Second)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Set read deadline
 	if err := conn.SetReadDeadline(time.Now().Add(time.Duration(timeout) * time.Second)); err != nil {
 		return nil, err
 	}
 
-	// Build IKEv2 SA_INIT request packet
-	ikeRequest := buildIKEv2SAInitRequest()
-
-	// Send the request
-	if _, err := conn.Write(ikeRequest); err != nil {
+	if _, err := conn.Write(ikeprotocol.BuildIKEv2SAInitRequest()); err != nil {
 		return nil, err
 	}
 
-	// Read response
 	buffer := make([]byte, 4096)
 	n, err := conn.Read(buffer)
 	if err != nil {
 		return nil, err
 	}
 
-	// IKE response must be at least 28 bytes (header size)
 	if n < 28 {
 		return nil, fmt.Errorf("invalid IKE response size: %d", n)
 	}
 
-	// Parse IKE response header
 	response := buffer[:n]
-	ikeHeader, err := parseIKEHeader(response)
+	ikeHeader, err := ikeprotocol.ParseIKEHeader(response)
 	if err != nil {
 		return nil, err
 	}
 
-	// Validate it's an IKE response
 	if ikeHeader.NextPayload == 0 && ikeHeader.MajorVersion == 0 {
 		return nil, fmt.Errorf("invalid IKE header")
 	}
 
-	// Parse payloads for additional information
-	vendorIDs, proposals := parseIKEPayloads(response[28:n], ikeHeader.NextPayload)
+	vendorIDs, proposals := ikeprotocol.ParseIKEPayloads(response[28:n], ikeHeader.NextPayload)
 
 	version := fmt.Sprintf("IKEv%d", ikeHeader.MajorVersion)
 	initiatorSPI := hex.EncodeToString(ikeHeader.InitiatorSPI[:])
 	responderSPI := hex.EncodeToString(ikeHeader.ResponderSPI[:])
-	exchangeType := getExchangeTypeName(ikeHeader.ExchangeType)
+	exchangeType := ikeprotocol.GetExchangeTypeName(ikeHeader.ExchangeType)
 	flags := fmt.Sprintf("0x%02x", ikeHeader.Flags)
 	messageID := fmt.Sprintf("%d", ikeHeader.MessageID)
 
@@ -86,12 +75,9 @@ func (IKEFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		MessageId:    &messageID,
 	}
 
-	// Add vendor IDs if any were found
 	if len(vendorIDs) > 0 {
 		metadata.VendorIds = vendorIDs
 	}
-
-	// Add security proposal details if found
 	if len(proposals.EncryptionAlgs) > 0 {
 		metadata.EncryptionAlgorithms = proposals.EncryptionAlgs
 	}
@@ -117,355 +103,4 @@ func (IKEFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 	}
 
 	return result, nil
-}
-
-// IKEHeader represents the IKE message header
-type IKEHeader struct {
-	InitiatorSPI [8]byte
-	ResponderSPI [8]byte
-	NextPayload  byte
-	MajorVersion byte
-	MinorVersion byte
-	ExchangeType byte
-	Flags        byte
-	MessageID    uint32
-	Length       uint32
-}
-
-// SecurityProposals holds parsed security association proposals
-type SecurityProposals struct {
-	EncryptionAlgs []string
-	HashAlgs       []string
-	AuthMethods    []string
-	DHGroups       []string
-}
-
-// parseIKEHeader parses the IKE message header
-func parseIKEHeader(data []byte) (*IKEHeader, error) {
-	if len(data) < 28 {
-		return nil, fmt.Errorf("data too short for IKE header")
-	}
-
-	header := &IKEHeader{
-		NextPayload:  data[16],
-		MajorVersion: (data[17] & 0xF0) >> 4,
-		MinorVersion: data[17] & 0x0F,
-		ExchangeType: data[18],
-		Flags:        data[19],
-		MessageID:    binary.BigEndian.Uint32(data[20:24]),
-		Length:       binary.BigEndian.Uint32(data[24:28]),
-	}
-
-	copy(header.InitiatorSPI[:], data[0:8])
-	copy(header.ResponderSPI[:], data[8:16])
-
-	return header, nil
-}
-
-// parseIKEPayloads extracts vendor IDs and security proposals from IKE payloads
-func parseIKEPayloads(data []byte, nextPayload byte) ([]string, *SecurityProposals) {
-	var vendorIDs []string
-	proposals := &SecurityProposals{
-		EncryptionAlgs: []string{},
-		HashAlgs:       []string{},
-		AuthMethods:    []string{},
-		DHGroups:       []string{},
-	}
-
-	currentPayload := nextPayload
-	offset := 0
-
-	for offset < len(data) && currentPayload != 0 {
-		if offset+4 > len(data) {
-			break
-		}
-
-		payloadLength := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
-		if payloadLength < 4 || offset+payloadLength > len(data) {
-			break
-		}
-
-		payloadData := data[offset+4 : offset+payloadLength]
-
-		// Parse vendor ID payloads (type 43)
-		if currentPayload == 43 && len(payloadData) > 0 {
-			vendorID := string(payloadData)
-			// Only add printable vendor IDs
-			if isIKEVendorIDPrintable(vendorID) {
-				vendorIDs = append(vendorIDs, vendorID)
-			} else {
-				// Store as hex if not printable
-				vendorIDs = append(vendorIDs, hex.EncodeToString(payloadData))
-			}
-		}
-
-		// Parse Security Association payloads (type 33)
-		if currentPayload == 33 && len(payloadData) > 0 {
-			parseSAPayload(payloadData, proposals)
-		}
-
-		// Move to next payload
-		currentPayload = data[offset]
-		offset += payloadLength
-	}
-
-	return vendorIDs, proposals
-}
-
-// parseSAPayload extracts security proposals from SA payload
-func parseSAPayload(data []byte, proposals *SecurityProposals) {
-	offset := 0
-	for offset+8 <= len(data) {
-		// Parse proposal
-		proposalLength := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
-		if proposalLength < 8 || offset+proposalLength > len(data) {
-			break
-		}
-
-		numTransforms := int(data[offset+7])
-		transformOffset := offset + 8
-
-		// Parse transforms
-		for i := 0; i < numTransforms && transformOffset+8 <= len(data); i++ {
-			transformLength := int(binary.BigEndian.Uint16(data[transformOffset+2 : transformOffset+4]))
-			if transformLength < 8 {
-				break
-			}
-
-			transformType := data[transformOffset+4]
-			transformID := binary.BigEndian.Uint16(data[transformOffset+6 : transformOffset+8])
-
-			switch transformType {
-			case 1: // Encryption Algorithm
-				proposals.EncryptionAlgs = appendUnique(proposals.EncryptionAlgs, getEncryptionAlgorithmName(transformID))
-			case 2: // PRF (Pseudo-random Function)
-				proposals.HashAlgs = appendUnique(proposals.HashAlgs, getPRFName(transformID))
-			case 3: // Integrity Algorithm
-				proposals.HashAlgs = appendUnique(proposals.HashAlgs, getIntegrityAlgorithmName(transformID))
-			case 4: // Diffie-Hellman Group
-				proposals.DHGroups = appendUnique(proposals.DHGroups, getDHGroupName(transformID))
-			}
-
-			transformOffset += transformLength
-		}
-
-		offset += proposalLength
-	}
-}
-
-// Helper function to append unique strings
-func appendUnique(slice []string, item string) []string {
-	for _, existing := range slice {
-		if existing == item {
-			return slice
-		}
-	}
-	return append(slice, item)
-}
-
-// isIKEVendorIDPrintable checks if a string contains only printable ASCII characters
-func isIKEVendorIDPrintable(s string) bool {
-	for _, r := range s {
-		if r < 32 || r > 126 {
-			return false
-		}
-	}
-	return true
-}
-
-// buildIKEv2SAInitRequest creates an IKEv2 SA_INIT request packet
-func buildIKEv2SAInitRequest() []byte {
-	// IKE header (28 bytes)
-	packet := make([]byte, 28)
-
-	// Initiator SPI (8 bytes) - random
-	initiatorSPI := []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}
-	copy(packet[0:8], initiatorSPI)
-
-	// Responder SPI (8 bytes) - zeros for initial request
-	// Already zeros from make()
-
-	// Next Payload: SA (33)
-	packet[16] = 33
-
-	// Version: 2.0
-	packet[17] = 0x20 // Major: 2, Minor: 0
-
-	// Exchange Type: IKE_SA_INIT (34)
-	packet[18] = 34
-
-	// Flags: Initiator
-	packet[19] = 0x08
-
-	// Message ID: 0
-	// Already zeros
-
-	// Length: 28 (just header for simple detection)
-	binary.BigEndian.PutUint32(packet[24:28], 28)
-
-	return packet
-}
-
-// getExchangeTypeName returns the human-readable name for an exchange type
-func getExchangeTypeName(exchangeType byte) string {
-	switch exchangeType {
-	case 34:
-		return "IKE_SA_INIT"
-	case 35:
-		return "IKE_AUTH"
-	case 36:
-		return "CREATE_CHILD_SA"
-	case 37:
-		return "INFORMATIONAL"
-	default:
-		return fmt.Sprintf("UNKNOWN_%d", exchangeType)
-	}
-}
-
-// getEncryptionAlgorithmName returns the name for an encryption algorithm ID
-func getEncryptionAlgorithmName(id uint16) string {
-	switch id {
-	case 1:
-		return "DES-CBC"
-	case 2:
-		return "IDEA-CBC"
-	case 3:
-		return "Blowfish-CBC"
-	case 5:
-		return "3DES-CBC"
-	case 7:
-		return "CAST-CBC"
-	case 11:
-		return "NULL"
-	case 12:
-		return "AES-CBC"
-	case 13:
-		return "AES-CTR"
-	case 18:
-		return "AES-GCM-8"
-	case 19:
-		return "AES-GCM-12"
-	case 20:
-		return "AES-GCM-16"
-	case 23:
-		return "Camellia-CBC"
-	case 28:
-		return "ChaCha20-Poly1305"
-	default:
-		return fmt.Sprintf("ENC_%d", id)
-	}
-}
-
-// getPRFName returns the name for a PRF algorithm ID
-func getPRFName(id uint16) string {
-	switch id {
-	case 1:
-		return "PRF-HMAC-MD5"
-	case 2:
-		return "PRF-HMAC-SHA1"
-	case 3:
-		return "PRF-HMAC-TIGER"
-	case 4:
-		return "PRF-AES128-XCBC"
-	case 5:
-		return "PRF-HMAC-SHA256"
-	case 6:
-		return "PRF-HMAC-SHA384"
-	case 7:
-		return "PRF-HMAC-SHA512"
-	case 8:
-		return "PRF-AES128-CMAC"
-	default:
-		return fmt.Sprintf("PRF_%d", id)
-	}
-}
-
-// getIntegrityAlgorithmName returns the name for an integrity algorithm ID
-func getIntegrityAlgorithmName(id uint16) string {
-	switch id {
-	case 0:
-		return "NONE"
-	case 1:
-		return "HMAC-MD5-96"
-	case 2:
-		return "HMAC-SHA1-96"
-	case 3:
-		return "DES-MAC"
-	case 4:
-		return "KPDK-MD5"
-	case 5:
-		return "AES-XCBC-96"
-	case 6:
-		return "HMAC-MD5-128"
-	case 7:
-		return "HMAC-SHA1-160"
-	case 8:
-		return "AES-CMAC-96"
-	case 9:
-		return "AES-128-GMAC"
-	case 10:
-		return "AES-192-GMAC"
-	case 11:
-		return "AES-256-GMAC"
-	case 12:
-		return "HMAC-SHA256-128"
-	case 13:
-		return "HMAC-SHA384-192"
-	case 14:
-		return "HMAC-SHA512-256"
-	default:
-		return fmt.Sprintf("AUTH_%d", id)
-	}
-}
-
-// getDHGroupName returns the name for a Diffie-Hellman group ID
-func getDHGroupName(id uint16) string {
-	switch id {
-	case 1:
-		return "MODP-768"
-	case 2:
-		return "MODP-1024"
-	case 5:
-		return "MODP-1536"
-	case 14:
-		return "MODP-2048"
-	case 15:
-		return "MODP-3072"
-	case 16:
-		return "MODP-4096"
-	case 17:
-		return "MODP-6144"
-	case 18:
-		return "MODP-8192"
-	case 19:
-		return "ECP-256"
-	case 20:
-		return "ECP-384"
-	case 21:
-		return "ECP-521"
-	case 22:
-		return "MODP-1024-160"
-	case 23:
-		return "MODP-2048-224"
-	case 24:
-		return "MODP-2048-256"
-	case 25:
-		return "ECP-192"
-	case 26:
-		return "ECP-224"
-	case 27:
-		return "ECP-224-BP"
-	case 28:
-		return "ECP-256-BP"
-	case 29:
-		return "ECP-384-BP"
-	case 30:
-		return "ECP-512-BP"
-	case 31:
-		return "Curve25519"
-	case 32:
-		return "Curve448"
-	default:
-		return fmt.Sprintf("DH_%d", id)
-	}
 }

--- a/internal/enumerate/engine.go
+++ b/internal/enumerate/engine.go
@@ -13,6 +13,7 @@ import (
 	// Internal
 	ftp "github.com/Method-Security/networkscan/internal/enumerate/ftp"
 	grpc "github.com/Method-Security/networkscan/internal/enumerate/grpc"
+	ike "github.com/Method-Security/networkscan/internal/enumerate/ike"
 	ldap "github.com/Method-Security/networkscan/internal/enumerate/ldap"
 	smb "github.com/Method-Security/networkscan/internal/enumerate/smb"
 	smtp "github.com/Method-Security/networkscan/internal/enumerate/smtp"
@@ -143,6 +144,8 @@ func getEngine(serviceType enumeratefern.SupportedServiceType) (NetworkApplicati
 		return NetworkApplicationEngine{Library: &smb.LibraryEnumerateSMB{}}, nil
 	case enumeratefern.SupportedServiceTypeLdap:
 		return NetworkApplicationEngine{Library: &ldap.LibraryEnumerateLDAP{}}, nil
+	case enumeratefern.SupportedServiceTypeIke:
+		return NetworkApplicationEngine{Library: &ike.LibraryEnumerateIKE{}}, nil
 	default:
 		return NetworkApplicationEngine{}, fmt.Errorf("unsupported network application: %v", serviceType)
 	}

--- a/internal/enumerate/ike/constants.go
+++ b/internal/enumerate/ike/constants.go
@@ -1,0 +1,39 @@
+package ike
+
+// knownVendorIDs maps known IKE Vendor ID hex strings to human-readable names.
+// These are MD5 hashes standardized by vendors for capability advertisement.
+var knownVendorIDs = map[string]string{
+	"afcad71368a1f1c96b8696fc77570100": "Dead Peer Detection (RFC 3706)",
+	"4a131c81070358455c5728f20e95452f": "NAT-T (RFC 3947)",
+	"cd60464335df21f87cfdb2fc68b6a448": "XAUTH",
+	"12f5f28c457168a9702d9fe274cc0100": "Cisco Unity",
+	"1e2b516905991c7d7c96fcbfb587e461": "Cisco VPN 3000",
+	"c0f8f3a4c20f75ef0bb6a96a697d0aff": "Fortinet",
+	"882fe56d6fd20dbc2251613b2ebe5beb": "strongSwan",
+	"699369228741c6d4ca094c93e242c9de": "Microsoft Windows",
+	"4048b7d56ebce88525e7de7f00d6c2d3": "Check Point",
+}
+
+// dpdVendorIDPrefix is the well-known prefix for Dead Peer Detection vendor IDs.
+const dpdVendorIDPrefix = "afcad71368a1f1c96b8696fc7757"
+
+// weakEncryptionAlgorithms are encryption algorithms considered cryptographically insecure.
+var weakEncryptionAlgorithms = []string{
+	"DES-CBC",
+	"NULL",
+}
+
+// weakHashAlgorithms are hash/integrity algorithms considered cryptographically weak.
+var weakHashAlgorithms = []string{
+	"PRF-HMAC-MD5",
+	"HMAC-MD5-96",
+	"PRF-HMAC-SHA1",
+	"HMAC-SHA1-96",
+}
+
+// weakDHGroups are Diffie-Hellman groups that are too small to be secure.
+var weakDHGroups = []string{
+	"MODP-768",  // 768-bit, considered broken
+	"MODP-1024", // 1024-bit, broken by Logjam attack
+	"MODP-1536", // 1536-bit, considered marginal
+}

--- a/internal/enumerate/ike/helpers.go
+++ b/internal/enumerate/ike/helpers.go
@@ -1,0 +1,407 @@
+package ike
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// --- UDP Probe ---
+// probeUDP sends a UDP packet to addr and returns the response.
+func probeUDP(ctx context.Context, addr string, packet []byte) ([]byte, error) {
+	timeout := 5 * time.Second
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < timeout {
+			timeout = remaining
+		}
+	}
+	if timeout <= 0 {
+		return nil, context.DeadlineExceeded
+	}
+	conn, err := net.DialTimeout("udp", addr, timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetReadDeadline(deadline)
+	} else {
+		_ = conn.SetReadDeadline(time.Now().Add(timeout))
+	}
+	if _, err := conn.Write(packet); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+// --- IKEv2 Packet Builder ---
+// buildIKEv2SAInitRequest creates a minimal IKEv2 IKE_SA_INIT request.
+func buildIKEv2SAInitRequest() []byte {
+	packet := make([]byte, 28)
+	copy(packet[0:8], []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}) // initiator SPI
+	packet[16] = 33                                                           // next payload: SA
+	packet[17] = 0x20                                                         // version: IKEv2
+	packet[18] = 34                                                           // exchange type: IKE_SA_INIT
+	packet[19] = 0x08                                                         // flags: initiator
+	binary.BigEndian.PutUint32(packet[24:28], 28)
+	return packet
+}
+
+// --- IKEv1 Aggressive Mode Packet Builder ---
+// buildIKEv1AggressiveModeProbe creates an IKEv1 Aggressive Mode probe packet.
+// It proposes DES-CBC + MD5 + PSK + MODP-768 — the weakest common set — to
+// maximize the chance that a configured server will accept and respond.
+func buildIKEv1AggressiveModeProbe() []byte {
+	// Transform: DES-CBC / MD5 / PSK / DH-Group1 (MODP-768)
+	// Attributes use TV (Type-Value) format: MSB of type byte = 1
+	transform := []byte{
+		0x00, 0x00, 0x00, 0x20, // next=0(last), reserved, len=32
+		0x01, 0x01, 0x00, 0x00, // transform#=1, ID=KEY_IKE, reserved2
+		0x80, 0x01, 0x00, 0x01, // Encryption: DES-CBC
+		0x80, 0x02, 0x00, 0x01, // Hash: MD5
+		0x80, 0x03, 0x00, 0x01, // Auth: PSK
+		0x80, 0x04, 0x00, 0x01, // DH Group: MODP-768
+		0x80, 0x0b, 0x00, 0x01, // Life Type: seconds
+		0x80, 0x0c, 0x70, 0x80, // Life Duration: 28800s (TV format)
+	}
+	// Proposal: protocol=ISAKMP, SPI-size=0, 1 transform
+	proposal := make([]byte, 8+len(transform))
+	proposal[4] = 0x01 // proposal #1
+	proposal[5] = 0x01 // protocol: ISAKMP
+	proposal[6] = 0x00 // SPI size: 0
+	proposal[7] = 0x01 // # transforms: 1
+	binary.BigEndian.PutUint16(proposal[2:4], uint16(len(proposal)))
+	copy(proposal[8:], transform)
+	// SA payload: next=KE(4), DOI=IPSEC, Situation=SIT_IDENTITY_ONLY
+	saPayload := make([]byte, 4+4+4+len(proposal))
+	saPayload[0] = 0x04 // next: KE
+	binary.BigEndian.PutUint16(saPayload[2:4], uint16(len(saPayload)))
+	binary.BigEndian.PutUint32(saPayload[4:8], 1)  // DOI: IPSEC
+	binary.BigEndian.PutUint32(saPayload[8:12], 1) // Situation: SIT_IDENTITY_ONLY
+	copy(saPayload[12:], proposal)
+	// KE payload: MODP-768 = 96 bytes of zeros; next=Nonce(10)
+	kePayload := make([]byte, 4+96)
+	kePayload[0] = 0x0a // next: Nonce
+	binary.BigEndian.PutUint16(kePayload[2:4], uint16(len(kePayload)))
+	// Nonce payload: 16 zero bytes; next=ID(5)
+	noncePayload := make([]byte, 4+16)
+	noncePayload[0] = 0x05 // next: ID
+	binary.BigEndian.PutUint16(noncePayload[2:4], uint16(len(noncePayload)))
+	// ID payload: ID_IPV4_ADDR for 192.168.0.1; next=0(none)
+	idPayload := []byte{
+		0x00, 0x00, 0x00, 0x0c, // next=0, reserved, len=12
+		0x01, 0x00, 0x00, 0x00, // ID_IPV4_ADDR, protocol=0, port=0
+		0xc0, 0xa8, 0x00, 0x01, // 192.168.0.1
+	}
+	body := append(saPayload, kePayload...)
+	body = append(body, noncePayload...)
+	body = append(body, idPayload...)
+	// IKE header
+	header := make([]byte, 28)
+	copy(header[0:8], []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}) // initiator SPI
+	header[16] = 0x01                                                         // next payload: SA
+	header[17] = 0x10                                                         // version: IKEv1
+	header[18] = 0x04                                                         // exchange type: Aggressive Mode
+	binary.BigEndian.PutUint32(header[24:28], uint32(28+len(body)))
+	return append(header, body...)
+}
+
+// --- IKE Header Parsing (shared with discover plugin) ---
+// IKEHeader represents the parsed IKE message header.
+type IKEHeader struct {
+	InitiatorSPI [8]byte
+	ResponderSPI [8]byte
+	NextPayload  byte
+	MajorVersion byte
+	MinorVersion byte
+	ExchangeType byte
+	Flags        byte
+	MessageID    uint32
+	Length       uint32
+}
+
+// parseIKEHeader parses the 28-byte IKE message header.
+func parseIKEHeader(data []byte) (*IKEHeader, error) {
+	if len(data) < 28 {
+		return nil, fmt.Errorf("data too short for IKE header: %d bytes", len(data))
+	}
+	h := &IKEHeader{
+		NextPayload:  data[16],
+		MajorVersion: (data[17] & 0xF0) >> 4,
+		MinorVersion: data[17] & 0x0F,
+		ExchangeType: data[18],
+		Flags:        data[19],
+		MessageID:    binary.BigEndian.Uint32(data[20:24]),
+		Length:       binary.BigEndian.Uint32(data[24:28]),
+	}
+	copy(h.InitiatorSPI[:], data[0:8])
+	copy(h.ResponderSPI[:], data[8:16])
+	return h, nil
+}
+
+// isIKEv1AggressiveResponse checks if a raw IKE response is an IKEv1 Aggressive Mode reply.
+func isIKEv1AggressiveResponse(data []byte) (aggressiveMode bool, ikev1Supported bool) {
+	if len(data) < 28 {
+		return false, false
+	}
+	majorVersion := (data[17] & 0xF0) >> 4
+	exchangeType := data[18]
+	if majorVersion == 1 {
+		ikev1Supported = true
+		aggressiveMode = exchangeType == 4
+	}
+	return aggressiveMode, ikev1Supported
+}
+
+// --- Payload Parsing (shared with discover plugin) ---
+// SecurityProposals holds parsed IKE security association proposals.
+type SecurityProposals struct {
+	EncryptionAlgs []string
+	HashAlgs       []string
+	AuthMethods    []string
+	DHGroups       []string
+}
+
+// parseIKEPayloads extracts vendor IDs and SA proposals from the payload section.
+func parseIKEPayloads(data []byte, nextPayload byte) ([]string, *SecurityProposals) {
+	var vendorIDs []string
+	proposals := &SecurityProposals{}
+	current := nextPayload
+	offset := 0
+	for offset < len(data) && current != 0 {
+		if offset+4 > len(data) {
+			break
+		}
+		payloadLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		if payloadLen < 4 || offset+payloadLen > len(data) {
+			break
+		}
+		payload := data[offset+4 : offset+payloadLen]
+		switch current {
+		case 43: // Vendor ID
+			if len(payload) > 0 {
+				h := hex.EncodeToString(payload)
+				if isAllPrintable(string(payload)) {
+					vendorIDs = append(vendorIDs, string(payload))
+				} else {
+					vendorIDs = append(vendorIDs, h)
+				}
+			}
+		case 33: // Security Association (IKEv2)
+			parseSAPayload(payload, proposals)
+		}
+		current = data[offset]
+		offset += payloadLen
+	}
+	return vendorIDs, proposals
+}
+func parseSAPayload(data []byte, proposals *SecurityProposals) {
+	offset := 0
+	for offset+8 <= len(data) {
+		proposalLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		if proposalLen < 8 || offset+proposalLen > len(data) {
+			break
+		}
+		numTransforms := int(data[offset+7])
+		txOffset := offset + 8
+		for i := 0; i < numTransforms && txOffset+8 <= len(data); i++ {
+			txLen := int(binary.BigEndian.Uint16(data[txOffset+2 : txOffset+4]))
+			if txLen < 8 {
+				break
+			}
+			txType := data[txOffset+4]
+			txID := binary.BigEndian.Uint16(data[txOffset+6 : txOffset+8])
+			switch txType {
+			case 1:
+				proposals.EncryptionAlgs = appendUnique(proposals.EncryptionAlgs, getEncryptionAlgorithmName(txID))
+			case 2:
+				proposals.HashAlgs = appendUnique(proposals.HashAlgs, getPRFName(txID))
+			case 3:
+				proposals.HashAlgs = appendUnique(proposals.HashAlgs, getIntegrityAlgorithmName(txID))
+			case 4:
+				proposals.DHGroups = appendUnique(proposals.DHGroups, getDHGroupName(txID))
+			}
+			txOffset += txLen
+		}
+		offset += proposalLen
+	}
+}
+
+// --- Security Assessment Helpers ---
+// detectWeakAlgorithms returns a list of weak algorithm names found in the SA proposals.
+func detectWeakAlgorithms(encAlgs, hashAlgs, dhGroups []string) []string {
+	var weak []string
+	for _, alg := range encAlgs {
+		for _, w := range weakEncryptionAlgorithms {
+			if alg == w {
+				weak = appendUnique(weak, alg)
+			}
+		}
+	}
+	for _, alg := range hashAlgs {
+		for _, w := range weakHashAlgorithms {
+			if alg == w {
+				weak = appendUnique(weak, alg)
+			}
+		}
+	}
+	for _, g := range dhGroups {
+		for _, w := range weakDHGroups {
+			if g == w {
+				weak = appendUnique(weak, g)
+			}
+		}
+	}
+	return weak
+}
+
+// checkDPDSupport returns true if any vendor ID matches the Dead Peer Detection magic.
+func checkDPDSupport(vendorIDs []string) bool {
+	for _, vid := range vendorIDs {
+		lower := strings.ToLower(vid)
+		if strings.HasPrefix(lower, dpdVendorIDPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractVendorIdentification returns a human-readable vendor name if any vendor ID is recognized.
+func extractVendorIdentification(vendorIDs []string) *string {
+	for _, vid := range vendorIDs {
+		lower := strings.ToLower(vid)
+		if name, ok := knownVendorIDs[lower]; ok {
+			return &name
+		}
+	}
+	return nil
+}
+
+// --- Algorithm Name Maps (from RFC 7296 / IANA IKEv2 registries) ---
+func getExchangeTypeName(t byte) string {
+	switch t {
+	case 34:
+		return "IKE_SA_INIT"
+	case 35:
+		return "IKE_AUTH"
+	case 36:
+		return "CREATE_CHILD_SA"
+	case 37:
+		return "INFORMATIONAL"
+	default:
+		return fmt.Sprintf("UNKNOWN_%d", t)
+	}
+}
+func getEncryptionAlgorithmName(id uint16) string {
+	switch id {
+	case 1:
+		return "DES-CBC"
+	case 5:
+		return "3DES-CBC"
+	case 11:
+		return "NULL"
+	case 12:
+		return "AES-CBC"
+	case 13:
+		return "AES-CTR"
+	case 18:
+		return "AES-GCM-8"
+	case 19:
+		return "AES-GCM-12"
+	case 20:
+		return "AES-GCM-16"
+	case 28:
+		return "ChaCha20-Poly1305"
+	default:
+		return fmt.Sprintf("ENC_%d", id)
+	}
+}
+func getPRFName(id uint16) string {
+	switch id {
+	case 1:
+		return "PRF-HMAC-MD5"
+	case 2:
+		return "PRF-HMAC-SHA1"
+	case 5:
+		return "PRF-HMAC-SHA256"
+	case 6:
+		return "PRF-HMAC-SHA384"
+	case 7:
+		return "PRF-HMAC-SHA512"
+	default:
+		return fmt.Sprintf("PRF_%d", id)
+	}
+}
+func getIntegrityAlgorithmName(id uint16) string {
+	switch id {
+	case 0:
+		return "NONE"
+	case 1:
+		return "HMAC-MD5-96"
+	case 2:
+		return "HMAC-SHA1-96"
+	case 12:
+		return "HMAC-SHA256-128"
+	case 13:
+		return "HMAC-SHA384-192"
+	case 14:
+		return "HMAC-SHA512-256"
+	default:
+		return fmt.Sprintf("AUTH_%d", id)
+	}
+}
+func getDHGroupName(id uint16) string {
+	switch id {
+	case 1:
+		return "MODP-768"
+	case 2:
+		return "MODP-1024"
+	case 5:
+		return "MODP-1536"
+	case 14:
+		return "MODP-2048"
+	case 15:
+		return "MODP-3072"
+	case 16:
+		return "MODP-4096"
+	case 19:
+		return "ECP-256"
+	case 20:
+		return "ECP-384"
+	case 21:
+		return "ECP-521"
+	case 31:
+		return "Curve25519"
+	case 32:
+		return "Curve448"
+	default:
+		return fmt.Sprintf("DH_%d", id)
+	}
+}
+
+// --- Utility ---
+func appendUnique(slice []string, item string) []string {
+	for _, s := range slice {
+		if s == item {
+			return slice
+		}
+	}
+	return append(slice, item)
+}
+func isAllPrintable(s string) bool {
+	for _, r := range s {
+		if r < 32 || r > 126 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/enumerate/ike/helpers.go
+++ b/internal/enumerate/ike/helpers.go
@@ -3,11 +3,11 @@ package ike
 import (
 	"context"
 	"encoding/binary"
-	"encoding/hex"
-	"fmt"
 	"net"
 	"strings"
 	"time"
+
+	ikeprotocol "github.com/Method-Security/networkscan/internal/protocol/ike"
 )
 
 // --- UDP Probe ---
@@ -41,19 +41,6 @@ func probeUDP(ctx context.Context, addr string, packet []byte) ([]byte, error) {
 		return nil, err
 	}
 	return buf[:n], nil
-}
-
-// --- IKEv2 Packet Builder ---
-// buildIKEv2SAInitRequest creates a minimal IKEv2 IKE_SA_INIT request.
-func buildIKEv2SAInitRequest() []byte {
-	packet := make([]byte, 28)
-	copy(packet[0:8], []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}) // initiator SPI
-	packet[16] = 33                                                           // next payload: SA
-	packet[17] = 0x20                                                         // version: IKEv2
-	packet[18] = 34                                                           // exchange type: IKE_SA_INIT
-	packet[19] = 0x08                                                         // flags: initiator
-	binary.BigEndian.PutUint32(packet[24:28], 28)
-	return packet
 }
 
 // --- IKEv1 Aggressive Mode Packet Builder ---
@@ -115,39 +102,6 @@ func buildIKEv1AggressiveModeProbe() []byte {
 	return append(header, body...)
 }
 
-// --- IKE Header Parsing (shared with discover plugin) ---
-// IKEHeader represents the parsed IKE message header.
-type IKEHeader struct {
-	InitiatorSPI [8]byte
-	ResponderSPI [8]byte
-	NextPayload  byte
-	MajorVersion byte
-	MinorVersion byte
-	ExchangeType byte
-	Flags        byte
-	MessageID    uint32
-	Length       uint32
-}
-
-// parseIKEHeader parses the 28-byte IKE message header.
-func parseIKEHeader(data []byte) (*IKEHeader, error) {
-	if len(data) < 28 {
-		return nil, fmt.Errorf("data too short for IKE header: %d bytes", len(data))
-	}
-	h := &IKEHeader{
-		NextPayload:  data[16],
-		MajorVersion: (data[17] & 0xF0) >> 4,
-		MinorVersion: data[17] & 0x0F,
-		ExchangeType: data[18],
-		Flags:        data[19],
-		MessageID:    binary.BigEndian.Uint32(data[20:24]),
-		Length:       binary.BigEndian.Uint32(data[24:28]),
-	}
-	copy(h.InitiatorSPI[:], data[0:8])
-	copy(h.ResponderSPI[:], data[8:16])
-	return h, nil
-}
-
 // isIKEv1AggressiveResponse checks if a raw IKE response is an IKEv1 Aggressive Mode reply.
 func isIKEv1AggressiveResponse(data []byte) (aggressiveMode bool, ikev1Supported bool) {
 	if len(data) < 28 {
@@ -162,80 +116,6 @@ func isIKEv1AggressiveResponse(data []byte) (aggressiveMode bool, ikev1Supported
 	return aggressiveMode, ikev1Supported
 }
 
-// --- Payload Parsing (shared with discover plugin) ---
-// SecurityProposals holds parsed IKE security association proposals.
-type SecurityProposals struct {
-	EncryptionAlgs []string
-	HashAlgs       []string
-	AuthMethods    []string
-	DHGroups       []string
-}
-
-// parseIKEPayloads extracts vendor IDs and SA proposals from the payload section.
-func parseIKEPayloads(data []byte, nextPayload byte) ([]string, *SecurityProposals) {
-	var vendorIDs []string
-	proposals := &SecurityProposals{}
-	current := nextPayload
-	offset := 0
-	for offset < len(data) && current != 0 {
-		if offset+4 > len(data) {
-			break
-		}
-		payloadLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
-		if payloadLen < 4 || offset+payloadLen > len(data) {
-			break
-		}
-		payload := data[offset+4 : offset+payloadLen]
-		switch current {
-		case 43: // Vendor ID
-			if len(payload) > 0 {
-				h := hex.EncodeToString(payload)
-				if isAllPrintable(string(payload)) {
-					vendorIDs = append(vendorIDs, string(payload))
-				} else {
-					vendorIDs = append(vendorIDs, h)
-				}
-			}
-		case 33: // Security Association (IKEv2)
-			parseSAPayload(payload, proposals)
-		}
-		current = data[offset]
-		offset += payloadLen
-	}
-	return vendorIDs, proposals
-}
-func parseSAPayload(data []byte, proposals *SecurityProposals) {
-	offset := 0
-	for offset+8 <= len(data) {
-		proposalLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
-		if proposalLen < 8 || offset+proposalLen > len(data) {
-			break
-		}
-		numTransforms := int(data[offset+7])
-		txOffset := offset + 8
-		for i := 0; i < numTransforms && txOffset+8 <= len(data); i++ {
-			txLen := int(binary.BigEndian.Uint16(data[txOffset+2 : txOffset+4]))
-			if txLen < 8 {
-				break
-			}
-			txType := data[txOffset+4]
-			txID := binary.BigEndian.Uint16(data[txOffset+6 : txOffset+8])
-			switch txType {
-			case 1:
-				proposals.EncryptionAlgs = appendUnique(proposals.EncryptionAlgs, getEncryptionAlgorithmName(txID))
-			case 2:
-				proposals.HashAlgs = appendUnique(proposals.HashAlgs, getPRFName(txID))
-			case 3:
-				proposals.HashAlgs = appendUnique(proposals.HashAlgs, getIntegrityAlgorithmName(txID))
-			case 4:
-				proposals.DHGroups = appendUnique(proposals.DHGroups, getDHGroupName(txID))
-			}
-			txOffset += txLen
-		}
-		offset += proposalLen
-	}
-}
-
 // --- Security Assessment Helpers ---
 // detectWeakAlgorithms returns a list of weak algorithm names found in the SA proposals.
 func detectWeakAlgorithms(encAlgs, hashAlgs, dhGroups []string) []string {
@@ -243,21 +123,21 @@ func detectWeakAlgorithms(encAlgs, hashAlgs, dhGroups []string) []string {
 	for _, alg := range encAlgs {
 		for _, w := range weakEncryptionAlgorithms {
 			if alg == w {
-				weak = appendUnique(weak, alg)
+				weak = ikeprotocol.AppendUnique(weak, alg)
 			}
 		}
 	}
 	for _, alg := range hashAlgs {
 		for _, w := range weakHashAlgorithms {
 			if alg == w {
-				weak = appendUnique(weak, alg)
+				weak = ikeprotocol.AppendUnique(weak, alg)
 			}
 		}
 	}
 	for _, g := range dhGroups {
 		for _, w := range weakDHGroups {
 			if g == w {
-				weak = appendUnique(weak, g)
+				weak = ikeprotocol.AppendUnique(weak, g)
 			}
 		}
 	}
@@ -284,124 +164,4 @@ func extractVendorIdentification(vendorIDs []string) *string {
 		}
 	}
 	return nil
-}
-
-// --- Algorithm Name Maps (from RFC 7296 / IANA IKEv2 registries) ---
-func getExchangeTypeName(t byte) string {
-	switch t {
-	case 34:
-		return "IKE_SA_INIT"
-	case 35:
-		return "IKE_AUTH"
-	case 36:
-		return "CREATE_CHILD_SA"
-	case 37:
-		return "INFORMATIONAL"
-	default:
-		return fmt.Sprintf("UNKNOWN_%d", t)
-	}
-}
-func getEncryptionAlgorithmName(id uint16) string {
-	switch id {
-	case 1:
-		return "DES-CBC"
-	case 5:
-		return "3DES-CBC"
-	case 11:
-		return "NULL"
-	case 12:
-		return "AES-CBC"
-	case 13:
-		return "AES-CTR"
-	case 18:
-		return "AES-GCM-8"
-	case 19:
-		return "AES-GCM-12"
-	case 20:
-		return "AES-GCM-16"
-	case 28:
-		return "ChaCha20-Poly1305"
-	default:
-		return fmt.Sprintf("ENC_%d", id)
-	}
-}
-func getPRFName(id uint16) string {
-	switch id {
-	case 1:
-		return "PRF-HMAC-MD5"
-	case 2:
-		return "PRF-HMAC-SHA1"
-	case 5:
-		return "PRF-HMAC-SHA256"
-	case 6:
-		return "PRF-HMAC-SHA384"
-	case 7:
-		return "PRF-HMAC-SHA512"
-	default:
-		return fmt.Sprintf("PRF_%d", id)
-	}
-}
-func getIntegrityAlgorithmName(id uint16) string {
-	switch id {
-	case 0:
-		return "NONE"
-	case 1:
-		return "HMAC-MD5-96"
-	case 2:
-		return "HMAC-SHA1-96"
-	case 12:
-		return "HMAC-SHA256-128"
-	case 13:
-		return "HMAC-SHA384-192"
-	case 14:
-		return "HMAC-SHA512-256"
-	default:
-		return fmt.Sprintf("AUTH_%d", id)
-	}
-}
-func getDHGroupName(id uint16) string {
-	switch id {
-	case 1:
-		return "MODP-768"
-	case 2:
-		return "MODP-1024"
-	case 5:
-		return "MODP-1536"
-	case 14:
-		return "MODP-2048"
-	case 15:
-		return "MODP-3072"
-	case 16:
-		return "MODP-4096"
-	case 19:
-		return "ECP-256"
-	case 20:
-		return "ECP-384"
-	case 21:
-		return "ECP-521"
-	case 31:
-		return "Curve25519"
-	case 32:
-		return "Curve448"
-	default:
-		return fmt.Sprintf("DH_%d", id)
-	}
-}
-
-// --- Utility ---
-func appendUnique(slice []string, item string) []string {
-	for _, s := range slice {
-		if s == item {
-			return slice
-		}
-	}
-	return append(slice, item)
-}
-func isAllPrintable(s string) bool {
-	for _, r := range s {
-		if r < 32 || r > 126 {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/enumerate/ike/ike.go
+++ b/internal/enumerate/ike/ike.go
@@ -85,10 +85,13 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 			svc1log.SafeParam("aggressiveMode", aggressiveMode),
 			svc1log.SafeParam("ikev1", ikev1))
 	}
-	// NAT-T probe on UDP 4500 (only if not already probing 4500)
+	// NAT-T probe on UDP 4500 (only if not already probing 4500).
+	// RFC 3948 §2.3 requires a 4-byte Non-ESP marker (0x00000000) before IKE
+	// packets on port 4500; without it the receiver treats the initiator SPI
+	// bytes as an ESP SPI and silently drops the packet.
 	if portStr != "4500" {
 		natTarget := net.JoinHostPort(host, "4500")
-		_, natErr := probeUDP(ctx, natTarget, ikeprotocol.BuildIKEv2SAInitRequest())
+		_, natErr := probeUDP(ctx, natTarget, ikeprotocol.BuildNATTIKEv2SAInitRequest())
 		if natErr == nil {
 			natT := true
 			serverInfo.NatTraversalSupported = &natT

--- a/internal/enumerate/ike/ike.go
+++ b/internal/enumerate/ike/ike.go
@@ -1,0 +1,111 @@
+package ike
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strconv"
+
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
+	ikefern "github.com/Method-Security/networkscan/generated/go/enumerate/ike"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// LibraryEnumerateIKE implements NetworkApplicationLibrary for IKE enumeration.
+type LibraryEnumerateIKE struct{}
+
+// EnumerateTarget Overview:
+// 1. Parse target host:port
+// 2. Probe with IKEv2 SA_INIT → detect IKEv2 support, extract SA proposals and vendor IDs
+// 3. Probe with IKEv1 Aggressive Mode → detect IKEv1 and Aggressive Mode support
+// 4. If target port is not 4500, probe UDP 4500 → detect NAT-T capability
+// 5. Analyze vendor IDs for DPD support and vendor identification
+// 6. Scan SA proposals for weak algorithms
+func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string) (*enumeratefern.EnumerateServiceDetails, []string) {
+	log := svc1log.FromContext(ctx)
+	var serverInfo commonprotocolfern.IkeServerInfo
+	var details ikefern.EnumerateIkeDetails
+	errors := []string{}
+	host, portStr, err := net.SplitHostPort(target)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("invalid target %q: %v", target, err))
+		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateIkeDetails(&details), errors
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("invalid port in target %q: %v", target, err))
+		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateIkeDetails(&details), errors
+	}
+	details.Target = host
+	details.Port = port
+	// IKEv2 probe
+	ikev2Response, err := probeUDP(ctx, target, buildIKEv2SAInitRequest())
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("IKEv2 probe failed on %s: %v", target, err))
+		log.Warn("IKEv2 probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
+	} else if len(ikev2Response) >= 28 {
+		ikev2 := true
+		serverInfo.Ikev2Supported = &ikev2
+		log.Info("IKEv2 response received", svc1log.SafeParam("target", target))
+		if header, parseErr := parseIKEHeader(ikev2Response); parseErr == nil {
+			version := fmt.Sprintf("IKEv%d", header.MajorVersion)
+			initiatorSPI := hex.EncodeToString(header.InitiatorSPI[:])
+			responderSPI := hex.EncodeToString(header.ResponderSPI[:])
+			exchangeType := getExchangeTypeName(header.ExchangeType)
+			flags := fmt.Sprintf("0x%02x", header.Flags)
+			messageID := fmt.Sprintf("%d", header.MessageID)
+			serverInfo.Version = &version
+			serverInfo.InitiatorSpi = &initiatorSPI
+			serverInfo.ResponderSpi = &responderSPI
+			serverInfo.ExchangeType = &exchangeType
+			serverInfo.Flags = &flags
+			serverInfo.MessageId = &messageID
+			vendorIDs, proposals := parseIKEPayloads(ikev2Response[28:], header.NextPayload)
+			serverInfo.VendorIds = vendorIDs
+			serverInfo.EncryptionAlgorithms = proposals.EncryptionAlgs
+			serverInfo.HashAlgorithms = proposals.HashAlgs
+			serverInfo.AuthenticationMethods = proposals.AuthMethods
+			serverInfo.DhGroups = proposals.DHGroups
+		}
+	}
+	// IKEv1 Aggressive Mode probe
+	amResponse, err := probeUDP(ctx, target, buildIKEv1AggressiveModeProbe())
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("IKEv1 AM probe failed on %s: %v", target, err))
+		log.Warn("IKEv1 AM probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
+	} else if len(amResponse) >= 28 {
+		aggressiveMode, ikev1 := isIKEv1AggressiveResponse(amResponse)
+		serverInfo.AggressiveModeEnabled = &aggressiveMode
+		serverInfo.Ikev1Supported = &ikev1
+		log.Info("IKEv1 AM probe response",
+			svc1log.SafeParam("target", target),
+			svc1log.SafeParam("aggressiveMode", aggressiveMode),
+			svc1log.SafeParam("ikev1", ikev1))
+	}
+	// NAT-T probe on UDP 4500 (only if not already probing 4500)
+	if portStr != "4500" {
+		natTarget := net.JoinHostPort(host, "4500")
+		_, natErr := probeUDP(ctx, natTarget, buildIKEv2SAInitRequest())
+		if natErr == nil {
+			natT := true
+			serverInfo.NatTraversalSupported = &natT
+			log.Info("NAT-T port 4500 responded", svc1log.SafeParam("host", host))
+		}
+	}
+	// Vendor ID analysis
+	if len(serverInfo.VendorIds) > 0 {
+		dpd := checkDPDSupport(serverInfo.VendorIds)
+		serverInfo.DeadPeerDetectionSupported = &dpd
+		serverInfo.VendorIdentification = extractVendorIdentification(serverInfo.VendorIds)
+	}
+	// Weak algorithm detection
+	serverInfo.WeakAlgorithmsDetected = detectWeakAlgorithms(
+		serverInfo.EncryptionAlgorithms,
+		serverInfo.HashAlgorithms,
+		serverInfo.DhGroups,
+	)
+	details.ServerInfo = &serverInfo
+	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateIkeDetails(&details), errors
+}

--- a/internal/enumerate/ike/ike.go
+++ b/internal/enumerate/ike/ike.go
@@ -47,10 +47,10 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 		errors = append(errors, fmt.Sprintf("IKEv2 probe failed on %s: %v", target, err))
 		log.Warn("IKEv2 probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
 	} else if len(ikev2Response) >= 28 {
-		ikev2 := true
-		serverInfo.Ikev2Supported = &ikev2
-		log.Info("IKEv2 response received", svc1log.SafeParam("target", target))
 		if header, parseErr := ikeprotocol.ParseIKEHeader(ikev2Response); parseErr == nil {
+			ikev2 := header.MajorVersion == 2
+			serverInfo.Ikev2Supported = &ikev2
+			log.Info("IKEv2 response received", svc1log.SafeParam("target", target), svc1log.SafeParam("ikev2", ikev2))
 			version := fmt.Sprintf("IKEv%d", header.MajorVersion)
 			initiatorSPI := hex.EncodeToString(header.InitiatorSPI[:])
 			responderSPI := hex.EncodeToString(header.ResponderSPI[:])

--- a/internal/enumerate/ike/ike.go
+++ b/internal/enumerate/ike/ike.go
@@ -10,6 +10,7 @@ import (
 	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	ikefern "github.com/Method-Security/networkscan/generated/go/enumerate/ike"
+	ikeprotocol "github.com/Method-Security/networkscan/internal/protocol/ike"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
@@ -41,7 +42,7 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 	details.Target = host
 	details.Port = port
 	// IKEv2 probe
-	ikev2Response, err := probeUDP(ctx, target, buildIKEv2SAInitRequest())
+	ikev2Response, err := probeUDP(ctx, target, ikeprotocol.BuildIKEv2SAInitRequest())
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("IKEv2 probe failed on %s: %v", target, err))
 		log.Warn("IKEv2 probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
@@ -49,11 +50,11 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 		ikev2 := true
 		serverInfo.Ikev2Supported = &ikev2
 		log.Info("IKEv2 response received", svc1log.SafeParam("target", target))
-		if header, parseErr := parseIKEHeader(ikev2Response); parseErr == nil {
+		if header, parseErr := ikeprotocol.ParseIKEHeader(ikev2Response); parseErr == nil {
 			version := fmt.Sprintf("IKEv%d", header.MajorVersion)
 			initiatorSPI := hex.EncodeToString(header.InitiatorSPI[:])
 			responderSPI := hex.EncodeToString(header.ResponderSPI[:])
-			exchangeType := getExchangeTypeName(header.ExchangeType)
+			exchangeType := ikeprotocol.GetExchangeTypeName(header.ExchangeType)
 			flags := fmt.Sprintf("0x%02x", header.Flags)
 			messageID := fmt.Sprintf("%d", header.MessageID)
 			serverInfo.Version = &version
@@ -62,7 +63,7 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 			serverInfo.ExchangeType = &exchangeType
 			serverInfo.Flags = &flags
 			serverInfo.MessageId = &messageID
-			vendorIDs, proposals := parseIKEPayloads(ikev2Response[28:], header.NextPayload)
+			vendorIDs, proposals := ikeprotocol.ParseIKEPayloads(ikev2Response[28:], header.NextPayload)
 			serverInfo.VendorIds = vendorIDs
 			serverInfo.EncryptionAlgorithms = proposals.EncryptionAlgs
 			serverInfo.HashAlgorithms = proposals.HashAlgs
@@ -87,7 +88,7 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 	// NAT-T probe on UDP 4500 (only if not already probing 4500)
 	if portStr != "4500" {
 		natTarget := net.JoinHostPort(host, "4500")
-		_, natErr := probeUDP(ctx, natTarget, buildIKEv2SAInitRequest())
+		_, natErr := probeUDP(ctx, natTarget, ikeprotocol.BuildIKEv2SAInitRequest())
 		if natErr == nil {
 			natT := true
 			serverInfo.NatTraversalSupported = &natT

--- a/internal/protocol/ike/parser.go
+++ b/internal/protocol/ike/parser.go
@@ -118,6 +118,7 @@ func ParseSAPayload(data []byte, proposals *SecurityProposals) {
 }
 
 // BuildIKEv2SAInitRequest creates a minimal IKEv2 IKE_SA_INIT request packet.
+// Use this for the standard IKE port (UDP 500).
 func BuildIKEv2SAInitRequest() []byte {
 	packet := make([]byte, 28)
 	copy(packet[0:8], []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}) // initiator SPI
@@ -127,6 +128,18 @@ func BuildIKEv2SAInitRequest() []byte {
 	packet[19] = 0x08                                                         // flags: initiator
 	binary.BigEndian.PutUint32(packet[24:28], 28)
 	return packet
+}
+
+// BuildNATTIKEv2SAInitRequest creates an IKEv2 IKE_SA_INIT request framed for
+// UDP port 4500 per RFC 3948 §2.3: a 4-byte Non-ESP marker (0x00000000) is
+// prepended so the receiver can distinguish IKE traffic from ESP packets.
+func BuildNATTIKEv2SAInitRequest() []byte {
+	ike := BuildIKEv2SAInitRequest()
+	framed := make([]byte, 4+len(ike))
+	// Non-ESP marker: four zero bytes (RFC 3948 §2.3)
+	binary.BigEndian.PutUint32(framed[0:4], 0)
+	copy(framed[4:], ike)
+	return framed
 }
 
 // GetExchangeTypeName returns the human-readable name for an IKE exchange type.

--- a/internal/protocol/ike/parser.go
+++ b/internal/protocol/ike/parser.go
@@ -1,0 +1,308 @@
+// Package ike provides shared IKE (Internet Key Exchange) protocol parsing and
+// packet-building utilities used by both the discover and enumerate modules.
+package ike
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+)
+
+// IKEHeader represents the parsed 28-byte IKE message header.
+type IKEHeader struct {
+	InitiatorSPI [8]byte
+	ResponderSPI [8]byte
+	NextPayload  byte
+	MajorVersion byte
+	MinorVersion byte
+	ExchangeType byte
+	Flags        byte
+	MessageID    uint32
+	Length       uint32
+}
+
+// SecurityProposals holds parsed IKE security association proposals.
+type SecurityProposals struct {
+	EncryptionAlgs []string
+	HashAlgs       []string
+	AuthMethods    []string
+	DHGroups       []string
+}
+
+// ParseIKEHeader parses the 28-byte IKE message header.
+func ParseIKEHeader(data []byte) (*IKEHeader, error) {
+	if len(data) < 28 {
+		return nil, fmt.Errorf("data too short for IKE header: %d bytes", len(data))
+	}
+	h := &IKEHeader{
+		NextPayload:  data[16],
+		MajorVersion: (data[17] & 0xF0) >> 4,
+		MinorVersion: data[17] & 0x0F,
+		ExchangeType: data[18],
+		Flags:        data[19],
+		MessageID:    binary.BigEndian.Uint32(data[20:24]),
+		Length:       binary.BigEndian.Uint32(data[24:28]),
+	}
+	copy(h.InitiatorSPI[:], data[0:8])
+	copy(h.ResponderSPI[:], data[8:16])
+	return h, nil
+}
+
+// ParseIKEPayloads extracts vendor IDs (hex-encoded) and SA proposals from the
+// payload section of an IKE message. nextPayload is taken from the IKE header.
+func ParseIKEPayloads(data []byte, nextPayload byte) ([]string, *SecurityProposals) {
+	var vendorIDs []string
+	proposals := &SecurityProposals{}
+	current := nextPayload
+	offset := 0
+	for offset < len(data) && current != 0 {
+		if offset+4 > len(data) {
+			break
+		}
+		payloadLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		if payloadLen < 4 || offset+payloadLen > len(data) {
+			break
+		}
+		payload := data[offset+4 : offset+payloadLen]
+		switch current {
+		case 43: // Vendor ID — always store as lowercase hex for consistent matching
+			if len(payload) > 0 {
+				vendorIDs = append(vendorIDs, hex.EncodeToString(payload))
+			}
+		case 33: // Security Association (IKEv2)
+			ParseSAPayload(payload, proposals)
+		}
+		current = data[offset]
+		offset += payloadLen
+	}
+	return vendorIDs, proposals
+}
+
+// ParseSAPayload extracts transform attributes from an IKEv2 SA payload,
+// correctly skipping any per-proposal SPI bytes before the transform list.
+func ParseSAPayload(data []byte, proposals *SecurityProposals) {
+	offset := 0
+	for offset+8 <= len(data) {
+		proposalLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		if proposalLen < 8 || offset+proposalLen > len(data) {
+			break
+		}
+		spiSize := int(data[offset+6])
+		numTransforms := int(data[offset+7])
+		txOffset := offset + 8 + spiSize
+		if txOffset > offset+proposalLen {
+			offset += proposalLen
+			continue
+		}
+		for i := 0; i < numTransforms && txOffset+8 <= len(data); i++ {
+			txLen := int(binary.BigEndian.Uint16(data[txOffset+2 : txOffset+4]))
+			if txLen < 8 {
+				break
+			}
+			txType := data[txOffset+4]
+			txID := binary.BigEndian.Uint16(data[txOffset+6 : txOffset+8])
+			switch txType {
+			case 1:
+				proposals.EncryptionAlgs = AppendUnique(proposals.EncryptionAlgs, GetEncryptionAlgorithmName(txID))
+			case 2:
+				proposals.HashAlgs = AppendUnique(proposals.HashAlgs, GetPRFName(txID))
+			case 3:
+				proposals.HashAlgs = AppendUnique(proposals.HashAlgs, GetIntegrityAlgorithmName(txID))
+			case 4:
+				proposals.DHGroups = AppendUnique(proposals.DHGroups, GetDHGroupName(txID))
+			}
+			txOffset += txLen
+		}
+		offset += proposalLen
+	}
+}
+
+// BuildIKEv2SAInitRequest creates a minimal IKEv2 IKE_SA_INIT request packet.
+func BuildIKEv2SAInitRequest() []byte {
+	packet := make([]byte, 28)
+	copy(packet[0:8], []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}) // initiator SPI
+	packet[16] = 33                                                           // next payload: SA
+	packet[17] = 0x20                                                         // version: IKEv2
+	packet[18] = 34                                                           // exchange type: IKE_SA_INIT
+	packet[19] = 0x08                                                         // flags: initiator
+	binary.BigEndian.PutUint32(packet[24:28], 28)
+	return packet
+}
+
+// GetExchangeTypeName returns the human-readable name for an IKE exchange type.
+func GetExchangeTypeName(t byte) string {
+	switch t {
+	case 34:
+		return "IKE_SA_INIT"
+	case 35:
+		return "IKE_AUTH"
+	case 36:
+		return "CREATE_CHILD_SA"
+	case 37:
+		return "INFORMATIONAL"
+	default:
+		return fmt.Sprintf("UNKNOWN_%d", t)
+	}
+}
+
+// GetEncryptionAlgorithmName returns the IANA name for an IKEv2 encryption
+// transform ID (RFC 7296 / IANA "IKEv2 Transform Type 1" registry).
+func GetEncryptionAlgorithmName(id uint16) string {
+	switch id {
+	case 1:
+		return "DES-CBC"
+	case 2:
+		return "IDEA-CBC"
+	case 3:
+		return "Blowfish-CBC"
+	case 5:
+		return "3DES-CBC"
+	case 7:
+		return "CAST-CBC"
+	case 11:
+		return "NULL"
+	case 12:
+		return "AES-CBC"
+	case 13:
+		return "AES-CTR"
+	case 18:
+		return "AES-GCM-8"
+	case 19:
+		return "AES-GCM-12"
+	case 20:
+		return "AES-GCM-16"
+	case 23:
+		return "Camellia-CBC"
+	case 28:
+		return "ChaCha20-Poly1305"
+	default:
+		return fmt.Sprintf("ENC_%d", id)
+	}
+}
+
+// GetPRFName returns the IANA name for an IKEv2 PRF transform ID
+// (RFC 7296 / IANA "IKEv2 Transform Type 2" registry).
+func GetPRFName(id uint16) string {
+	switch id {
+	case 1:
+		return "PRF-HMAC-MD5"
+	case 2:
+		return "PRF-HMAC-SHA1"
+	case 3:
+		return "PRF-HMAC-TIGER"
+	case 4:
+		return "PRF-AES128-XCBC"
+	case 5:
+		return "PRF-HMAC-SHA256"
+	case 6:
+		return "PRF-HMAC-SHA384"
+	case 7:
+		return "PRF-HMAC-SHA512"
+	case 8:
+		return "PRF-AES128-CMAC"
+	default:
+		return fmt.Sprintf("PRF_%d", id)
+	}
+}
+
+// GetIntegrityAlgorithmName returns the IANA name for an IKEv2 integrity
+// transform ID (RFC 7296 / IANA "IKEv2 Transform Type 3" registry).
+func GetIntegrityAlgorithmName(id uint16) string {
+	switch id {
+	case 0:
+		return "NONE"
+	case 1:
+		return "HMAC-MD5-96"
+	case 2:
+		return "HMAC-SHA1-96"
+	case 3:
+		return "DES-MAC"
+	case 4:
+		return "KPDK-MD5"
+	case 5:
+		return "AES-XCBC-96"
+	case 6:
+		return "HMAC-MD5-128"
+	case 7:
+		return "HMAC-SHA1-160"
+	case 8:
+		return "AES-CMAC-96"
+	case 9:
+		return "AES-128-GMAC"
+	case 10:
+		return "AES-192-GMAC"
+	case 11:
+		return "AES-256-GMAC"
+	case 12:
+		return "HMAC-SHA256-128"
+	case 13:
+		return "HMAC-SHA384-192"
+	case 14:
+		return "HMAC-SHA512-256"
+	default:
+		return fmt.Sprintf("AUTH_%d", id)
+	}
+}
+
+// GetDHGroupName returns the IANA name for an IKEv2 Diffie-Hellman group ID
+// (RFC 7296 / IANA "IKEv2 Transform Type 4" registry).
+func GetDHGroupName(id uint16) string {
+	switch id {
+	case 1:
+		return "MODP-768"
+	case 2:
+		return "MODP-1024"
+	case 5:
+		return "MODP-1536"
+	case 14:
+		return "MODP-2048"
+	case 15:
+		return "MODP-3072"
+	case 16:
+		return "MODP-4096"
+	case 17:
+		return "MODP-6144"
+	case 18:
+		return "MODP-8192"
+	case 19:
+		return "ECP-256"
+	case 20:
+		return "ECP-384"
+	case 21:
+		return "ECP-521"
+	case 22:
+		return "MODP-1024-160"
+	case 23:
+		return "MODP-2048-224"
+	case 24:
+		return "MODP-2048-256"
+	case 25:
+		return "ECP-192"
+	case 26:
+		return "ECP-224"
+	case 27:
+		return "ECP-224-BP"
+	case 28:
+		return "ECP-256-BP"
+	case 29:
+		return "ECP-384-BP"
+	case 30:
+		return "ECP-512-BP"
+	case 31:
+		return "Curve25519"
+	case 32:
+		return "Curve448"
+	default:
+		return fmt.Sprintf("DH_%d", id)
+	}
+}
+
+// AppendUnique appends item to slice only if it is not already present.
+func AppendUnique(slice []string, item string) []string {
+	for _, s := range slice {
+		if s == item {
+			return slice
+		}
+	}
+	return append(slice, item)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new IKE enumeration probes (IKEv2 SA_INIT, IKEv1 aggressive mode, NAT-T on 4500) and expands reported metadata, which may affect scan accuracy and increase network traffic/timeouts across targets.
> 
> **Overview**
> Adds first-class **IKE enumeration** support, wiring `IKE` into `SupportedServiceType` and returning `EnumerateIkeDetails` with `IkeServerInfo` results.
> 
> Expands the `IkeServerInfo` schema with **security assessment fields** (IKEv1/IKEv2 support, aggressive mode, NAT-T, DPD, weak algorithm detection, and vendor identification) and implements UDP probing to populate them.
> 
> Refactors IKE discovery to use a new shared `internal/protocol/ike` module for building/parsing IKE packets and extracting vendor IDs/SA proposals (including NAT-T framing for UDP 4500).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea1fc2e4d31d767d895c86e25305ac62cb8a226e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->