### PR TITLE
Fix IKE Enumerate Bugs

### DIFF
--- a/internal/enumerate/ike/helpers.go
+++ b/internal/enumerate/ike/helpers.go
@@ -57,8 +57,8 @@ func probeUDP(ctx context.Context, addr string, packet []byte) ([]byte, error) {
 
 // --- IKEv1 Aggressive Mode Packet Builder ---
 // buildIKEv1AggressiveModeProbe creates an IKEv1 Aggressive Mode probe packet.
-// It proposes DES-CBC + MD5 + PSK + MODP-768 — the weakest common set — to
-// maximize the chance that a configured server will accept and respond.
+// It proposes three transforms (3DES-CBC, AES-128, AES-256) all with SHA1 +
+// PSK + MODP-1024 to maximize the chance that a configured server will respond.
 func buildIKEv1AggressiveModeProbe() []byte {
 	// Three transforms, all using MODP-1024 to match the single KE payload.
 	// Attributes use TV (Type-Value) format: MSB of type byte = 1.
@@ -139,12 +139,12 @@ func buildIKEv1AggressiveModeProbe() []byte {
 // server that has Aggressive Mode enabled.
 //
 // Exchange type 4 (Aggressive Mode) is direct confirmation. Exchange type 5
-// (INFORMATIONAL) is also treated as confirmation unless the Notification
-// payload contains INVALID-EXCHANGE-TYPE (type 7), which means the server
-// explicitly rejected the AM exchange type and only supports Main Mode. Any
-// other notification type (e.g. NO-PROPOSAL-CHOSEN=14, INVALID-ID-INFORMATION=18)
-// means the server accepted the AM exchange type but rejected our specific
-// proposal or identity — so AM is supported.
+// (INFORMATIONAL) is treated as confirmation only when the Notification
+// payload contains a type that implies the server accepted the AM exchange
+// but rejected our specific proposal or identity (NO-PROPOSAL-CHOSEN=14,
+// INVALID-ID-INFORMATION=18). Other notification types (e.g.
+// INVALID-EXCHANGE-TYPE=7, DOI-NOT-SUPPORTED=2, INVALID-COOKIE=4) do not
+// imply AM support.
 //
 // It first validates the packet is a plausible IKE packet by checking the
 // length field matches the actual data, to avoid false positives from non-IKE
@@ -161,14 +161,26 @@ func isIKEv1AggressiveResponse(data []byte) (aggressiveMode bool, ikev1Supported
 		case 4: // Aggressive Mode — direct confirmation
 			aggressiveMode = true
 		case 5: // Informational — infer from notification type
-			// INVALID-EXCHANGE-TYPE (7) means server rejected AM entirely.
-			// Any other non-zero notification means AM was accepted but our SA or ID was rejected.
-			const invalidExchangeType = 7
 			notifyType := ikeprotocol.ParseIKEv1NotificationType(data)
-			aggressiveMode = notifyType != 0 && notifyType != invalidExchangeType
+			aggressiveMode = isAMConfirmingNotification(notifyType)
 		}
 	}
 	return aggressiveMode, ikev1Supported
+}
+
+// isAMConfirmingNotification returns true for IKEv1 notification types that
+// indicate the server accepted the Aggressive Mode exchange type but rejected
+// our specific proposal or identity. Per RFC 2408 §3.14.1:
+//   - NO-PROPOSAL-CHOSEN (14): AM supported, SA proposals didn't match
+//   - INVALID-ID-INFORMATION (18): AM supported, identity was rejected
+//   - AUTHENTICATION-FAILED (24): AM supported, auth check failed
+func isAMConfirmingNotification(notifyType uint16) bool {
+	switch notifyType {
+	case 14, 18, 24:
+		return true
+	default:
+		return false
+	}
 }
 
 // --- Security Assessment Helpers ---

--- a/internal/enumerate/ike/ike.go
+++ b/internal/enumerate/ike/ike.go
@@ -44,7 +44,7 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 	ikev2Response, err := probeUDP(ctx, target, ikeprotocol.BuildIKEv2SAInitRequest())
 	if err != nil {
 		log.Warn("IKEv2 probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
-	} else if len(ikev2Response) >= 28 {
+	} else if len(ikev2Response) >= 28 && isPlausibleIKEPacket(ikev2Response) {
 		applyIKEv2ResponseToServerInfo(ikev2Response, &serverInfo)
 		if serverInfo.Ikev2Supported != nil {
 			log.Info("IKEv2 response received", svc1log.SafeParam("target", target), svc1log.SafeParam("ikev2", *serverInfo.Ikev2Supported))
@@ -56,9 +56,13 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 		log.Warn("IKEv1 AM probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
 	} else if len(amResponse) >= 28 {
 		aggressiveMode, ikev1 := isIKEv1AggressiveResponse(amResponse)
-		serverInfo.AggressiveModeEnabled = &aggressiveMode
-		serverInfo.Ikev1Supported = &ikev1
-		mergeIKEv1ProposalsIntoServerInfo(ikeprotocol.ParseIKEv1SAResponse(amResponse), &serverInfo)
+		if aggressiveMode {
+			serverInfo.AggressiveModeEnabled = &aggressiveMode
+		}
+		if ikev1 {
+			serverInfo.Ikev1Supported = &ikev1
+			mergeIKEv1ProposalsIntoServerInfo(ikeprotocol.ParseIKEv1SAResponse(amResponse), &serverInfo)
+		}
 		log.Info("IKEv1 AM probe response",
 			svc1log.SafeParam("target", target),
 			svc1log.SafeParam("aggressiveMode", aggressiveMode),
@@ -72,35 +76,34 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 		natTarget := net.JoinHostPort(host, "4500")
 		// IKEv2 NAT-T probe
 		natv2Response, natErr := probeUDP(ctx, natTarget, ikeprotocol.BuildNATTIKEv2SAInitRequest())
-		if natErr == nil {
-			natT := true
-			serverInfo.NatTraversalSupported = &natT
-			log.Info("NAT-T port 4500 responded to IKEv2", svc1log.SafeParam("host", host), svc1log.SafeParam("responseBytes", len(natv2Response)))
-			// If port 500 probes failed, parse the NAT-T response to populate serverInfo.
-			if serverInfo.Version == nil {
-				data := stripNonESPMarker(natv2Response)
-				if isPlausibleIKEPacket(data) {
+		if natErr == nil && len(natv2Response) >= 4 {
+			data := stripNonESPMarker(natv2Response)
+			if isPlausibleIKEPacket(data) {
+				natT := true
+				serverInfo.NatTraversalSupported = &natT
+				log.Info("NAT-T port 4500 responded to IKEv2", svc1log.SafeParam("host", host), svc1log.SafeParam("responseBytes", len(natv2Response)))
+				if serverInfo.Version == nil {
 					applyIKEv2ResponseToServerInfo(data, &serverInfo)
 				}
 			}
 		}
 		// IKEv1 AM NAT-T probe — some devices only respond to AM on port 4500
 		natAMResponse, natAMErr := probeUDP(ctx, natTarget, ikeprotocol.BuildNATTIKEv1AMRequest(buildIKEv1AggressiveModeProbe()))
-		if natAMErr == nil {
-			natT := true
-			serverInfo.NatTraversalSupported = &natT
-			if len(natAMResponse) >= 28 {
-				// Strip Non-ESP marker (0x00000000) if present per RFC 3948 §2.3.
-				// Some implementations omit it, so only strip if the first 4 bytes are zeros.
-				data := stripNonESPMarker(natAMResponse)
+		if natAMErr == nil && len(natAMResponse) >= 4 {
+			// Strip Non-ESP marker (0x00000000) if present per RFC 3948 §2.3.
+			// Some implementations omit it, so only strip if the first 4 bytes are zeros.
+			data := stripNonESPMarker(natAMResponse)
+			if isPlausibleIKEPacket(data) {
+				natT := true
+				serverInfo.NatTraversalSupported = &natT
 				aggressiveMode, ikev1 := isIKEv1AggressiveResponse(data)
 				if aggressiveMode {
 					serverInfo.AggressiveModeEnabled = &aggressiveMode
 				}
 				if ikev1 {
 					serverInfo.Ikev1Supported = &ikev1
+					mergeIKEv1ProposalsIntoServerInfo(ikeprotocol.ParseIKEv1SAResponse(data), &serverInfo)
 				}
-				mergeIKEv1ProposalsIntoServerInfo(ikeprotocol.ParseIKEv1SAResponse(data), &serverInfo)
 				log.Info("NAT-T port 4500 responded to IKEv1 AM",
 					svc1log.SafeParam("host", host),
 					svc1log.SafeParam("aggressiveMode", aggressiveMode))

--- a/internal/protocol/ike/parser.go
+++ b/internal/protocol/ike/parser.go
@@ -94,9 +94,10 @@ func ParseSAPayload(data []byte, proposals *SecurityProposals) {
 			offset += proposalLen
 			continue
 		}
-		for i := 0; i < numTransforms && txOffset+8 <= len(data); i++ {
+		proposalEnd := offset + proposalLen
+		for i := 0; i < numTransforms && txOffset+8 <= proposalEnd; i++ {
 			txLen := int(binary.BigEndian.Uint16(data[txOffset+2 : txOffset+4]))
-			if txLen < 8 {
+			if txLen < 8 || txOffset+txLen > proposalEnd {
 				break
 			}
 			txType := data[txOffset+4]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches network-protocol detection and parsing of untrusted UDP input, so mistakes could change scan results or reintroduce parsing edge cases. Scope is small and primarily adds validation/bounds checks, which mitigates risk.
> 
> **Overview**
> Improves IKE probing to reduce false positives/negatives by only parsing responses that pass `isPlausibleIKEPacket`, including NAT-T (4500) responses after stripping the Non-ESP marker.
> 
> Updates IKEv1 Aggressive Mode detection to treat `INFORMATIONAL` replies as confirmation only for specific notification types (e.g. `NO-PROPOSAL-CHOSEN`, `INVALID-ID-INFORMATION`, `AUTHENTICATION-FAILED`), and avoids populating `AggressiveModeEnabled`/`Ikev1Supported` fields when the result is false.
> 
> Hardens IKEv2 SA parsing (`ParseSAPayload`) with proposal-bounded transform iteration to prevent out-of-bounds reads on malformed packets, and adjusts the IKEv1 AM probe proposal to use multiple common transforms (3DES/AES) with SHA1/PSK/MODP-1024.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57aa2bfe151b01c011402de899fd32a0f4e4bab2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->