### PR TITLE
SNMP Enumerate Tool

### DIFF
--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -63,7 +63,7 @@ func (a *NetworkScan) InitEnumerateCommand() {
 		},
 	}
 	enumerateServiceCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to enumerate")
-	enumerateServiceCmd.Flags().String("service", "", "Service to enumerate (ftp, grpc, ldap, smb, smtp, ssh)")
+	enumerateServiceCmd.Flags().String("service", "", "Service to enumerate (ftp, grpc, ldap, smb, smtp, snmp, ssh)")
 	enumerateServiceCmd.Flags().Int("timeout", 30, "Timeout in seconds for enumerating each target")
 
 	// Mark Required Flags

--- a/fern/definition/enumerate/enumerate.yml
+++ b/fern/definition/enumerate/enumerate.yml
@@ -6,6 +6,7 @@ imports:
   smb: ./smb/smb.yml
   ldap: ./ldap/ldap.yml
   ike: ./ike/ike.yml
+  snmp: ./snmp/snmp.yml
 types:
   # ENUMs
   SupportedServiceType:
@@ -17,6 +18,7 @@ types:
       - SMB
       - LDAP
       - IKE
+      - SNMP
   # Report structs
   EnumerateServiceDetails:
     union:
@@ -27,6 +29,7 @@ types:
       EnumerateSmbDetails: smb.EnumerateSmbDetails
       EnumerateLdapDetails: ldap.EnumerateLdapDetails
       EnumerateIkeDetails: ike.EnumerateIkeDetails
+      EnumerateSnmpDetails: snmp.EnumerateSnmpDetails
   EnumerateServiceResult:
     properties:
       details: optional<list<EnumerateServiceDetails>>

--- a/fern/definition/enumerate/snmp/snmp.yml
+++ b/fern/definition/enumerate/snmp/snmp.yml
@@ -1,0 +1,9 @@
+types:
+  # SNMP Enumeration Details - focused on authentication testing
+  EnumerateSnmpDetails:
+    properties:
+      target: optional<string>
+      v3Detected: optional<boolean> # Whether SNMPv3 engine was found
+      v3NoAuthAccess: optional<boolean> # Whether NoAuthNoPriv grants read access (misconfiguration if true)
+      v3UnauthenticatedUsernames: optional<list<string>> # Usernames that work with NoAuthNoPriv
+      v3RequiredSecurityLevel: optional<string> # Minimum required: noAuthNoPriv, authNoPriv, or authPriv

--- a/internal/discover/service/plugins/snmp.go
+++ b/internal/discover/service/plugins/snmp.go
@@ -3,15 +3,13 @@ package plugins
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"net"
-	"strings"
-	"time"
 
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	snmplib "github.com/Method-Security/networkscan/internal/protocol/snmp"
 	"github.com/gosnmp/gosnmp"
 )
 
