### PR TITLE
Remove accidentally committed build binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ go.work.sum
 # Other
 .DS_Store
 
+# Build binary
+/networkscan
+
 # Ignore contents of generated, but not the folder itself
 generated/**
 


### PR DESCRIPTION
## Summary

- Untracks the `networkscan` build binary that was accidentally committed in a previous PR
- Adds `/networkscan` to `.gitignore` so it can never be committed again

## Test plan

- [ ] Verify `networkscan` no longer appears in `git ls-files`
- [ ] Verify the `ike` PR no longer shows the binary in its file diff after this merges

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk housekeeping change that only updates `.gitignore` to prevent committing the `networkscan` build artifact; no runtime code paths are affected.
> 
> **Overview**
> Prevents accidentally committing the compiled `networkscan` executable by adding `/networkscan` to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aeb9795459cca7c70d6488b59997d732d7f47fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->