### PR TITLE
Embed wordlists and config files into compiled binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,9 @@ RUN \
   mkdir -p /opt/method/${CLI_NAME}/ && \
   mkdir -p /opt/method/${CLI_NAME}/var/data && \
   mkdir -p /opt/method/${CLI_NAME}/var/data/tmp && \
-  mkdir -p /opt/method/${CLI_NAME}/var/conf && \
   mkdir -p /opt/method/${CLI_NAME}/var/log && \
   mkdir -p /opt/method/${CLI_NAME}/service/bin && \
   mkdir -p /mnt/output
-
-COPY configs/                              /opt/method/${CLI_NAME}/var/conf/
 
 COPY ${CLI_NAME} /opt/method/${CLI_NAME}/service/bin/${CLI_NAME}
 

--- a/configs/embed.go
+++ b/configs/embed.go
@@ -3,7 +3,6 @@ package configs
 import (
 	"embed"
 	"fmt"
-	"io/fs"
 	"strings"
 )
 
@@ -22,11 +21,15 @@ func ReadLines(path string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read embedded config %s: %w", path, err)
 	}
-	content := strings.TrimRight(string(data), "\n")
+	content := strings.TrimRight(string(data), "\r\n")
 	if content == "" {
 		return []string{}, nil
 	}
-	return strings.Split(content, "\n"), nil
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, "\r")
+	}
+	return lines, nil
 }
 
 // ReadMultipleLineFiles reads multiple text files and combines their lines.
@@ -40,9 +43,4 @@ func ReadMultipleLineFiles(paths []string) ([]string, error) {
 		entries = append(entries, lines...)
 	}
 	return entries, nil
-}
-
-// FS returns the embedded filesystem for direct access if needed.
-func FS() fs.FS {
-	return configFS
 }

--- a/configs/embed.go
+++ b/configs/embed.go
@@ -1,0 +1,48 @@
+package configs
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+//go:embed pentest discover
+var configFS embed.FS
+
+// ReadFile reads a file from the embedded config filesystem.
+// The path should be relative to the configs/ directory (e.g., "pentest/spray/system_passwords.txt").
+func ReadFile(path string) ([]byte, error) {
+	return configFS.ReadFile(path)
+}
+
+// ReadLines reads a text file from the embedded config filesystem and returns its lines.
+func ReadLines(path string) ([]string, error) {
+	data, err := configFS.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embedded config %s: %w", path, err)
+	}
+	content := strings.TrimRight(string(data), "\n")
+	if content == "" {
+		return []string{}, nil
+	}
+	return strings.Split(content, "\n"), nil
+}
+
+// ReadMultipleLineFiles reads multiple text files and combines their lines.
+func ReadMultipleLineFiles(paths []string) ([]string, error) {
+	var entries []string
+	for _, path := range paths {
+		lines, err := ReadLines(path)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, lines...)
+	}
+	return entries, nil
+}
+
+// FS returns the embedded filesystem for direct access if needed.
+func FS() fs.FS {
+	return configFS
+}

--- a/internal/discover/port/stealth.go
+++ b/internal/discover/port/stealth.go
@@ -17,7 +17,9 @@ import (
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 
 	// Internal
+	"github.com/Method-Security/networkscan/configs"
 	"github.com/Method-Security/networkscan/utils"
+
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -229,7 +231,7 @@ func getTopPortsConfig() (map[string]string, error) {
 		return topPortsConfig.PortLists, nil
 	}
 
-	data, err := utils.LoadEmbeddedConfigFile("discover/port/top_ports.json")
+	data, err := configs.ReadFile("discover/port/top_ports.json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read top ports config: %w", err)
 	}

--- a/internal/discover/port/stealth.go
+++ b/internal/discover/port/stealth.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -230,10 +229,7 @@ func getTopPortsConfig() (map[string]string, error) {
 		return topPortsConfig.PortLists, nil
 	}
 
-	resolver := utils.GetDefaultWordlistResolver()
-	filePath := resolver.GetConfigFilePath("discover/port/top_ports.json")
-
-	data, err := os.ReadFile(filePath)
+	data, err := utils.LoadEmbeddedConfigFile("discover/port/top_ports.json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read top ports config: %w", err)
 	}

