### PR TITLE
IKE Enumerate Fix

### DIFF
--- a/internal/enumerate/ike/helpers.go
+++ b/internal/enumerate/ike/helpers.go
@@ -56,49 +56,92 @@ func probeUDP(ctx context.Context, addr string, packet []byte) ([]byte, error) {
 }
 
 // --- IKEv1 Aggressive Mode Packet Builder ---
-// buildIKEv1AggressiveModeProbe creates an IKEv1 Aggressive Mode probe packet.
-// It proposes three transforms (3DES-CBC, AES-128, AES-256) all with SHA1 +
-// PSK + MODP-1024 to maximize the chance that a configured server will respond.
+// buildIKEv1AggressiveModeProbe creates an IKEv1 Aggressive Mode probe with
+// MODP-1024 KE. Covers SHA-1 and SHA-256 hash variants.
 func buildIKEv1AggressiveModeProbe() []byte {
-	// Three transforms, all using MODP-1024 to match the single KE payload.
+	return buildIKEv1AMProbeForDH(0x02, 128) // MODP-1024
+}
+
+// buildIKEv1AMProbeModp2048 creates an IKEv1 Aggressive Mode probe with
+// MODP-2048 KE for servers that require stronger DH groups.
+func buildIKEv1AMProbeModp2048() []byte {
+	return buildIKEv1AMProbeForDH(0x0e, 256) // MODP-2048
+}
+
+// buildIKEv1AMProbeForDH builds an IKEv1 Aggressive Mode probe packet with the
+// specified DH group. It proposes six transforms (3DES-CBC, AES-128, AES-256
+// each paired with SHA-1 and SHA-256) all with PSK auth.
+func buildIKEv1AMProbeForDH(dhGroupID uint16, keSize int) []byte {
+	dhHi := byte(dhGroupID >> 8)
+	dhLo := byte(dhGroupID & 0xFF)
+	// Six transforms covering SHA-1 and SHA-256 with the specified DH group.
 	// Attributes use TV (Type-Value) format: MSB of type byte = 1.
 	// Last/More byte: 0x03 = more transforms, 0x00 = last transform.
 	transforms := []byte{
-		// Transform 1: 3DES-CBC + SHA1 + PSK + MODP-1024 (most widely supported)
+		// Transform 1: 3DES-CBC + SHA1 + PSK + DH
 		0x03, 0x00, 0x00, 0x20, 0x01, 0x01, 0x00, 0x00,
 		0x80, 0x01, 0x00, 0x05, // Encryption: 3DES-CBC
 		0x80, 0x02, 0x00, 0x02, // Hash: SHA1
 		0x80, 0x03, 0x00, 0x01, // Auth: PSK
-		0x80, 0x04, 0x00, 0x02, // DH Group: MODP-1024
+		0x80, 0x04, dhHi, dhLo, // DH Group
 		0x80, 0x0b, 0x00, 0x01, // Life Type: seconds
 		0x80, 0x0c, 0x70, 0x80, // Life Duration: 28800s
 
-		// Transform 2: AES-128-CBC + SHA1 + PSK + MODP-1024
+		// Transform 2: AES-128-CBC + SHA1 + PSK + DH
 		0x03, 0x00, 0x00, 0x24, 0x02, 0x01, 0x00, 0x00,
 		0x80, 0x01, 0x00, 0x07, // Encryption: AES-CBC
 		0x80, 0x0e, 0x00, 0x80, // Key Length: 128 bits
 		0x80, 0x02, 0x00, 0x02, // Hash: SHA1
 		0x80, 0x03, 0x00, 0x01, // Auth: PSK
-		0x80, 0x04, 0x00, 0x02, // DH Group: MODP-1024
+		0x80, 0x04, dhHi, dhLo, // DH Group
 		0x80, 0x0b, 0x00, 0x01, // Life Type: seconds
 		0x80, 0x0c, 0x70, 0x80, // Life Duration: 28800s
 
-		// Transform 3: AES-256-CBC + SHA1 + PSK + MODP-1024 (last)
-		0x00, 0x00, 0x00, 0x24, 0x03, 0x01, 0x00, 0x00,
+		// Transform 3: AES-256-CBC + SHA1 + PSK + DH
+		0x03, 0x00, 0x00, 0x24, 0x03, 0x01, 0x00, 0x00,
 		0x80, 0x01, 0x00, 0x07, // Encryption: AES-CBC
 		0x80, 0x0e, 0x01, 0x00, // Key Length: 256 bits
 		0x80, 0x02, 0x00, 0x02, // Hash: SHA1
 		0x80, 0x03, 0x00, 0x01, // Auth: PSK
-		0x80, 0x04, 0x00, 0x02, // DH Group: MODP-1024
+		0x80, 0x04, dhHi, dhLo, // DH Group
+		0x80, 0x0b, 0x00, 0x01, // Life Type: seconds
+		0x80, 0x0c, 0x70, 0x80, // Life Duration: 28800s
+
+		// Transform 4: 3DES-CBC + SHA256 + PSK + DH
+		0x03, 0x00, 0x00, 0x20, 0x04, 0x01, 0x00, 0x00,
+		0x80, 0x01, 0x00, 0x05, // Encryption: 3DES-CBC
+		0x80, 0x02, 0x00, 0x04, // Hash: SHA256
+		0x80, 0x03, 0x00, 0x01, // Auth: PSK
+		0x80, 0x04, dhHi, dhLo, // DH Group
+		0x80, 0x0b, 0x00, 0x01, // Life Type: seconds
+		0x80, 0x0c, 0x70, 0x80, // Life Duration: 28800s
+
+		// Transform 5: AES-128-CBC + SHA256 + PSK + DH
+		0x03, 0x00, 0x00, 0x24, 0x05, 0x01, 0x00, 0x00,
+		0x80, 0x01, 0x00, 0x07, // Encryption: AES-CBC
+		0x80, 0x0e, 0x00, 0x80, // Key Length: 128 bits
+		0x80, 0x02, 0x00, 0x04, // Hash: SHA256
+		0x80, 0x03, 0x00, 0x01, // Auth: PSK
+		0x80, 0x04, dhHi, dhLo, // DH Group
+		0x80, 0x0b, 0x00, 0x01, // Life Type: seconds
+		0x80, 0x0c, 0x70, 0x80, // Life Duration: 28800s
+
+		// Transform 6: AES-256-CBC + SHA256 + PSK + DH (last)
+		0x00, 0x00, 0x00, 0x24, 0x06, 0x01, 0x00, 0x00,
+		0x80, 0x01, 0x00, 0x07, // Encryption: AES-CBC
+		0x80, 0x0e, 0x01, 0x00, // Key Length: 256 bits
+		0x80, 0x02, 0x00, 0x04, // Hash: SHA256
+		0x80, 0x03, 0x00, 0x01, // Auth: PSK
+		0x80, 0x04, dhHi, dhLo, // DH Group
 		0x80, 0x0b, 0x00, 0x01, // Life Type: seconds
 		0x80, 0x0c, 0x70, 0x80, // Life Duration: 28800s
 	}
-	// Proposal: protocol=ISAKMP, SPI-size=0, 3 transforms
+	// Proposal: protocol=ISAKMP, SPI-size=0, 6 transforms
 	proposal := make([]byte, 8+len(transforms))
 	proposal[4] = 0x01 // proposal #1
 	proposal[5] = 0x01 // protocol: ISAKMP
 	proposal[6] = 0x00 // SPI size: 0
-	proposal[7] = 0x03 // # transforms: 3
+	proposal[7] = 0x06 // # transforms: 6
 	binary.BigEndian.PutUint16(proposal[2:4], uint16(len(proposal)))
 	copy(proposal[8:], transforms)
 	// SA payload: next=KE(4), DOI=IPSEC, Situation=SIT_IDENTITY_ONLY
@@ -108,8 +151,8 @@ func buildIKEv1AggressiveModeProbe() []byte {
 	binary.BigEndian.PutUint32(saPayload[4:8], 1)  // DOI: IPSEC
 	binary.BigEndian.PutUint32(saPayload[8:12], 1) // Situation: SIT_IDENTITY_ONLY
 	copy(saPayload[12:], proposal)
-	// KE payload: MODP-1024 = 128 bytes of zeros; next=Nonce(10)
-	kePayload := make([]byte, 4+128)
+	// KE payload: keSize bytes of zeros; next=Nonce(10)
+	kePayload := make([]byte, 4+keSize)
 	kePayload[0] = 0x0a // next: Nonce
 	binary.BigEndian.PutUint16(kePayload[2:4], uint16(len(kePayload)))
 	// Nonce payload: 16 zero bytes; next=ID(5)
@@ -138,17 +181,11 @@ func buildIKEv1AggressiveModeProbe() []byte {
 // isIKEv1AggressiveResponse checks if a raw IKE response is from an IKEv1
 // server that has Aggressive Mode enabled.
 //
-// Exchange type 4 (Aggressive Mode) is direct confirmation. Exchange type 5
-// (INFORMATIONAL) is treated as confirmation only when the Notification
-// payload contains a type that implies the server accepted the AM exchange
-// but rejected our specific proposal or identity (NO-PROPOSAL-CHOSEN=14,
-// INVALID-ID-INFORMATION=18). Other notification types (e.g.
-// INVALID-EXCHANGE-TYPE=7, DOI-NOT-SUPPORTED=2, INVALID-COOKIE=4) do not
-// imply AM support.
-//
-// It first validates the packet is a plausible IKE packet by checking the
-// length field matches the actual data, to avoid false positives from non-IKE
-// protocols.
+// Only exchange type 4 (Aggressive Mode) is treated as confirmation.
+// INFORMATIONAL responses (exchange type 5) are NOT used to infer AM support
+// because buggy Main-Mode-only implementations may respond with notifications
+// like NO-PROPOSAL-CHOSEN without validating the exchange type, causing false
+// positives.
 func isIKEv1AggressiveResponse(data []byte) (aggressiveMode bool, ikev1Supported bool) {
 	if !isPlausibleIKEPacket(data) {
 		return false, false
@@ -157,30 +194,11 @@ func isIKEv1AggressiveResponse(data []byte) (aggressiveMode bool, ikev1Supported
 	exchangeType := data[18]
 	if majorVersion == 1 {
 		ikev1Supported = true
-		switch exchangeType {
-		case 4: // Aggressive Mode — direct confirmation
+		if exchangeType == 4 {
 			aggressiveMode = true
-		case 5: // Informational — infer from notification type
-			notifyType := ikeprotocol.ParseIKEv1NotificationType(data)
-			aggressiveMode = isAMConfirmingNotification(notifyType)
 		}
 	}
 	return aggressiveMode, ikev1Supported
-}
-
-// isAMConfirmingNotification returns true for IKEv1 notification types that
-// indicate the server accepted the Aggressive Mode exchange type but rejected
-// our specific proposal or identity. Per RFC 2408 §3.14.1:
-//   - NO-PROPOSAL-CHOSEN (14): AM supported, SA proposals didn't match
-//   - INVALID-ID-INFORMATION (18): AM supported, identity was rejected
-//   - AUTHENTICATION-FAILED (24): AM supported, auth check failed
-func isAMConfirmingNotification(notifyType uint16) bool {
-	switch notifyType {
-	case 14, 18, 24:
-		return true
-	default:
-		return false
-	}
 }
 
 // --- Security Assessment Helpers ---

--- a/internal/enumerate/ike/ike.go
+++ b/internal/enumerate/ike/ike.go
@@ -50,14 +50,25 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 			log.Info("IKEv2 response received", svc1log.SafeParam("target", target), svc1log.SafeParam("ikev2", *serverInfo.Ikev2Supported))
 		}
 	}
-	// IKEv1 Aggressive Mode probe
-	amResponse, err := probeUDP(ctx, target, buildIKEv1AggressiveModeProbe())
-	if err != nil {
-		log.Warn("IKEv1 AM probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
-	} else if len(amResponse) >= 28 {
+	// IKEv1 Aggressive Mode probes — two rounds with different DH groups
+	// to avoid false negatives when a server only accepts MODP-2048.
+	amDetected := false
+	for _, amProbe := range [][]byte{buildIKEv1AggressiveModeProbe(), buildIKEv1AMProbeModp2048()} {
+		if amDetected {
+			break
+		}
+		amResponse, amErr := probeUDP(ctx, target, amProbe)
+		if amErr != nil {
+			log.Warn("IKEv1 AM probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", amErr))
+			continue
+		}
+		if len(amResponse) < 28 {
+			continue
+		}
 		aggressiveMode, ikev1 := isIKEv1AggressiveResponse(amResponse)
 		if aggressiveMode {
 			serverInfo.AggressiveModeEnabled = &aggressiveMode
+			amDetected = true
 		}
 		if ikev1 {
 			serverInfo.Ikev1Supported = &ikev1
@@ -67,6 +78,12 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 			svc1log.SafeParam("target", target),
 			svc1log.SafeParam("aggressiveMode", aggressiveMode),
 			svc1log.SafeParam("ikev1", ikev1))
+	}
+	// Explicitly set AggressiveModeEnabled to false if no probe confirmed it,
+	// so consumers can distinguish "not supported" from "not tested".
+	if serverInfo.AggressiveModeEnabled == nil {
+		amFalse := false
+		serverInfo.AggressiveModeEnabled = &amFalse
 	}
 	// NAT-T probes on UDP 4500 (only if not already probing 4500).
 	// RFC 3948 §2.3 requires a 4-byte Non-ESP marker (0x00000000) before IKE
@@ -87,28 +104,48 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 				}
 			}
 		}
-		// IKEv1 AM NAT-T probe — some devices only respond to AM on port 4500
-		natAMResponse, natAMErr := probeUDP(ctx, natTarget, ikeprotocol.BuildNATTIKEv1AMRequest(buildIKEv1AggressiveModeProbe()))
-		if natAMErr == nil && len(natAMResponse) >= 4 {
+		// IKEv1 AM NAT-T probes — some devices only respond to AM on port 4500.
+		// Try both MODP-1024 and MODP-2048 for the same coverage as the main probes.
+		for _, natAMProbe := range [][]byte{buildIKEv1AggressiveModeProbe(), buildIKEv1AMProbeModp2048()} {
+			natAMResponse, natAMErr := probeUDP(ctx, natTarget, ikeprotocol.BuildNATTIKEv1AMRequest(natAMProbe))
+			if natAMErr != nil || len(natAMResponse) < 4 {
+				continue
+			}
 			// Strip Non-ESP marker (0x00000000) if present per RFC 3948 §2.3.
 			// Some implementations omit it, so only strip if the first 4 bytes are zeros.
 			data := stripNonESPMarker(natAMResponse)
-			if isPlausibleIKEPacket(data) {
-				natT := true
-				serverInfo.NatTraversalSupported = &natT
-				aggressiveMode, ikev1 := isIKEv1AggressiveResponse(data)
-				if aggressiveMode {
-					serverInfo.AggressiveModeEnabled = &aggressiveMode
-				}
-				if ikev1 {
-					serverInfo.Ikev1Supported = &ikev1
-					mergeIKEv1ProposalsIntoServerInfo(ikeprotocol.ParseIKEv1SAResponse(data), &serverInfo)
-				}
-				log.Info("NAT-T port 4500 responded to IKEv1 AM",
-					svc1log.SafeParam("host", host),
-					svc1log.SafeParam("aggressiveMode", aggressiveMode))
+			if !isPlausibleIKEPacket(data) {
+				continue
+			}
+			natT := true
+			serverInfo.NatTraversalSupported = &natT
+			aggressiveMode, ikev1 := isIKEv1AggressiveResponse(data)
+			if aggressiveMode {
+				serverInfo.AggressiveModeEnabled = &aggressiveMode
+			}
+			if ikev1 {
+				serverInfo.Ikev1Supported = &ikev1
+				mergeIKEv1ProposalsIntoServerInfo(ikeprotocol.ParseIKEv1SAResponse(data), &serverInfo)
+			}
+			log.Info("NAT-T port 4500 responded to IKEv1 AM",
+				svc1log.SafeParam("host", host),
+				svc1log.SafeParam("aggressiveMode", aggressiveMode))
+			if aggressiveMode {
+				break // no need for additional probes
 			}
 		}
+	}
+	// Reconcile the version field based on all detected protocol support.
+	// applyIKEv2ResponseToServerInfo sets version from the IKEv2 response
+	// header alone, so it won't reflect IKEv1 support detected by the AM probe.
+	ikev1 := serverInfo.Ikev1Supported != nil && *serverInfo.Ikev1Supported
+	ikev2 := serverInfo.Ikev2Supported != nil && *serverInfo.Ikev2Supported
+	if ikev1 && ikev2 {
+		v := "IKEv1/IKEv2"
+		serverInfo.Version = &v
+	} else if ikev1 && serverInfo.Version == nil {
+		v := "IKEv1"
+		serverInfo.Version = &v
 	}
 	// Vendor ID analysis
 	if len(serverInfo.VendorIds) > 0 {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes IKEv1 Aggressive Mode probing/detection heuristics and packet construction, which can shift reported protocol support (false positives/negatives) and affect downstream consumers of scan results.
> 
> **Overview**
> Improves IKE enumeration accuracy by expanding IKEv1 Aggressive Mode probing and tightening detection.
> 
> The Aggressive Mode probe now supports multiple DH groups (MODP-1024 and MODP-2048) and proposes additional SHA-256 transforms, and enumeration runs both probes (including NAT-T on UDP 4500) to reduce false negatives.
> 
> Aggressive Mode detection is made stricter by only treating exchange type `4` as confirmation (dropping inference from INFORMATIONAL notifications), `AggressiveModeEnabled` is explicitly set to `false` when not confirmed, and the reported `Version` is reconciled to reflect combined IKEv1/IKEv2 support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27e77a6528d78fb03b6b8b6b856e339b4ab6875f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->