@@ -22,44 +20,39 @@ func (SNMPFingerprinter) Name() string { return "snmp" }
 func (SNMPFingerprinter) DefaultPorts() []int { return []int{161, 162} }
 
 func (SNMPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
-	// Test all SNMP versions to get comprehensive version support information
-	// A server can support multiple versions simultaneously (e.g., v1, v2c, AND v3)
+	if port < 1 || port > 65535 {
+		return nil, fmt.Errorf("port %d out of range", port)
+	}
+	snmpPort := uint16(port)
+
 	fingerprintTimeout := 1
 	if timeout < fingerprintTimeout {
 		fingerprintTimeout = timeout
 	}
 
-	// Track all findings across all versions
 	var allVersions []string
 	var allCommunities []string
-	var v3Info *SNMPv3EngineInfo
-	var sysInfo *SNMPSystemInfo
+	var v3Info *snmplib.SNMPv3EngineInfo
+	var sysInfo *snmplib.SNMPSystemInfo
 
 	// Try SNMPv3 discovery FIRST (use at least 2 seconds for discovery round-trip)
 	v3Timeout := fingerprintTimeout
 	if v3Timeout < 2 {
 		v3Timeout = 2
 	}
-	if v3InfoResult, sysDescr, err := trySNMPv3Check(ip, port, v3Timeout); err == nil && v3InfoResult != nil {
+	if v3InfoResult, sysDescr, err := snmplib.TrySNMPv3Discovery(ip, snmpPort, v3Timeout); err == nil && v3InfoResult != nil {
 		allVersions = append(allVersions, "SNMPv3")
 		v3Info = v3InfoResult
-		// Store basic system description from v3
 		if sysDescr != "" && sysInfo == nil {
-			sysInfo = &SNMPSystemInfo{SysDescr: sysDescr}
+			sysInfo = &snmplib.SNMPSystemInfo{SysDescr: sysDescr}
 		}
 	}
 
 	// Try v1/v2c with community strings
-	// Use very short timeout (500ms) since UDP responses are fast
-	// If a server doesn't respond quickly, it's likely not going to respond at all
 	communityTimeout := fingerprintTimeout / 2
 	if communityTimeout < 1 {
 		communityTimeout = 1
 	}
-	// But for the SNMP library, we need to use a fractional timeout
-	// Let's use 0.5 seconds (500ms) which should be plenty for UDP
-	// However, gosnmp timeout is in seconds (int), so minimum is 1
-	// We'll rely on the Retries=0 to make it fast
 
 	type versionTest struct {
 		version     gosnmp.SnmpVersion
@@ -70,279 +63,49 @@ func (SNMPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		{gosnmp.Version1, "SNMPv1"},
 	}
 	communities := []string{"public", "private"}
-
-	// Track which communities work to avoid duplicates
 	workingCommunities := make(map[string]bool)
 
 	for _, vt := range versionTests {
 		versionWorks := false
 		for _, community := range communities {
-			success, sysInfoResult, err := trySNMPCommunityCheck(ip, port, communityTimeout, community, vt.version)
+			success, sysInfoResult, err := snmplib.TrySNMPCommunityCheck(ip, snmpPort, communityTimeout, community, vt.version)
 			if err == nil && success {
 				versionWorks = true
-				// Only add community if we haven't seen it yet
 				if !workingCommunities[community] {
 					allCommunities = append(allCommunities, community)
 					workingCommunities[community] = true
 				}
-				// Use full system info from the first successful community check
 				if sysInfo == nil || sysInfo.SysName == "" {
 					sysInfo = sysInfoResult
 				}
 			}
 		}
-		// If this version works with any community, add it to the list
 		if versionWorks {
 			allVersions = append(allVersions, vt.versionName)
 		}
 	}
 
-	// If we found any working SNMP version, create a comprehensive result
 	if len(allVersions) > 0 {
-		return createCombinedSNMPResult(ip, port, host, allVersions, allCommunities, v3Info, sysInfo), nil
+		return createSNMPResult(ip, port, host, allVersions, allCommunities, v3Info, sysInfo), nil
 	}
 
-	// If nothing worked, service not detected
 	return nil, fmt.Errorf("no SNMP response")
 }
 
-// trySNMPv3Check attempts to discover SNMPv3 engine information
-// Returns engine info, system description, and error
-func trySNMPv3Check(ip net.IP, port int, timeout int) (*SNMPv3EngineInfo, string, error) {
-	// Create GoSNMP instance for SNMPv3 discovery
-	// For SNMPv3 discovery, we need to first discover the engine ID without authentication
-	// This is done by sending a packet with empty engine ID and credentials
-	g := &gosnmp.GoSNMP{
-		Target:    ip.String(),
-		Port:      uint16(port),
-		Version:   gosnmp.Version3,
-		Timeout:   time.Duration(timeout) * time.Second,
-		Retries:   2, // Increased retries for SNMPv3 discovery
-		Transport: "udp",
-		// For discovery, we use no authentication
-		SecurityModel: gosnmp.UserSecurityModel,
-		MsgFlags:      gosnmp.NoAuthNoPriv,
-		SecurityParameters: &gosnmp.UsmSecurityParameters{
-			UserName:                 "public", // Username required by library even for discovery
-			AuthoritativeEngineID:    "",       // Empty engine ID triggers discovery
-			AuthoritativeEngineBoots: 0,
-			AuthoritativeEngineTime:  0,
-		},
-	}
-
-	err := g.Connect()
-	if err != nil {
-		return nil, "", err
-	}
-	defer func() { _ = g.Close() }()
-
-	// Try to get system description - this will trigger SNMPv3 engine discovery internally
-	// The gosnmp library automatically sends a discovery packet first if needed
-	oids := []string{"1.3.6.1.2.1.1.1.0"} // sysDescr
-	result, err := g.Get(oids)
-
-	// Even if Get fails (e.g., "unknown username"), check if we got engine information from the discovery
-	// SNMPv3 discovery happens automatically when the engine ID is empty, and we get the engine info
-	// back even if authentication fails
-	usmParams := g.SecurityParameters.(*gosnmp.UsmSecurityParameters)
-	if len(usmParams.AuthoritativeEngineID) > 0 {
-		// We successfully discovered an SNMPv3 engine
-		// AuthoritativeEngineID is stored as raw bytes in a string
-		engineIDBytes := []byte(usmParams.AuthoritativeEngineID)
-		engineIDHex := hex.EncodeToString(engineIDBytes)
-
-		engineInfo := &SNMPv3EngineInfo{
-			EngineID:    engineIDHex,
-			EngineBoots: int(usmParams.AuthoritativeEngineBoots),
-			EngineTime:  int(usmParams.AuthoritativeEngineTime),
-		}
-
-		// Parse engine ID format from raw bytes
-		engineInfo.EngineIDFormat, engineInfo.EngineIDData, engineInfo.Enterprise =
-			parseEngineID(engineIDBytes)
-
-		// Add system description if we got it successfully
-		var sysDescr string
-		if err == nil && len(result.Variables) > 0 && result.Variables[0].Value != nil {
-			switch v := result.Variables[0].Value.(type) {
-			case []byte:
-				sysDescr = string(v)
-			case string:
-				sysDescr = v
-			default:
-				sysDescr = fmt.Sprintf("%v", v)
-			}
-		}
-
-		return engineInfo, sysDescr, nil
-	}
-
-	// No engine information received
-	if err != nil {
-		return nil, "", err
-	}
-	return nil, "", fmt.Errorf("no SNMPv3 engine information received")
-}
-
-// SNMPSystemInfo holds additional SNMP system information
-type SNMPSystemInfo struct {
-	SysDescr    string
-	SysObjectID string
-	SysUpTime   uint32
-	SysContact  string
-	SysName     string
-	SysLocation string
-	SysServices int
-}
-
-// trySNMPCommunityCheck tests if an SNMP community string works
-// Returns success status, system info, and error
-func trySNMPCommunityCheck(ip net.IP, port int, timeout int, community string, version gosnmp.SnmpVersion) (bool, *SNMPSystemInfo, error) {
-	g := &gosnmp.GoSNMP{
-		Target:    ip.String(),
-		Port:      uint16(port),
-		Community: community,
-		Version:   version,
-		Timeout:   time.Duration(timeout) * time.Second,
-		Retries:   0, // No retries for faster detection when testing multiple versions
-		Transport: "udp",
-	}
-
-	err := g.Connect()
-	if err != nil {
-		return false, nil, err
-	}
-	defer func() { _ = g.Close() }()
-
-	// Query multiple system OIDs in one request for efficiency
-	oids := []string{
-		"1.3.6.1.2.1.1.1.0", // sysDescr
-		"1.3.6.1.2.1.1.2.0", // sysObjectID
-		"1.3.6.1.2.1.1.3.0", // sysUpTime
-		"1.3.6.1.2.1.1.4.0", // sysContact
-		"1.3.6.1.2.1.1.5.0", // sysName
-		"1.3.6.1.2.1.1.6.0", // sysLocation
-		"1.3.6.1.2.1.1.7.0", // sysServices
-	}
-
-	result, err := g.Get(oids)
-	if err != nil {
-		return false, nil, err
-	}
-
-	sysInfo := &SNMPSystemInfo{}
-
-	// Extract values from response
-	if len(result.Variables) >= 1 {
-		sysInfo.SysDescr = extractStringValue(result.Variables[0].Value)
-	}
-	if len(result.Variables) >= 2 {
-		if oid, ok := result.Variables[1].Value.(string); ok {
-			sysInfo.SysObjectID = oid
-		}
-	}
-	if len(result.Variables) >= 3 {
-		if uptime, ok := result.Variables[2].Value.(uint32); ok {
-			sysInfo.SysUpTime = uptime
-		}
-	}
-	if len(result.Variables) >= 4 {
-		sysInfo.SysContact = extractStringValue(result.Variables[3].Value)
-	}
-	if len(result.Variables) >= 5 {
-		sysInfo.SysName = extractStringValue(result.Variables[4].Value)
-	}
-	if len(result.Variables) >= 6 {
-		sysInfo.SysLocation = extractStringValue(result.Variables[5].Value)
-	}
-	if len(result.Variables) >= 7 {
-		if services, ok := result.Variables[6].Value.(int); ok {
-			sysInfo.SysServices = services
-		}
-	}
-
-	return true, sysInfo, nil
-}
-
-// extractStringValue converts various SNMP value types to string
-func extractStringValue(value interface{}) string {
-	switch v := value.(type) {
-	case []byte: // Note: []byte and []uint8 are the same type
-		return string(v)
-	case string:
-		return v
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}
-
-// createCombinedSNMPResult creates a ServiceDetails result combining all detected SNMP versions
-func createCombinedSNMPResult(ip net.IP, port int, host string, versions []string, communities []string, v3Info *SNMPv3EngineInfo, sysInfo *SNMPSystemInfo) *discoverfern.ServiceDetails {
+// createSNMPResult creates a ServiceDetails result combining all detected SNMP versions
+func createSNMPResult(ip net.IP, port int, host string, versions []string, communities []string, v3Info *snmplib.SNMPv3EngineInfo, sysInfo *snmplib.SNMPSystemInfo) *discoverfern.ServiceDetails {
 	metadata := &protocol.SnmpServerInfo{
 		Versions: versions,
 	}
 
-	// Add community strings if any were found
 	if len(communities) > 0 {
 		metadata.CommunityStrings = communities
 	}
 
-	// Add system information from successful SNMP queries
-	if sysInfo != nil {
-		if sysInfo.SysDescr != "" {
-			metadata.SystemDescription = &sysInfo.SysDescr
-		}
-		if sysInfo.SysObjectID != "" {
-			metadata.SysObjectId = &sysInfo.SysObjectID
-		}
-		if sysInfo.SysUpTime > 0 {
-			uptime := formatUptime(int(sysInfo.SysUpTime / 100)) // Convert centiseconds to seconds
-			metadata.SysUptime = &uptime
-		}
-		if sysInfo.SysContact != "" {
-			metadata.SysContact = &sysInfo.SysContact
-		}
-		if sysInfo.SysName != "" {
-			metadata.SysName = &sysInfo.SysName
-		}
-		if sysInfo.SysLocation != "" {
-			metadata.SysLocation = &sysInfo.SysLocation
-		}
-		if sysInfo.SysServices > 0 {
-			metadata.SysServices = &sysInfo.SysServices
-		}
-	}
+	snmplib.PopulateServerInfo(metadata, v3Info, sysInfo)
 
-	// Add v3 engine information if available
-	if v3Info != nil {
-		if v3Info.EngineID != "" {
-			metadata.V3EngineId = &v3Info.EngineID
-			metadata.V3EngineIdFormat = &v3Info.EngineIDFormat
-			if v3Info.EngineIDData != "" {
-				metadata.V3EngineIdData = &v3Info.EngineIDData
-			}
-		}
-		if v3Info.EngineBoots > 0 {
-			metadata.V3EngineBoots = &v3Info.EngineBoots
-		}
-		if v3Info.EngineTime > 0 {
-			metadata.V3EngineTime = &v3Info.EngineTime
-			uptime := formatUptime(v3Info.EngineTime)
-			metadata.V3EngineUptime = &uptime
-		}
-		if v3Info.Enterprise > 0 {
-			metadata.V3Enterprise = &v3Info.Enterprise
-			// Add enterprise name lookup
-			enterpriseName := lookupEnterpriseName(v3Info.Enterprise)
-			if enterpriseName != "" {
-				metadata.V3EnterpriseName = &enterpriseName
-			}
-		}
-	}
-
-	// Use the highest version as the primary version string
 	versionStr := versions[len(versions)-1]
-	result := &discoverfern.ServiceDetails{
+	return &discoverfern.ServiceDetails{
 		Host:      host,
 		Ip:        ip.String(),
 		Port:      port,
@@ -352,110 +115,4 @@ func createCombinedSNMPResult(ip net.IP, port int, host string, versions []strin
 		Version:   &versionStr,
 		Metadata:  discoverfern.NewServiceMetadataFromSnmp(metadata),
 	}
-
-	return result
-}
-
-// lookupEnterpriseName returns the enterprise name for a given enterprise ID
-// This is a simple lookup for common vendors. For a complete solution, you'd want
-// to download and parse the IANA enterprise numbers file periodically.
-func lookupEnterpriseName(enterpriseID int) string {
-	// Common enterprise IDs - add more as needed
-	enterpriseNames := map[int]string{
-		9:     "Cisco",
-		11:    "HP",
-		43:    "3Com",
-		311:   "Microsoft",
-		2011:  "Huawei",
-		2636:  "Juniper",
-		6876:  "VMware",
-		8072:  "Net-SNMP",
-		14988: "MikroTik",
-		25506: "H3C",
-		35098: "Arista",
-	}
-
-	if name, ok := enterpriseNames[enterpriseID]; ok {
-		return name
-	}
-	return ""
-}
-
-// SNMPv3EngineInfo holds SNMPv3 engine discovery information
-type SNMPv3EngineInfo struct {
-	EngineID       string
-	EngineIDFormat string
-	EngineIDData   string
-	EngineBoots    int
-	EngineTime     int
-	Enterprise     int
-}
-
-// parseEngineID analyzes the engine ID format and extracts relevant information
-func parseEngineID(engineID []byte) (format, data string, enterprise int) {
-	if len(engineID) < 5 {
-		return "unknown", "", 0
-	}
-
-	// First 4 bytes are enterprise ID (bits 0-30, bit 31 is the format indicator)
-	// We need to mask off the high bit which indicates RFC3411 format
-	enterprise = (int(engineID[0])<<24 | int(engineID[1])<<16 | int(engineID[2])<<8 | int(engineID[3])) & 0x7FFFFFFF
-
-	if len(engineID) < 6 {
-		return "enterprise", "", enterprise
-	}
-
-	// 5th byte indicates format
-	formatByte := engineID[4]
-	remainder := engineID[5:]
-
-	switch formatByte {
-	case 1:
-		if len(remainder) >= 4 {
-			return "ipv4", fmt.Sprintf("%d.%d.%d.%d", remainder[0], remainder[1], remainder[2], remainder[3]), enterprise
-		}
-	case 2:
-		if len(remainder) >= 16 {
-			return "ipv6", hex.EncodeToString(remainder[:16]), enterprise
-		}
-	case 3:
-		if len(remainder) >= 6 {
-			return "mac", fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
-				remainder[0], remainder[1], remainder[2], remainder[3], remainder[4], remainder[5]), enterprise
-		}
-	case 4:
-		return "text", string(remainder), enterprise
-	case 5:
-		return "octets", hex.EncodeToString(remainder), enterprise
-	default:
-		return "reserved", hex.EncodeToString(remainder), enterprise
-	}
-
-	return "unknown", hex.EncodeToString(remainder), enterprise
-}
-
-// formatUptime converts engine time (seconds) to a human-readable format
-func formatUptime(seconds int) string {
-	if seconds <= 0 {
-		return "0 seconds"
-	}
-
-	days := seconds / 86400
-	hours := (seconds % 86400) / 3600
-	minutes := (seconds % 3600) / 60
-	secs := seconds % 60
-
-	var parts []string
-	if days > 0 {
-		parts = append(parts, fmt.Sprintf("%d days", days))
-	}
-	if hours > 0 || days > 0 {
-		parts = append(parts, fmt.Sprintf("%02d:%02d:%02d", hours, minutes, secs))
-	} else if minutes > 0 {
-		parts = append(parts, fmt.Sprintf("%d:%02d", minutes, secs))
-	} else {
-		parts = append(parts, fmt.Sprintf("%d seconds", secs))
-	}
-
-	return strings.Join(parts, ", ")
 }

--- a/internal/enumerate/engine.go
+++ b/internal/enumerate/engine.go
@@ -17,6 +17,7 @@ import (
 	ldap "github.com/Method-Security/networkscan/internal/enumerate/ldap"
 	smb "github.com/Method-Security/networkscan/internal/enumerate/smb"
 	smtp "github.com/Method-Security/networkscan/internal/enumerate/smtp"
+	snmp "github.com/Method-Security/networkscan/internal/enumerate/snmp"
 	ssh "github.com/Method-Security/networkscan/internal/enumerate/ssh"
 
 	// External
@@ -146,6 +147,8 @@ func getEngine(serviceType enumeratefern.SupportedServiceType) (NetworkApplicati
 		return NetworkApplicationEngine{Library: &ldap.LibraryEnumerateLDAP{}}, nil
 	case enumeratefern.SupportedServiceTypeIke:
 		return NetworkApplicationEngine{Library: &ike.LibraryEnumerateIKE{}}, nil
+	case enumeratefern.SupportedServiceTypeSnmp:
+		return NetworkApplicationEngine{Library: &snmp.LibraryEnumerateSNMP{}}, nil
 	default:
 		return NetworkApplicationEngine{}, fmt.Errorf("unsupported network application: %v", serviceType)
 	}

--- a/internal/enumerate/snmp/snmp.go
+++ b/internal/enumerate/snmp/snmp.go
@@ -1,0 +1,88 @@
+// Package snmp implements SNMP authentication testing using the GoSNMP library.
+package snmp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
+	snmpfern "github.com/Method-Security/networkscan/generated/go/enumerate/snmp"
+	snmplib "github.com/Method-Security/networkscan/internal/protocol/snmp"
+)
+
+// LibraryEnumerateSNMP implements NetworkApplicationLibrary for SNMP enumeration.
+type LibraryEnumerateSNMP struct{}
+
+// EnumerateTarget tests SNMP authentication posture:
+// 1. Parse host and port from target string
+// 2. Try SNMPv3 engine discovery to confirm v3 is present
+// 3. Test if NoAuthNoPriv grants actual read access with common usernames
+// 4. Report the required security level and which usernames work unauthenticated
+func (s *LibraryEnumerateSNMP) EnumerateTarget(ctx context.Context, target string) (*enumeratefern.EnumerateServiceDetails, []string) {
+	var details snmpfern.EnumerateSnmpDetails
+	details.Target = &target
+	errors := []string{}
+
+	host, portStr, err := net.SplitHostPort(target)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("invalid target format %q: %v", target, err))
+		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("invalid port %q: %v", portStr, err))
+		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+	}
+	if port < 1 || port > 65535 {
+		errors = append(errors, fmt.Sprintf("port %d out of range (1-65535)", port))
+		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+	}
+	snmpPort := uint16(port)
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		ips, err := net.LookupIP(host)
+		if err != nil || len(ips) == 0 {
+			errors = append(errors, fmt.Sprintf("cannot resolve host %q: %v", host, err))
+			return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+		}
+		ip = ips[0]
+	}
+
+	// SNMPv3 engine discovery — needed to confirm v3 is present before auth testing
+	v3Info, _, v3Err := snmplib.TrySNMPv3Discovery(ip, snmpPort, 2)
+	v3Detected := v3Info != nil
+	details.V3Detected = &v3Detected
+
+	if !v3Detected {
+		if v3Err != nil {
+			errors = append(errors, fmt.Sprintf("SNMPv3 not detected: %v", v3Err))
+		} else {
+			errors = append(errors, "SNMPv3 not detected on target")
+		}
+		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+	}
+
+	// Test if NoAuthNoPriv grants actual read access with common usernames
+	var workingUsernames []string
+	for _, username := range snmplib.CommonNoAuthUsernames {
+		if ok, _ := snmplib.TrySNMPv3NoAuthGet(ip, snmpPort, username); ok {
+			workingUsernames = append(workingUsernames, username)
+		}
+	}
+
+	noAuthAccess := len(workingUsernames) > 0
+	details.V3NoAuthAccess = &noAuthAccess
+	if noAuthAccess {
+		details.V3UnauthenticatedUsernames = workingUsernames
+		level := "noAuthNoPriv"
+		details.V3RequiredSecurityLevel = &level
+	} else {
+		level := "authNoPriv"
+		details.V3RequiredSecurityLevel = &level
+	}
+
+	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+}

--- a/internal/protocol/snmp/snmp.go
+++ b/internal/protocol/snmp/snmp.go
@@ -1,0 +1,374 @@
+// Package snmp provides shared SNMP protocol helpers used by both discover and enumerate modules.
+package snmp
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	commonprotocolfern "github.com/Method-Security/networkscan/generated/go/common/protocol"
+	"github.com/gosnmp/gosnmp"
+)
+
+// SNMPv3EngineInfo holds SNMPv3 engine discovery information.
+type SNMPv3EngineInfo struct {
+	EngineID       string
+	EngineIDFormat string
+	EngineIDData   string
+	EngineBoots    int
+	EngineTime     int
+	Enterprise     int
+}
+
+// SNMPSystemInfo holds SNMP system MIB information.
+type SNMPSystemInfo struct {
+	SysDescr    string
+	SysObjectID string
+	SysUpTime   uint32
+	SysContact  string
+	SysName     string
+	SysLocation string
+	SysServices int
+}
+
+// SystemOIDs are the standard system MIB OIDs queried by SNMP operations.
+var SystemOIDs = []string{
+	"1.3.6.1.2.1.1.1.0", // sysDescr
+	"1.3.6.1.2.1.1.2.0", // sysObjectID
+	"1.3.6.1.2.1.1.3.0", // sysUpTime
+	"1.3.6.1.2.1.1.4.0", // sysContact
+	"1.3.6.1.2.1.1.5.0", // sysName
+	"1.3.6.1.2.1.1.6.0", // sysLocation
+	"1.3.6.1.2.1.1.7.0", // sysServices
+}
+
+// TrySNMPv3Discovery attempts SNMPv3 engine discovery.
+// Returns engine info, system description (if available), and error.
+func TrySNMPv3Discovery(ip net.IP, port uint16, timeout int) (*SNMPv3EngineInfo, string, error) {
+	g := &gosnmp.GoSNMP{
+		Target:        ip.String(),
+		Port:          port,
+		Version:       gosnmp.Version3,
+		Timeout:       time.Duration(timeout) * time.Second,
+		Retries:       2,
+		Transport:     "udp",
+		SecurityModel: gosnmp.UserSecurityModel,
+		MsgFlags:      gosnmp.NoAuthNoPriv,
+		SecurityParameters: &gosnmp.UsmSecurityParameters{
+			UserName:                 "public",
+			AuthoritativeEngineID:    "",
+			AuthoritativeEngineBoots: 0,
+			AuthoritativeEngineTime:  0,
+		},
+	}
+
+	err := g.Connect()
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = g.Close() }()
+
+	result, getErr := g.Get([]string{"1.3.6.1.2.1.1.1.0"})
+
+	usmParams := g.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+	if len(usmParams.AuthoritativeEngineID) == 0 {
+		if getErr != nil {
+			return nil, "", getErr
+		}
+		return nil, "", fmt.Errorf("no SNMPv3 engine information received")
+	}
+
+	engineIDBytes := []byte(usmParams.AuthoritativeEngineID)
+	engineIDHex := hex.EncodeToString(engineIDBytes)
+
+	engineInfo := &SNMPv3EngineInfo{
+		EngineID:    engineIDHex,
+		EngineBoots: int(usmParams.AuthoritativeEngineBoots),
+		EngineTime:  int(usmParams.AuthoritativeEngineTime),
+	}
+
+	engineInfo.EngineIDFormat, engineInfo.EngineIDData, engineInfo.Enterprise =
+		ParseEngineID(engineIDBytes)
+
+	var sysDescr string
+	if getErr == nil && len(result.Variables) > 0 && result.Variables[0].Value != nil {
+		sysDescr = ExtractStringValue(result.Variables[0].Value)
+	}
+
+	return engineInfo, sysDescr, nil
+}
+
+// TrySNMPCommunityCheck tests if an SNMP community string works.
+// Returns success status, system info, and error.
+func TrySNMPCommunityCheck(ip net.IP, port uint16, timeout int, community string, version gosnmp.SnmpVersion) (bool, *SNMPSystemInfo, error) {
+	g := &gosnmp.GoSNMP{
+		Target:    ip.String(),
+		Port:      port,
+		Community: community,
+		Version:   version,
+		Timeout:   time.Duration(timeout) * time.Second,
+		Retries:   0,
+		Transport: "udp",
+	}
+
+	err := g.Connect()
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() { _ = g.Close() }()
+
+	result, err := g.Get(SystemOIDs)
+	if err != nil {
+		return false, nil, err
+	}
+
+	sysInfo := ParseSystemInfo(result)
+	return true, sysInfo, nil
+}
+
+// TrySNMPv3NoAuthGet attempts a single SNMPv3 GET with NoAuthNoPriv for a specific username.
+// Returns true if the GET succeeds (unauthenticated read access is allowed).
+// Also returns parsed system info if the query succeeded.
+func TrySNMPv3NoAuthGet(ip net.IP, port uint16, username string) (bool, *SNMPSystemInfo) {
+	g := &gosnmp.GoSNMP{
+		Target:        ip.String(),
+		Port:          port,
+		Version:       gosnmp.Version3,
+		Timeout:       2 * time.Second,
+		Retries:       0,
+		Transport:     "udp",
+		SecurityModel: gosnmp.UserSecurityModel,
+		MsgFlags:      gosnmp.NoAuthNoPriv,
+		SecurityParameters: &gosnmp.UsmSecurityParameters{
+			UserName:                 username,
+			AuthoritativeEngineID:    "",
+			AuthoritativeEngineBoots: 0,
+			AuthoritativeEngineTime:  0,
+		},
+	}
+
+	err := g.Connect()
+	if err != nil {
+		return false, nil
+	}
+	defer func() { _ = g.Close() }()
+
+	result, err := g.Get(SystemOIDs)
+	if err != nil {
+		return false, nil
+	}
+
+	if len(result.Variables) == 0 || result.Variables[0].Type == gosnmp.NoSuchObject ||
+		result.Variables[0].Type == gosnmp.NoSuchInstance {
+		return false, nil
+	}
+
+	return true, ParseSystemInfo(result)
+}
+
+// ParseSystemInfo extracts system MIB values from an SNMP GET result.
+func ParseSystemInfo(result *gosnmp.SnmpPacket) *SNMPSystemInfo {
+	sysInfo := &SNMPSystemInfo{}
+
+	if len(result.Variables) >= 1 {
+		sysInfo.SysDescr = ExtractStringValue(result.Variables[0].Value)
+	}
+	if len(result.Variables) >= 2 {
+		if oid, ok := result.Variables[1].Value.(string); ok {
+			sysInfo.SysObjectID = oid
+		}
+	}
+	if len(result.Variables) >= 3 {
+		if uptime, ok := result.Variables[2].Value.(uint32); ok {
+			sysInfo.SysUpTime = uptime
+		}
+	}
+	if len(result.Variables) >= 4 {
+		sysInfo.SysContact = ExtractStringValue(result.Variables[3].Value)
+	}
+	if len(result.Variables) >= 5 {
+		sysInfo.SysName = ExtractStringValue(result.Variables[4].Value)
+	}
+	if len(result.Variables) >= 6 {
+		sysInfo.SysLocation = ExtractStringValue(result.Variables[5].Value)
+	}
+	if len(result.Variables) >= 7 {
+		if services, ok := result.Variables[6].Value.(int); ok {
+			sysInfo.SysServices = services
+		}
+	}
+
+	return sysInfo
+}
+
+// PopulateServerInfo fills a SnmpServerInfo from SNMPv3EngineInfo and SNMPSystemInfo.
+func PopulateServerInfo(serverInfo *commonprotocolfern.SnmpServerInfo, v3Info *SNMPv3EngineInfo, sysInfo *SNMPSystemInfo) {
+	if v3Info != nil {
+		if serverInfo.V3EngineId == nil {
+			serverInfo.V3EngineId = &v3Info.EngineID
+		}
+		if serverInfo.V3EngineIdFormat == nil {
+			serverInfo.V3EngineIdFormat = &v3Info.EngineIDFormat
+		}
+		if v3Info.EngineIDData != "" && serverInfo.V3EngineIdData == nil {
+			serverInfo.V3EngineIdData = &v3Info.EngineIDData
+		}
+		if v3Info.EngineBoots > 0 && serverInfo.V3EngineBoots == nil {
+			serverInfo.V3EngineBoots = &v3Info.EngineBoots
+		}
+		if v3Info.EngineTime > 0 && serverInfo.V3EngineTime == nil {
+			serverInfo.V3EngineTime = &v3Info.EngineTime
+			uptime := FormatUptime(v3Info.EngineTime)
+			serverInfo.V3EngineUptime = &uptime
+		}
+		if v3Info.Enterprise > 0 && serverInfo.V3Enterprise == nil {
+			serverInfo.V3Enterprise = &v3Info.Enterprise
+			if name := LookupEnterpriseName(v3Info.Enterprise); name != "" {
+				serverInfo.V3EnterpriseName = &name
+			}
+		}
+	}
+
+	if sysInfo != nil {
+		if sysInfo.SysDescr != "" && serverInfo.SystemDescription == nil {
+			serverInfo.SystemDescription = &sysInfo.SysDescr
+		}
+		if sysInfo.SysObjectID != "" && serverInfo.SysObjectId == nil {
+			serverInfo.SysObjectId = &sysInfo.SysObjectID
+		}
+		if sysInfo.SysUpTime > 0 && serverInfo.SysUptime == nil {
+			uptime := FormatUptime(int(sysInfo.SysUpTime / 100))
+			serverInfo.SysUptime = &uptime
+		}
+		if sysInfo.SysContact != "" && serverInfo.SysContact == nil {
+			serverInfo.SysContact = &sysInfo.SysContact
+		}
+		if sysInfo.SysName != "" && serverInfo.SysName == nil {
+			serverInfo.SysName = &sysInfo.SysName
+		}
+		if sysInfo.SysLocation != "" && serverInfo.SysLocation == nil {
+			serverInfo.SysLocation = &sysInfo.SysLocation
+		}
+		if sysInfo.SysServices > 0 && serverInfo.SysServices == nil {
+			serverInfo.SysServices = &sysInfo.SysServices
+		}
+	}
+}
+
+// ExtractStringValue converts various SNMP value types to string.
+// Returns empty string for nil values to avoid "<nil>" literals.
+func ExtractStringValue(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case []byte:
+		return string(v)
+	case string:
+		return v
+	default:
+		return ""
+	}
+}
+
+// ParseEngineID analyzes the engine ID format and extracts relevant information.
+func ParseEngineID(engineID []byte) (format, data string, enterprise int) {
+	if len(engineID) < 5 {
+		return "unknown", "", 0
+	}
+
+	enterprise = (int(engineID[0])<<24 | int(engineID[1])<<16 | int(engineID[2])<<8 | int(engineID[3])) & 0x7FFFFFFF
+
+	if len(engineID) < 6 {
+		return "enterprise", "", enterprise
+	}
+
+	formatByte := engineID[4]
+	remainder := engineID[5:]
+
+	switch formatByte {
+	case 1:
+		if len(remainder) >= 4 {
+			return "ipv4", fmt.Sprintf("%d.%d.%d.%d", remainder[0], remainder[1], remainder[2], remainder[3]), enterprise
+		}
+	case 2:
+		if len(remainder) >= 16 {
+			return "ipv6", hex.EncodeToString(remainder[:16]), enterprise
+		}
+	case 3:
+		if len(remainder) >= 6 {
+			return "mac", fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
+				remainder[0], remainder[1], remainder[2], remainder[3], remainder[4], remainder[5]), enterprise
+		}
+	case 4:
+		return "text", string(remainder), enterprise
+	case 5:
+		return "octets", hex.EncodeToString(remainder), enterprise
+	default:
+		return "reserved", hex.EncodeToString(remainder), enterprise
+	}
+
+	return "unknown", hex.EncodeToString(remainder), enterprise
+}
+
+// FormatUptime converts seconds to a human-readable format.
+func FormatUptime(seconds int) string {
+	if seconds <= 0 {
+		return "0 seconds"
+	}
+
+	days := seconds / 86400
+	hours := (seconds % 86400) / 3600
+	minutes := (seconds % 3600) / 60
+	secs := seconds % 60
+
+	var parts []string
+	if days > 0 {
+		parts = append(parts, fmt.Sprintf("%d days", days))
+	}
+	if hours > 0 || days > 0 {
+		parts = append(parts, fmt.Sprintf("%02d:%02d:%02d", hours, minutes, secs))
+	} else if minutes > 0 {
+		parts = append(parts, fmt.Sprintf("%d:%02d", minutes, secs))
+	} else {
+		parts = append(parts, fmt.Sprintf("%d seconds", secs))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// LookupEnterpriseName returns the enterprise name for a given enterprise ID.
+func LookupEnterpriseName(enterpriseID int) string {
+	enterpriseNames := map[int]string{
+		9:     "Cisco",
+		11:    "HP",
+		43:    "3Com",
+		311:   "Microsoft",
+		2011:  "Huawei",
+		2636:  "Juniper",
+		6876:  "VMware",
+		8072:  "Net-SNMP",
+		14988: "MikroTik",
+		25506: "H3C",
+		35098: "Arista",
+	}
+
+	if name, ok := enterpriseNames[enterpriseID]; ok {
+		return name
+	}
+	return ""
+}
+
+// CommonNoAuthUsernames are the default usernames tested for NoAuthNoPriv access.
+var CommonNoAuthUsernames = []string{
+	"public",
+	"initial",
+	"admin",
+	"snmpuser",
+	"default",
+	"monitor",
+	"noauth",
+	"",
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds active SNMPv3 probing and new enumeration logic, which can affect scan behavior/timeouts and touches protocol-level networking code used in discovery.
> 
> **Overview**
> Adds **SNMP** as a supported `enumerate service` target (CLI + Fern API schema), including a new `EnumerateSnmpDetails` report focused on SNMPv3 auth posture (engine detection, NoAuthNoPriv access, and working usernames).
> 
> Implements SNMP enumeration that performs SNMPv3 engine discovery and tests common usernames for unauthenticated read access.
> 
> Refactors SNMP discovery fingerprinting by extracting its SNMPv3/community/system-parsing logic into a new shared `internal/protocol/snmp` helper package and reusing it from the discovery plugin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be3f694a7a78067340417c0271e12620297f59e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->