--- a/internal/pentest/spray.go
+++ b/internal/pentest/spray.go
@@ -783,9 +783,6 @@ func generateUsernameEnumStatistics(attempts []*pentestfern.SprayAttempt, userna
 
 // loadCredentialsFromConfig loads usernames, passwords, and NTLM hashes from config including built-in wordlists
 func loadCredentialsFromConfig(config *pentestfern.SprayPasswordConfig) ([]string, []string, []string, error) {
-	// Initialize wordlist resolver
-	resolver := utils.GetDefaultWordlistResolver()
-
 	// Start with explicitly provided usernames, passwords, and NTLM hashes
 	usernames := make([]string, len(config.Usernames))
 	copy(usernames, config.Usernames)
@@ -798,7 +795,7 @@ func loadCredentialsFromConfig(config *pentestfern.SprayPasswordConfig) ([]strin
 
 	// Load usernames from built-in wordlists if specified
 	if len(config.UsernameLists) > 0 {
-		wordlistUsernames, err := resolver.GetUsernameWordlists(config.UsernameLists)
+		wordlistUsernames, err := utils.GetUsernameWordlists(config.UsernameLists)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to load username wordlists: %v", err)
 		}
@@ -807,7 +804,7 @@ func loadCredentialsFromConfig(config *pentestfern.SprayPasswordConfig) ([]strin
 
 	// Load passwords from built-in wordlists if specified
 	if len(config.PasswordLists) > 0 {
-		wordlistPasswords, err := resolver.GetPasswordWordlists(config.PasswordLists)
+		wordlistPasswords, err := utils.GetPasswordWordlists(config.PasswordLists)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to load password wordlists: %v", err)
 		}
@@ -819,16 +816,12 @@ func loadCredentialsFromConfig(config *pentestfern.SprayPasswordConfig) ([]strin
 
 // loadUsernamesFromConfig loads usernames from config including built-in wordlists and generated schemes
 func loadUsernamesFromConfig(config *pentestfern.SprayUsernameConfig) ([]string, error) {
-	// Initialize wordlist resolver
-	resolver := utils.GetDefaultWordlistResolver()
-
 	// Start with explicitly provided usernames
 	usernames := make([]string, len(config.Usernames))
 	copy(usernames, config.Usernames)
 
 	// Generate usernames from scheme if specified
 	if config.UsernameScheme != nil {
-		// Generate a reasonable number of usernames (e.g., 10000) to avoid excessive lists
 		generatedUsernames, err := utils.GenerateUsernamesWithLimit(*config.UsernameScheme, 10000)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate usernames from scheme: %v", err)
@@ -838,7 +831,7 @@ func loadUsernamesFromConfig(config *pentestfern.SprayUsernameConfig) ([]string,
 
 	// Load usernames from built-in wordlists if specified
 	if len(config.UsernameLists) > 0 {
-		wordlistUsernames, err := resolver.GetUsernameWordlists(config.UsernameLists)
+		wordlistUsernames, err := utils.GetUsernameWordlists(config.UsernameLists)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load username wordlists: %v", err)
 		}
@@ -847,7 +840,7 @@ func loadUsernamesFromConfig(config *pentestfern.SprayUsernameConfig) ([]string,
 
 	// If no usernames are provided through any method, default to domain usernames list
 	if len(usernames) == 0 {
-		wordlistUsernames, err := resolver.GetUsernameWordlists([]pentestfern.WordlistType{pentestfern.WordlistTypeDomainUsernames})
+		wordlistUsernames, err := utils.GetUsernameWordlists([]pentestfern.WordlistType{pentestfern.WordlistTypeDomainUsernames})
 		if err != nil {
 			return nil, fmt.Errorf("failed to load default username wordlist: %v", err)
 		}

--- a/utils/username_generator.go
+++ b/utils/username_generator.go
@@ -1,22 +1,16 @@
 package utils
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 
+	"github.com/Method-Security/networkscan/configs"
 	"github.com/Method-Security/networkscan/generated/go/pentest"
 )
 
-// loadNamesFromFile loads names from config files using the existing resolver pattern
+// loadNamesFromFile loads names from embedded config files
 func loadNamesFromFile(filename string) ([]string, error) {
-	// Use the same resolver that wordlists use for consistent path handling
-	resolver := GetDefaultWordlistResolver()
-	filePath := resolver.GetConfigFilePath(filepath.Join("pentest", "spray", filename))
-	entries, err := GetEntriesFromTXTFiles([]string{filePath})
-	if err != nil {
-		return nil, err
-	}
-	return entries, nil
+	return configs.ReadLines(path.Join("pentest", "spray", filename))
 }
 
 // getFirstNames loads first names from file

--- a/utils/wordlist.go
+++ b/utils/wordlist.go
@@ -3,7 +3,6 @@ package utils
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/Method-Security/networkscan/configs"
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
@@ -75,21 +74,9 @@ func GetUsernameWordlists(usernameLists []pentestfern.WordlistType) ([]string, e
 	return LoadWordlistEntries(usernameLists)
 }
 
-// LoadEmbeddedConfigLines reads a text file from the embedded configs directory.
-// The path should be relative to configs/ (e.g., "pentest/spray/first_names.txt").
-func LoadEmbeddedConfigLines(relativePath string) ([]string, error) {
-	return configs.ReadLines(relativePath)
-}
-
 // LoadEmbeddedConfigFile reads a raw file from the embedded configs directory.
 func LoadEmbeddedConfigFile(relativePath string) ([]byte, error) {
 	return configs.ReadFile(relativePath)
-}
-
-// GetConfigPath returns the embedded path for a config file.
-// This is used for configs that are loaded by path (e.g., top_ports.json).
-func GetConfigPath(relativePath string) string {
-	return path.Clean(relativePath)
 }
 
 // ParseWordlistTypes converts string slice to WordlistType enums

--- a/utils/wordlist.go
+++ b/utils/wordlist.go
@@ -8,8 +8,8 @@ import (
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
 )
 
-// ResolveWordlistPaths returns the embedded config paths for the given wordlist types.
-func ResolveWordlistPaths(wordlistTypes []pentestfern.WordlistType) ([]string, error) {
+// resolveWordlistPaths returns the embedded config paths for the given wordlist types.
+func resolveWordlistPaths(wordlistTypes []pentestfern.WordlistType) ([]string, error) {
 	if len(wordlistTypes) == 0 {
 		return []string{}, nil
 	}
@@ -50,9 +50,9 @@ func getWordlistConfigPath(wordlistType pentestfern.WordlistType) (string, error
 	}
 }
 
-// LoadWordlistEntries loads entries from embedded wordlists for the given types.
-func LoadWordlistEntries(wordlistTypes []pentestfern.WordlistType) ([]string, error) {
-	paths, err := ResolveWordlistPaths(wordlistTypes)
+// loadWordlistEntries loads entries from embedded wordlists for the given types.
+func loadWordlistEntries(wordlistTypes []pentestfern.WordlistType) ([]string, error) {
+	paths, err := resolveWordlistPaths(wordlistTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -66,17 +66,12 @@ func LoadWordlistEntries(wordlistTypes []pentestfern.WordlistType) ([]string, er
 
 // GetPasswordWordlists loads password wordlists based on the config.
 func GetPasswordWordlists(passwordLists []pentestfern.WordlistType) ([]string, error) {
-	return LoadWordlistEntries(passwordLists)
+	return loadWordlistEntries(passwordLists)
 }
 
 // GetUsernameWordlists loads username wordlists based on the config.
 func GetUsernameWordlists(usernameLists []pentestfern.WordlistType) ([]string, error) {
-	return LoadWordlistEntries(usernameLists)
-}
-
-// LoadEmbeddedConfigFile reads a raw file from the embedded configs directory.
-func LoadEmbeddedConfigFile(relativePath string) ([]byte, error) {
-	return configs.ReadFile(relativePath)
+	return loadWordlistEntries(usernameLists)
 }
 
 // ParseWordlistTypes converts string slice to WordlistType enums

--- a/utils/wordlist.go
+++ b/utils/wordlist.go
@@ -3,96 +3,57 @@ package utils
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
+	"path"
 
+	"github.com/Method-Security/networkscan/configs"
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
 )
 
-// WordlistResolver provides functionality to resolve wordlist enums to file paths
-type WordlistResolver struct {
-	baseConfigDir string
-}
-
-// NewWordlistResolver creates a new WordlistResolver with the specified base config directory
-func NewWordlistResolver(baseConfigDir string) *WordlistResolver {
-	return &WordlistResolver{
-		baseConfigDir: baseConfigDir,
-	}
-}
-
-// GetDefaultWordlistResolver returns a WordlistResolver configured for the container environment
-func GetDefaultWordlistResolver() *WordlistResolver {
-	// In container, configs are mounted at /opt/method/networkscan/var/conf/
-	return NewWordlistResolver("/opt/method/networkscan/var/conf")
-}
-
-// GetConfigFilePath returns the full path for a file within the config directory
-// It automatically handles container vs development environment paths
-func (wr *WordlistResolver) GetConfigFilePath(relativePath string) string {
-	// Try multiple possible config paths (container vs local development)
-	possiblePaths := []string{
-		filepath.Join(wr.baseConfigDir, relativePath), // Configured base path (container)
-		filepath.Join("configs", relativePath),        // Local development path
-	}
-
-	// Return the first path that exists
-	for _, path := range possiblePaths {
-		if _, err := os.Stat(path); err == nil {
-			return path
-		}
-	}
-
-	// If none exist, return the configured path (original behavior)
-	return filepath.Join(wr.baseConfigDir, relativePath)
-}
-
-// ResolveWordlistPaths takes wordlist types and resolves them to actual file paths
-func (wr *WordlistResolver) ResolveWordlistPaths(wordlistTypes []pentestfern.WordlistType) ([]string, error) {
+// ResolveWordlistPaths returns the embedded config paths for the given wordlist types.
+func ResolveWordlistPaths(wordlistTypes []pentestfern.WordlistType) ([]string, error) {
 	if len(wordlistTypes) == 0 {
 		return []string{}, nil
 	}
 
 	var paths []string
 	for _, wordlistType := range wordlistTypes {
-		path, err := wr.getWordlistPath(wordlistType)
+		p, err := getWordlistConfigPath(wordlistType)
 		if err != nil {
 			return nil, err
 		}
-		if path != "" {
-			paths = append(paths, path)
+		if p != "" {
+			paths = append(paths, p)
 		}
 	}
 
 	return paths, nil
 }
 
-// getWordlistPath returns the file path for a specific wordlist type
-func (wr *WordlistResolver) getWordlistPath(wordlistType pentestfern.WordlistType) (string, error) {
+// getWordlistConfigPath returns the embedded config path for a specific wordlist type.
+func getWordlistConfigPath(wordlistType pentestfern.WordlistType) (string, error) {
 	switch wordlistType {
 	case pentestfern.WordlistTypeSystemPasswords:
-		return filepath.Join(wr.baseConfigDir, "pentest", "spray", "system_passwords.txt"), nil
+		return "pentest/spray/system_passwords.txt", nil
 	case pentestfern.WordlistTypeSystemUsernames:
-		return filepath.Join(wr.baseConfigDir, "pentest", "spray", "system_usernames.txt"), nil
+		return "pentest/spray/system_usernames.txt", nil
 	case pentestfern.WordlistTypeDomainPasswords:
-		return filepath.Join(wr.baseConfigDir, "pentest", "spray", "domain_passwords.txt"), nil
+		return "pentest/spray/domain_passwords.txt", nil
 	case pentestfern.WordlistTypeDomainUsernames:
-		return filepath.Join(wr.baseConfigDir, "pentest", "spray", "domain_usernames.txt"), nil
+		return "pentest/spray/domain_usernames.txt", nil
 	case pentestfern.WordlistTypeServicePasswords:
-		return filepath.Join(wr.baseConfigDir, "pentest", "spray", "service_passwords.txt"), nil
+		return "pentest/spray/service_passwords.txt", nil
 	case pentestfern.WordlistTypeServiceUsernames:
-		return filepath.Join(wr.baseConfigDir, "pentest", "spray", "service_usernames.txt"), nil
+		return "pentest/spray/service_usernames.txt", nil
 	case pentestfern.WordlistTypeCustom:
-		// Custom wordlists should be handled elsewhere - return empty path
 		return "", nil
 	default:
 		return "", fmt.Errorf("unsupported wordlist type: %s", wordlistType)
 	}
 }
 
-// LoadWordlistEntries loads entries from resolved wordlist paths
-func (wr *WordlistResolver) LoadWordlistEntries(wordlistTypes []pentestfern.WordlistType) ([]string, error) {
-	paths, err := wr.ResolveWordlistPaths(wordlistTypes)
+// LoadWordlistEntries loads entries from embedded wordlists for the given types.
+func LoadWordlistEntries(wordlistTypes []pentestfern.WordlistType) ([]string, error) {
+	paths, err := ResolveWordlistPaths(wordlistTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -101,17 +62,34 @@ func (wr *WordlistResolver) LoadWordlistEntries(wordlistTypes []pentestfern.Word
 		return []string{}, nil
 	}
 
-	return GetEntriesFromTXTFiles(paths)
+	return configs.ReadMultipleLineFiles(paths)
 }
 
-// GetPasswordWordlists loads password wordlists based on the config
-func (wr *WordlistResolver) GetPasswordWordlists(passwordLists []pentestfern.WordlistType) ([]string, error) {
-	return wr.LoadWordlistEntries(passwordLists)
+// GetPasswordWordlists loads password wordlists based on the config.
+func GetPasswordWordlists(passwordLists []pentestfern.WordlistType) ([]string, error) {
+	return LoadWordlistEntries(passwordLists)
 }
 
-// GetUsernameWordlists loads username wordlists based on the config
-func (wr *WordlistResolver) GetUsernameWordlists(usernameLists []pentestfern.WordlistType) ([]string, error) {
-	return wr.LoadWordlistEntries(usernameLists)
+// GetUsernameWordlists loads username wordlists based on the config.
+func GetUsernameWordlists(usernameLists []pentestfern.WordlistType) ([]string, error) {
+	return LoadWordlistEntries(usernameLists)
+}
+
+// LoadEmbeddedConfigLines reads a text file from the embedded configs directory.
+// The path should be relative to configs/ (e.g., "pentest/spray/first_names.txt").
+func LoadEmbeddedConfigLines(relativePath string) ([]string, error) {
+	return configs.ReadLines(relativePath)
+}
+
+// LoadEmbeddedConfigFile reads a raw file from the embedded configs directory.
+func LoadEmbeddedConfigFile(relativePath string) ([]byte, error) {
+	return configs.ReadFile(relativePath)
+}
+
+// GetConfigPath returns the embedded path for a config file.
+// This is used for configs that are loaded by path (e.g., top_ports.json).
+func GetConfigPath(relativePath string) string {
+	return path.Clean(relativePath)
 }
 
 // ParseWordlistTypes converts string slice to WordlistType enums


### PR DESCRIPTION
## Summary
- Uses Go's `//go:embed` to bake all `configs/` files (spray wordlists, top_ports.json, name lists) into the compiled binary
- Removes the `WordlistResolver` struct-based pattern and replaces with package-level functions that read from the embedded FS
- Password spray, username generation, and port config all work without Docker container mounts now

## What changed
- **`configs/embed.go`** — new `configs` package with `//go:embed pentest discover` directive
- **`utils/wordlist.go`** — replaced `WordlistResolver` struct with package-level `LoadWordlistEntries`, `GetPasswordWordlists`, `GetUsernameWordlists` that read from embedded FS
- **`utils/username_generator.go`** — reads `first_names.txt`/`last_names.txt` from embedded configs
- **`internal/discover/port/stealth.go`** — reads `top_ports.json` from embedded configs
- **`internal/pentest/spray.go`** — updated callers to use new package-level functions

## Behavior
- **Compiled binary**: All wordlists available from embedded FS — works without Docker
- **Custom user paths**: CLI flags (`--username-file`, `--password-file`) still read from filesystem

## Test plan
- [ ] Build binary and run password spray with built-in wordlists (e.g., `SYSTEM_PASSWORDS`)
- [ ] Verify `--username-file` custom file paths still work
- [ ] Verify port discovery with top ports still works
- [ ] Run in Docker container to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces filesystem-based config resolution with embedded reads, which could break runtime behavior if embedded paths or packaging are incorrect, affecting port discovery and pentest spray inputs.
> 
> **Overview**
> Built-in configs/wordlists are now **embedded into the compiled binary** via a new `configs` package (`//go:embed pentest discover`), with helpers to read whole files or line lists.
> 
> Port discovery (`top_ports.json`), username generation (first/last name lists), and password/username spray wordlists now load from the embedded FS instead of reading from container-mounted `var/conf`, and the old `WordlistResolver` path/`os.Stat` logic is removed in favor of package-level `utils.GetUsernameWordlists`/`utils.GetPasswordWordlists`.
> 
> The Docker image no longer creates/copies `/opt/method/.../var/conf` since configs are no longer shipped as container files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39af81d6cc20328b070216021b88ccb3fa301c1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->