### PR TITLE
Add custom SMTP service fingerprinter

### DIFF
--- a/fern/definition/common/protocol/smtp.yml
+++ b/fern/definition/common/protocol/smtp.yml
@@ -1,0 +1,12 @@
+types:
+  # SMTP Server Information
+  SmtpServerInfo:
+    properties:
+      banner: optional<string>
+      serverName: optional<string>
+      softwareName: optional<string>
+      softwareVersion: optional<string>
+      esmtpSupported: optional<boolean>
+      tlsSupported: optional<boolean>
+      authMethods: optional<list<string>>
+      supportedExtensions: optional<list<string>>

--- a/fern/definition/common/protocol/smtp.yml
+++ b/fern/definition/common/protocol/smtp.yml
@@ -1,4 +1,14 @@
 types:
+  # ENUMs
+  SmtpAuthCommand:
+    enum:
+      - XOAUTH2
+      - PLAIN
+      - LOGIN
+      - CRAMMD5
+      - NTLM
+      - GSSAPI
+
   # SMTP Server Information
   SmtpServerInfo:
     properties:
@@ -8,5 +18,5 @@ types:
       softwareVersion: optional<string>
       esmtpSupported: optional<boolean>
       tlsSupported: optional<boolean>
-      authMethods: optional<list<string>>
+      authMethods: optional<list<SmtpAuthCommand>>
       supportedExtensions: optional<list<string>>

--- a/fern/definition/discover/service.yml
+++ b/fern/definition/discover/service.yml
@@ -39,6 +39,7 @@ imports:
   foxProtocol: ../common/protocol/fox.yml
   memcachedProtocol: ../common/protocol/memcached.yml
   unistreamProtocol: ../common/protocol/unistream.yml
+  smtpProtocol: ../common/protocol/smtp.yml
 
 types:
   # Generic metadata for fingerprintx and other sources
@@ -90,6 +91,7 @@ types:
       fox: foxProtocol.FoxServerInfo
       memcached: memcachedProtocol.MemcachedServerInfo
       unistream: unistreamProtocol.UnistreamServerInfo
+      smtp: smtpProtocol.SmtpServerInfo
 
   # Stealth service types
   StealthServiceType:

--- a/fern/definition/enumerate/smtp/smtp.yml
+++ b/fern/definition/enumerate/smtp/smtp.yml
@@ -1,25 +1,12 @@
+imports:
+  smtpProtocol: ../../common/protocol/smtp.yml
+
 types:
-  # ENUMs
-  AuthCommand:
-    enum:
-      - XOAUTH2
-      - PLAIN
-      - LOGIN
-      - CRAMMD5
-      - NTLM
-      - GSSAPI
   # Report structs
   EnumerateSmtpDetails:
     properties:
       target: string
       canConnect: optional<boolean>
-      banner: optional<string>
-      serverName: optional<string>
-      softwareName: optional<string>
-      softwareVersion: optional<string>
-      esmtpSupported: optional<boolean>
-      tlsSupported: optional<boolean>
+      serverInfo: optional<smtpProtocol.SmtpServerInfo>
       forceTLS: optional<boolean>
-      authCommands: optional<list<AuthCommand>>
-      supportedExtensions: optional<list<string>>
       allowsUnauthenticatedEmail: optional<boolean>

--- a/fern/definition/enumerate/smtp/smtp.yml
+++ b/fern/definition/enumerate/smtp/smtp.yml
@@ -13,7 +13,13 @@ types:
     properties:
       target: string
       canConnect: optional<boolean>
+      banner: optional<string>
+      serverName: optional<string>
+      softwareName: optional<string>
+      softwareVersion: optional<string>
+      esmtpSupported: optional<boolean>
       tlsSupported: optional<boolean>
       forceTLS: optional<boolean>
       authCommands: optional<list<AuthCommand>>
+      supportedExtensions: optional<list<string>>
       allowsUnauthenticatedEmail: optional<boolean>

--- a/internal/discover/service/plugins/smtp.go
+++ b/internal/discover/service/plugins/smtp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	smtputil "github.com/Method-Security/networkscan/internal/protocol/smtp"
 )
 
 type SMTPFingerprinter struct{}
@@ -62,7 +63,7 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	banner := bannerLines[0]
 
 	// Parse banner for server info
-	serverName, softwareName, softwareVersion := parseSMTPBanner(banner)
+	serverName, softwareName, softwareVersion := smtputil.ParseBanner(banner)
 	esmtp := strings.Contains(banner, "ESMTP")
 
 	// Send EHLO to discover capabilities
@@ -158,56 +159,4 @@ func buildSMTPResult(host string, ip net.IP, port int, banner, serverName, softw
 		Version:   &version,
 		Metadata:  discoverfern.NewServiceMetadataFromSmtp(metadata),
 	}
-}
-
-// parseSMTPBanner extracts server name and software info from a 220 banner.
-// Common formats:
-//
-//	"220 mail.example.com ESMTP Postfix"
-//	"220 mail.example.com ESMTP hMailServer 5.6.9"
-//	"220-mail.example.com ESMTP"
-func parseSMTPBanner(banner string) (serverName, softwareName, softwareVersion string) {
-	// Strip the 220 code and any continuation marker
-	line := banner
-	if strings.HasPrefix(line, "220-") {
-		line = line[4:]
-	} else if strings.HasPrefix(line, "220 ") {
-		line = line[4:]
-	} else {
-		return
-	}
-
-	parts := strings.Fields(line)
-	if len(parts) == 0 {
-		return
-	}
-
-	serverName = parts[0]
-
-	// Skip ESMTP/SMTP marker to find software name
-	idx := 1
-	for idx < len(parts) {
-		upper := strings.ToUpper(parts[idx])
-		if upper == "ESMTP" || upper == "SMTP" {
-			idx++
-			break
-		}
-		idx++
-	}
-
-	if idx < len(parts) {
-		// Remaining parts are software name + possible version
-		remaining := parts[idx:]
-		// Try to find version-like token (starts with digit)
-		for i, token := range remaining {
-			if len(token) > 0 && token[0] >= '0' && token[0] <= '9' {
-				softwareName = strings.Join(remaining[:i], " ")
-				softwareVersion = strings.Join(remaining[i:], " ")
-				return
-			}
-		}
-		softwareName = strings.Join(remaining, " ")
-	}
-
-	return
 }

--- a/internal/discover/service/plugins/smtp.go
+++ b/internal/discover/service/plugins/smtp.go
@@ -19,7 +19,7 @@ type SMTPFingerprinter struct{}
 
 func (SMTPFingerprinter) Name() string { return "smtp" }
 
-func (SMTPFingerprinter) DefaultPorts() []int { return []int{25, 465, 587, 2525, 8025} }
+func (SMTPFingerprinter) DefaultPorts() []int { return []int{25, 587, 2525, 8025} }
 
 func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
 	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
@@ -79,6 +79,7 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	var extensions []string
 	var authMethods []protocol.SmtpAuthCommand
 	tlsSupported := false
+	firstLine := true
 
 	// Read EHLO response lines — only accept 250 responses
 	for {
@@ -95,6 +96,15 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		// Only process 250 response lines; anything else means EHLO failed or unexpected response
 		if !strings.HasPrefix(line, "250") {
 			break
+		}
+
+		// First 250 line is the server greeting (RFC 5321), not an extension
+		if firstLine {
+			firstLine = false
+			if line[3] == ' ' {
+				break
+			}
+			continue
 		}
 
 		ext := line[4:]

--- a/internal/discover/service/plugins/smtp.go
+++ b/internal/discover/service/plugins/smtp.go
@@ -77,7 +77,7 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	_ = conn.SetReadDeadline(time.Now().Add(dur))
 
 	var extensions []string
-	var authMethods []string
+	var authMethods []protocol.SmtpAuthCommand
 	tlsSupported := false
 
 	// Read EHLO response lines — only accept 250 responses
@@ -104,8 +104,10 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		}
 		if strings.HasPrefix(strings.ToUpper(ext), "AUTH ") {
 			methods := strings.Fields(ext)
-			if len(methods) > 1 {
-				authMethods = append(authMethods, methods[1:]...)
+			for _, m := range methods[1:] {
+				if cmd, err := protocol.NewSmtpAuthCommandFromString(strings.ToUpper(m)); err == nil {
+					authMethods = append(authMethods, cmd)
+				}
 			}
 		}
 		extensions = append(extensions, ext)
@@ -123,7 +125,7 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	return buildSMTPResult(host, ip, port, banner, serverName, softwareName, softwareVersion, esmtp, tlsSupported, authMethods, extensions), nil
 }
 
-func buildSMTPResult(host string, ip net.IP, port int, banner, serverName, softwareName, softwareVersion string, esmtp, tlsSupported bool, authMethods, extensions []string) *discoverfern.ServiceDetails {
+func buildSMTPResult(host string, ip net.IP, port int, banner, serverName, softwareName, softwareVersion string, esmtp, tlsSupported bool, authMethods []protocol.SmtpAuthCommand, extensions []string) *discoverfern.ServiceDetails {
 	metadata := &protocol.SmtpServerInfo{
 		Banner:              &banner,
 		EsmtpSupported:      &esmtp,

--- a/internal/discover/service/plugins/smtp.go
+++ b/internal/discover/service/plugins/smtp.go
@@ -4,7 +4,6 @@ package plugins
 import (
 	"bufio"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"strings"
@@ -13,7 +12,6 @@ import (
 	"github.com/Method-Security/networkscan/generated/go/common"
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
-	"github.com/Method-Security/networkscan/utils"
 )
 
 type SMTPFingerprinter struct{}
@@ -35,17 +33,33 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 
 	_ = conn.SetReadDeadline(time.Now().Add(dur))
 
-	// Read the banner — SMTP servers send a 220 greeting on connect
+	// Read the banner — SMTP servers send a 220 greeting on connect.
+	// Banners can be multi-line (220- continuation lines followed by a final 220 line).
 	reader := bufio.NewReader(conn)
-	banner, err := reader.ReadString('\n')
-	if err != nil {
-		return nil, err
-	}
-	banner = strings.TrimSpace(banner)
+	var bannerLines []string
+	for {
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			return nil, readErr
+		}
+		line = strings.TrimSpace(line)
 
-	if !strings.HasPrefix(banner, "220") {
-		return nil, fmt.Errorf("not an SMTP service: %s", banner)
+		if !strings.HasPrefix(line, "220") {
+			return nil, fmt.Errorf("not an SMTP service: %s", line)
+		}
+		bannerLines = append(bannerLines, line)
+
+		// "220 " (space at index 3) is the final banner line
+		if len(line) >= 4 && line[3] == ' ' {
+			break
+		}
+		// Single "220" with no continuation marker is also final
+		if len(line) < 4 {
+			break
+		}
 	}
+
+	banner := bannerLines[0]
 
 	// Parse banner for server info
 	serverName, softwareName, softwareVersion := parseSMTPBanner(banner)
@@ -56,7 +70,6 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	ehloHost := "scanner.local"
 	_, err = fmt.Fprintf(conn, "EHLO %s\r\n", ehloHost)
 	if err != nil {
-		// Still return what we have from the banner
 		return buildSMTPResult(host, ip, port, banner, serverName, softwareName, softwareVersion, esmtp, false, nil, nil), nil
 	}
 
@@ -66,7 +79,7 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	var authMethods []string
 	tlsSupported := false
 
-	// Read EHLO response lines (250- continuation, 250 final)
+	// Read EHLO response lines — only accept 250 responses
 	for {
 		line, readErr := reader.ReadString('\n')
 		if readErr != nil {
@@ -78,7 +91,11 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 			break
 		}
 
-		// Extract the extension part (after "250-" or "250 ")
+		// Only process 250 response lines; anything else means EHLO failed or unexpected response
+		if !strings.HasPrefix(line, "250") {
+			break
+		}
+
 		ext := line[4:]
 
 		if strings.HasPrefix(strings.ToUpper(ext), "STARTTLS") {
@@ -98,23 +115,6 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		}
 	}
 
-	// If STARTTLS is available, try upgrading to get TLS info
-	if tlsSupported {
-		_ = conn.SetWriteDeadline(time.Now().Add(dur))
-		_, _ = fmt.Fprintf(conn, "STARTTLS\r\n")
-		_ = conn.SetReadDeadline(time.Now().Add(dur))
-		tlsResp, readErr := reader.ReadString('\n')
-		if readErr == nil && strings.HasPrefix(strings.TrimSpace(tlsResp), "220") {
-			tlsConn := tls.Client(conn, &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec
-				ServerName:         host,
-			})
-			if tlsErr := tlsConn.HandshakeContext(ctx); tlsErr == nil {
-				defer func() { _ = tlsConn.Close() }()
-			}
-		}
-	}
-
 	// Send QUIT
 	_ = conn.SetWriteDeadline(time.Now().Add(dur))
 	_, _ = fmt.Fprintf(conn, "QUIT\r\n")
@@ -123,9 +123,6 @@ func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 }
 
 func buildSMTPResult(host string, ip net.IP, port int, banner, serverName, softwareName, softwareVersion string, esmtp, tlsSupported bool, authMethods, extensions []string) *discoverfern.ServiceDetails {
-	target := utils.FormatHostPort(host, port)
-	_ = target
-
 	metadata := &protocol.SmtpServerInfo{
 		Banner:              &banner,
 		EsmtpSupported:      &esmtp,

--- a/internal/discover/service/plugins/smtp.go
+++ b/internal/discover/service/plugins/smtp.go
@@ -1,0 +1,216 @@
+// Package plugins provides SMTP service fingerprinting
+package plugins
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/Method-Security/networkscan/generated/go/common"
+	"github.com/Method-Security/networkscan/generated/go/common/protocol"
+	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
+	"github.com/Method-Security/networkscan/utils"
+)
+
+type SMTPFingerprinter struct{}
+
+func (SMTPFingerprinter) Name() string { return "smtp" }
+
+func (SMTPFingerprinter) DefaultPorts() []int { return []int{25, 465, 587, 2525, 8025} }
+
+func (SMTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
+	addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
+	dur := time.Duration(timeout) * time.Second
+
+	dialer := net.Dialer{Timeout: dur}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetReadDeadline(time.Now().Add(dur))
+
+	// Read the banner — SMTP servers send a 220 greeting on connect
+	reader := bufio.NewReader(conn)
+	banner, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	banner = strings.TrimSpace(banner)
+
+	if !strings.HasPrefix(banner, "220") {
+		return nil, fmt.Errorf("not an SMTP service: %s", banner)
+	}
+
+	// Parse banner for server info
+	serverName, softwareName, softwareVersion := parseSMTPBanner(banner)
+	esmtp := strings.Contains(banner, "ESMTP")
+
+	// Send EHLO to discover capabilities
+	_ = conn.SetWriteDeadline(time.Now().Add(dur))
+	ehloHost := "scanner.local"
+	_, err = fmt.Fprintf(conn, "EHLO %s\r\n", ehloHost)
+	if err != nil {
+		// Still return what we have from the banner
+		return buildSMTPResult(host, ip, port, banner, serverName, softwareName, softwareVersion, esmtp, false, nil, nil), nil
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(dur))
+
+	var extensions []string
+	var authMethods []string
+	tlsSupported := false
+
+	// Read EHLO response lines (250- continuation, 250 final)
+	for {
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			break
+		}
+		line = strings.TrimSpace(line)
+
+		if len(line) < 4 {
+			break
+		}
+
+		// Extract the extension part (after "250-" or "250 ")
+		ext := line[4:]
+
+		if strings.HasPrefix(strings.ToUpper(ext), "STARTTLS") {
+			tlsSupported = true
+		}
+		if strings.HasPrefix(strings.ToUpper(ext), "AUTH ") {
+			methods := strings.Fields(ext)
+			if len(methods) > 1 {
+				authMethods = append(authMethods, methods[1:]...)
+			}
+		}
+		extensions = append(extensions, ext)
+
+		// "250 " (space, not dash) means last line
+		if line[3] == ' ' {
+			break
+		}
+	}
+
+	// If STARTTLS is available, try upgrading to get TLS info
+	if tlsSupported {
+		_ = conn.SetWriteDeadline(time.Now().Add(dur))
+		_, _ = fmt.Fprintf(conn, "STARTTLS\r\n")
+		_ = conn.SetReadDeadline(time.Now().Add(dur))
+		tlsResp, readErr := reader.ReadString('\n')
+		if readErr == nil && strings.HasPrefix(strings.TrimSpace(tlsResp), "220") {
+			tlsConn := tls.Client(conn, &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec
+				ServerName:         host,
+			})
+			if tlsErr := tlsConn.HandshakeContext(ctx); tlsErr == nil {
+				defer func() { _ = tlsConn.Close() }()
+			}
+		}
+	}
+
+	// Send QUIT
+	_ = conn.SetWriteDeadline(time.Now().Add(dur))
+	_, _ = fmt.Fprintf(conn, "QUIT\r\n")
+
+	return buildSMTPResult(host, ip, port, banner, serverName, softwareName, softwareVersion, esmtp, tlsSupported, authMethods, extensions), nil
+}
+
+func buildSMTPResult(host string, ip net.IP, port int, banner, serverName, softwareName, softwareVersion string, esmtp, tlsSupported bool, authMethods, extensions []string) *discoverfern.ServiceDetails {
+	target := utils.FormatHostPort(host, port)
+	_ = target
+
+	metadata := &protocol.SmtpServerInfo{
+		Banner:              &banner,
+		EsmtpSupported:      &esmtp,
+		TlsSupported:        &tlsSupported,
+		AuthMethods:         authMethods,
+		SupportedExtensions: extensions,
+	}
+	if serverName != "" {
+		metadata.ServerName = &serverName
+	}
+	if softwareName != "" {
+		metadata.SoftwareName = &softwareName
+	}
+	if softwareVersion != "" {
+		metadata.SoftwareVersion = &softwareVersion
+	}
+
+	version := banner
+	if softwareName != "" {
+		version = softwareName
+		if softwareVersion != "" {
+			version += " " + softwareVersion
+		}
+	}
+
+	return &discoverfern.ServiceDetails{
+		Host:      host,
+		Ip:        ip.String(),
+		Port:      port,
+		Tls:       false,
+		Transport: common.TransportTypeTcp,
+		Protocol:  common.ProtocolTypeSmtp,
+		Version:   &version,
+		Metadata:  discoverfern.NewServiceMetadataFromSmtp(metadata),
+	}
+}
+
+// parseSMTPBanner extracts server name and software info from a 220 banner.
+// Common formats:
+//
+//	"220 mail.example.com ESMTP Postfix"
+//	"220 mail.example.com ESMTP hMailServer 5.6.9"
+//	"220-mail.example.com ESMTP"
+func parseSMTPBanner(banner string) (serverName, softwareName, softwareVersion string) {
+	// Strip the 220 code and any continuation marker
+	line := banner
+	if strings.HasPrefix(line, "220-") {
+		line = line[4:]
+	} else if strings.HasPrefix(line, "220 ") {
+		line = line[4:]
+	} else {
+		return
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) == 0 {
+		return
+	}
+
+	serverName = parts[0]
+
+	// Skip ESMTP/SMTP marker to find software name
+	idx := 1
+	for idx < len(parts) {
+		upper := strings.ToUpper(parts[idx])
+		if upper == "ESMTP" || upper == "SMTP" {
+			idx++
+			break
+		}
+		idx++
+	}
+
+	if idx < len(parts) {
+		// Remaining parts are software name + possible version
+		remaining := parts[idx:]
+		// Try to find version-like token (starts with digit)
+		for i, token := range remaining {
+			if len(token) > 0 && token[0] >= '0' && token[0] <= '9' {
+				softwareName = strings.Join(remaining[:i], " ")
+				softwareVersion = strings.Join(remaining[i:], " ")
+				return
+			}
+		}
+		softwareName = strings.Join(remaining, " ")
+	}
+
+	return
+}

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -72,6 +72,7 @@ var customFingerprintModules = []Fingerprinter{
 	&localPlugins.FoxFingerprinter{},       // FOX (Tridium Niagara Framework)
 	&localPlugins.MemcachedFingerprinter{}, // MEMCACHED
 	&localPlugins.UnistreamFingerprinter{}, // Unitronics UniStream (EtherNet/IP)
+	&localPlugins.SMTPFingerprinter{},      // SMTP (Simple Mail Transfer Protocol)
 }
 
 // UDP fingerprinters mapped to their specific ports

--- a/internal/enumerate/smtp/constants.go
+++ b/internal/enumerate/smtp/constants.go
@@ -2,13 +2,13 @@ package smtp
 
 import (
 	// Generated
-	smtp "github.com/Method-Security/networkscan/generated/go/enumerate/smtp"
+	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 )
 
-var authCommands = map[string]smtp.AuthCommand{
-	"XOAUTH2":  smtp.AuthCommandXoauth2,
-	"PLAIN":    smtp.AuthCommandPlain,
-	"LOGIN":    smtp.AuthCommandLogin,
-	"CRAM_MD5": smtp.AuthCommandCrammd5,
-	"NTLM":     smtp.AuthCommandNtlm,
+var authCommands = map[string]protocol.SmtpAuthCommand{
+	"XOAUTH2":  protocol.SmtpAuthCommandXoauth2,
+	"PLAIN":    protocol.SmtpAuthCommandPlain,
+	"LOGIN":    protocol.SmtpAuthCommandLogin,
+	"CRAM_MD5": protocol.SmtpAuthCommandCrammd5,
+	"NTLM":     protocol.SmtpAuthCommandNtlm,
 }

--- a/internal/enumerate/smtp/helpers.go
+++ b/internal/enumerate/smtp/helpers.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	// Generated
-	smtp "github.com/Method-Security/networkscan/generated/go/enumerate/smtp"
+	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -29,8 +29,8 @@ func tryTLSConnection(target string, hostname string) (net.Conn, error) {
 	return tls.DialWithDialer(&dialer, "tcp", target, tlsConfig)
 }
 
-func parseAuthMethods(methods []string) []smtp.AuthCommand {
-	var result []smtp.AuthCommand
+func parseAuthMethods(methods []string) []protocol.SmtpAuthCommand {
+	var result []protocol.SmtpAuthCommand
 	for _, method := range methods {
 		if auth, ok := authCommands[strings.ToUpper(method)]; ok {
 			result = append(result, auth)

--- a/internal/enumerate/smtp/helpers.go
+++ b/internal/enumerate/smtp/helpers.go
@@ -2,11 +2,9 @@ package smtp
 
 import (
 	// Standard
-	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net"
 	netsmtp "net/smtp"
 	"strings"
@@ -19,90 +17,26 @@ import (
 
 func tryTCPConnection(ctx context.Context, target string) (net.Conn, error) {
 	dialer := net.Dialer{}
-	conn, err := dialer.DialContext(ctx, "tcp", target)
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
+	return dialer.DialContext(ctx, "tcp", target)
 }
 
-// readBanner reads the SMTP 220 banner by peeking at the connection data
-// without consuming it, so net/smtp.NewClient can still read it.
-// Returns a wrapped conn that replays the banner bytes.
-func readBanner(conn net.Conn) (net.Conn, string, error) {
-	buf := make([]byte, 4096)
-	n, err := conn.Read(buf)
-	if err != nil {
-		return conn, "", err
+func tryTLSConnection(target string, hostname string) (net.Conn, error) {
+	dialer := net.Dialer{}
+	tlsConfig := &tls.Config{
+		ServerName:         hostname,
+		InsecureSkipVerify: true,
 	}
-	data := buf[:n]
-
-	// Extract banner from the first line
-	banner := ""
-	lines := strings.Split(string(data), "\r\n")
-	if len(lines) > 0 && strings.HasPrefix(lines[0], "220") {
-		banner = strings.TrimSpace(lines[0])
-	}
-
-	// Wrap the connection so NewClient can re-read the banner
-	wrapped := &replayConn{
-		Conn:   conn,
-		reader: io.MultiReader(bytes.NewReader(data), conn),
-	}
-	return wrapped, banner, nil
+	return tls.DialWithDialer(&dialer, "tcp", target, tlsConfig)
 }
 
-// replayConn wraps a net.Conn, replaying buffered data before reading from the real connection.
-type replayConn struct {
-	net.Conn
-	reader io.Reader
-}
-
-func (c *replayConn) Read(p []byte) (int, error) {
-	return c.reader.Read(p)
-}
-
-// parseSMTPBanner extracts server name and software info from a 220 banner.
-func parseSMTPBanner(banner string) (serverName, softwareName, softwareVersion string) {
-	line := banner
-	if strings.HasPrefix(line, "220-") {
-		line = line[4:]
-	} else if strings.HasPrefix(line, "220 ") {
-		line = line[4:]
-	} else {
-		return
-	}
-
-	parts := strings.Fields(line)
-	if len(parts) == 0 {
-		return
-	}
-
-	serverName = parts[0]
-
-	idx := 1
-	for idx < len(parts) {
-		upper := strings.ToUpper(parts[idx])
-		if upper == "ESMTP" || upper == "SMTP" {
-			idx++
-			break
+func parseAuthMethods(methods []string) []smtp.AuthCommand {
+	var result []smtp.AuthCommand
+	for _, method := range methods {
+		if auth, ok := authCommands[strings.ToUpper(method)]; ok {
+			result = append(result, auth)
 		}
-		idx++
 	}
-
-	if idx < len(parts) {
-		remaining := parts[idx:]
-		for i, token := range remaining {
-			if len(token) > 0 && token[0] >= '0' && token[0] <= '9' {
-				softwareName = strings.Join(remaining[:i], " ")
-				softwareVersion = strings.Join(remaining[i:], " ")
-				return
-			}
-		}
-		softwareName = strings.Join(remaining, " ")
-	}
-
-	return
+	return result
 }
 
 // collectExtensions checks for common SMTP extensions via the client's Extension method.
@@ -123,25 +57,6 @@ func collectExtensions(c *netsmtp.Client) []string {
 		}
 	}
 	return found
-}
-
-func tryTLSConnection(target string, hostname string) (net.Conn, error) {
-	dialer := net.Dialer{}
-	tlsConfig := &tls.Config{
-		ServerName:         hostname,
-		InsecureSkipVerify: true,
-	}
-	return tls.DialWithDialer(&dialer, "tcp", target, tlsConfig)
-}
-
-func parseAuthMethods(methods []string) []smtp.AuthCommand {
-	var result []smtp.AuthCommand
-	for _, method := range methods {
-		if auth, ok := authCommands[strings.ToUpper(method)]; ok {
-			result = append(result, auth)
-		}
-	}
-	return result
 }
 
 func testUnauthenticatedEmail(ctx context.Context, c *netsmtp.Client, hostname string) bool {

--- a/internal/enumerate/smtp/helpers.go
+++ b/internal/enumerate/smtp/helpers.go
@@ -2,9 +2,11 @@ package smtp
 
 import (
 	// Standard
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	netsmtp "net/smtp"
 	"strings"
@@ -17,7 +19,110 @@ import (
 
 func tryTCPConnection(ctx context.Context, target string) (net.Conn, error) {
 	dialer := net.Dialer{}
-	return dialer.DialContext(ctx, "tcp", target)
+	conn, err := dialer.DialContext(ctx, "tcp", target)
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+// readBanner reads the SMTP 220 banner by peeking at the connection data
+// without consuming it, so net/smtp.NewClient can still read it.
+// Returns a wrapped conn that replays the banner bytes.
+func readBanner(conn net.Conn) (net.Conn, string, error) {
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return conn, "", err
+	}
+	data := buf[:n]
+
+	// Extract banner from the first line
+	banner := ""
+	lines := strings.Split(string(data), "\r\n")
+	if len(lines) > 0 && strings.HasPrefix(lines[0], "220") {
+		banner = strings.TrimSpace(lines[0])
+	}
+
+	// Wrap the connection so NewClient can re-read the banner
+	wrapped := &replayConn{
+		Conn:   conn,
+		reader: io.MultiReader(bytes.NewReader(data), conn),
+	}
+	return wrapped, banner, nil
+}
+
+// replayConn wraps a net.Conn, replaying buffered data before reading from the real connection.
+type replayConn struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (c *replayConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+// parseSMTPBanner extracts server name and software info from a 220 banner.
+func parseSMTPBanner(banner string) (serverName, softwareName, softwareVersion string) {
+	line := banner
+	if strings.HasPrefix(line, "220-") {
+		line = line[4:]
+	} else if strings.HasPrefix(line, "220 ") {
+		line = line[4:]
+	} else {
+		return
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) == 0 {
+		return
+	}
+
+	serverName = parts[0]
+
+	idx := 1
+	for idx < len(parts) {
+		upper := strings.ToUpper(parts[idx])
+		if upper == "ESMTP" || upper == "SMTP" {
+			idx++
+			break
+		}
+		idx++
+	}
+
+	if idx < len(parts) {
+		remaining := parts[idx:]
+		for i, token := range remaining {
+			if len(token) > 0 && token[0] >= '0' && token[0] <= '9' {
+				softwareName = strings.Join(remaining[:i], " ")
+				softwareVersion = strings.Join(remaining[i:], " ")
+				return
+			}
+		}
+		softwareName = strings.Join(remaining, " ")
+	}
+
+	return
+}
+
+// collectExtensions checks for common SMTP extensions via the client's Extension method.
+func collectExtensions(c *netsmtp.Client) []string {
+	knownExtensions := []string{
+		"8BITMIME", "AUTH", "BINARYMIME", "CHUNKING", "DSN",
+		"ENHANCEDSTATUSCODES", "ETRN", "PIPELINING", "SIZE",
+		"STARTTLS", "TURN", "VRFY",
+	}
+	var found []string
+	for _, ext := range knownExtensions {
+		if ok, param := c.Extension(ext); ok {
+			if param != "" {
+				found = append(found, ext+" "+param)
+			} else {
+				found = append(found, ext)
+			}
+		}
+	}
+	return found
 }
 
 func tryTLSConnection(target string, hostname string) (net.Conn, error) {

--- a/internal/enumerate/smtp/smtp.go
+++ b/internal/enumerate/smtp/smtp.go
@@ -13,6 +13,8 @@ import (
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	smtp "github.com/Method-Security/networkscan/generated/go/enumerate/smtp"
 
+	// Internal
+	smtputil "github.com/Method-Security/networkscan/internal/protocol/smtp"
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -81,10 +83,10 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	log.Info("Connected to target", svc1log.SafeParam("target", target))
 
 	// Read the SMTP banner, wrapping the connection so NewClient can replay it
-	conn, banner, bannerErr := readBanner(conn)
+	conn, banner, bannerErr := smtputil.ReadBannerFromConn(conn)
 	if bannerErr == nil && banner != "" {
 		detail.Banner = &banner
-		serverName, softwareName, softwareVersion := parseSMTPBanner(banner)
+		serverName, softwareName, softwareVersion := smtputil.ParseBanner(banner)
 		if serverName != "" {
 			detail.ServerName = &serverName
 		}

--- a/internal/enumerate/smtp/smtp.go
+++ b/internal/enumerate/smtp/smtp.go
@@ -80,7 +80,25 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	detail.CanConnect = &canConnect
 	log.Info("Connected to target", svc1log.SafeParam("target", target))
 
-	// Create SMTP client
+	// Read the SMTP banner, wrapping the connection so NewClient can replay it
+	conn, banner, bannerErr := readBanner(conn)
+	if bannerErr == nil && banner != "" {
+		detail.Banner = &banner
+		serverName, softwareName, softwareVersion := parseSMTPBanner(banner)
+		if serverName != "" {
+			detail.ServerName = &serverName
+		}
+		if softwareName != "" {
+			detail.SoftwareName = &softwareName
+		}
+		if softwareVersion != "" {
+			detail.SoftwareVersion = &softwareVersion
+		}
+		esmtp := strings.Contains(banner, "ESMTP")
+		detail.EsmtpSupported = &esmtp
+	}
+
+	// Create SMTP client from existing connection (banner already consumed)
 	client, err := netsmtp.NewClient(conn, hostname)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("SMTP client creation failed: %v", err))
@@ -103,7 +121,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 		}
 	}
 
-	// Check authentication methods
+	// Check authentication methods and collect supported extensions
 	log.Debug("Checking authentication methods")
 	if ok, param := client.Extension("AUTH"); ok {
 		authMethods := parseAuthMethods(strings.Split(param, " "))
@@ -111,6 +129,12 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 		log.Debug("Supported auth methods", svc1log.SafeParam("authMethods", authMethods))
 	} else {
 		log.Debug("No authentication methods found")
+	}
+
+	// Collect supported EHLO extensions
+	extensions := collectExtensions(client)
+	if len(extensions) > 0 {
+		detail.SupportedExtensions = extensions
 	}
 
 	// Test if unauthenticated email is allowed

--- a/internal/enumerate/smtp/smtp.go
+++ b/internal/enumerate/smtp/smtp.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	// Generated
+	"github.com/Method-Security/networkscan/generated/go/common/protocol"
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	smtp "github.com/Method-Security/networkscan/generated/go/enumerate/smtp"
 
@@ -40,6 +41,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	detail := smtp.EnumerateSmtpDetails{
 		Target: target,
 	}
+	serverInfo := &protocol.SmtpServerInfo{}
 	errors := []string{}
 
 	// Get hostname for HELLO command and TLS
@@ -48,7 +50,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 		errors = append(errors, fmt.Sprintf("invalid target format: %v", err))
 		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
 	}
-	config := &tls.Config{
+	tlsConfig := &tls.Config{
 		ServerName:         hostname,
 		InsecureSkipVerify: true,
 	}
@@ -72,9 +74,9 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 			return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
 		}
 		log.Debug("TLS connection successful")
-		TLSSupported := true
+		tlsSupported := true
 		forceTLS := true
-		detail.TlsSupported = &TLSSupported
+		serverInfo.TlsSupported = &tlsSupported
 		detail.ForceTls = &forceTLS
 	}
 
@@ -85,41 +87,42 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	// Read the SMTP banner, wrapping the connection so NewClient can replay it
 	conn, banner, bannerErr := smtputil.ReadBannerFromConn(conn)
 	if bannerErr == nil && banner != "" {
-		detail.Banner = &banner
+		serverInfo.Banner = &banner
 		serverName, softwareName, softwareVersion := smtputil.ParseBanner(banner)
 		if serverName != "" {
-			detail.ServerName = &serverName
+			serverInfo.ServerName = &serverName
 		}
 		if softwareName != "" {
-			detail.SoftwareName = &softwareName
+			serverInfo.SoftwareName = &softwareName
 		}
 		if softwareVersion != "" {
-			detail.SoftwareVersion = &softwareVersion
+			serverInfo.SoftwareVersion = &softwareVersion
 		}
 		esmtp := strings.Contains(banner, "ESMTP")
-		detail.EsmtpSupported = &esmtp
+		serverInfo.EsmtpSupported = &esmtp
 	}
 
 	// Create SMTP client from existing connection (banner already consumed)
 	client, err := netsmtp.NewClient(conn, hostname)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("SMTP client creation failed: %v", err))
+		detail.ServerInfo = serverInfo
 		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
 	}
 
 	// Try STARTTLS if TLS connection established above
-	if detail.TlsSupported == nil {
+	if serverInfo.TlsSupported == nil {
 		log.Debug("Attempting STARTTLS")
-		err = client.StartTLS(config)
+		err = client.StartTLS(tlsConfig)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("TLS upgrade failed: %v", err))
-			TLSSupported := false
-			detail.TlsSupported = &TLSSupported
+			tlsSupported := false
+			serverInfo.TlsSupported = &tlsSupported
 			log.Debug("STARTTLS failed")
 		} else {
 			log.Debug("STARTTLS successful")
-			TLSSupported := true
-			detail.TlsSupported = &TLSSupported
+			tlsSupported := true
+			serverInfo.TlsSupported = &tlsSupported
 		}
 	}
 
@@ -127,7 +130,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	log.Debug("Checking authentication methods")
 	if ok, param := client.Extension("AUTH"); ok {
 		authMethods := parseAuthMethods(strings.Split(param, " "))
-		detail.AuthCommands = authMethods
+		serverInfo.AuthMethods = authMethods
 		log.Debug("Supported auth methods", svc1log.SafeParam("authMethods", authMethods))
 	} else {
 		log.Debug("No authentication methods found")
@@ -136,8 +139,10 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	// Collect supported EHLO extensions
 	extensions := collectExtensions(client)
 	if len(extensions) > 0 {
-		detail.SupportedExtensions = extensions
+		serverInfo.SupportedExtensions = extensions
 	}
+
+	detail.ServerInfo = serverInfo
 
 	// Test if unauthenticated email is allowed
 	log.Debug("Testing unauthenticated email")

--- a/internal/protocol/smtp/banner.go
+++ b/internal/protocol/smtp/banner.go
@@ -91,17 +91,12 @@ func ReadBannerFromConn(conn net.Conn) (net.Conn, string, error) {
 		}
 	}
 
-	// Wrap connection: replay buffered data, then continue reading from conn
-	// The bufio.Reader may have buffered extra bytes beyond what TeeReader wrote,
-	// so we need to include any remaining buffered data too.
-	remaining := make([]byte, reader.Buffered())
-	if len(remaining) > 0 {
-		_, _ = reader.Read(remaining)
-	}
-
+	// Wrap connection: replay buffered data, then continue reading from conn.
+	// The TeeReader has already copied all bytes read (including any bufio read-ahead)
+	// into buf, so we only need buf + the original conn for remaining data.
 	wrapped := &replayConn{
 		Conn:   conn,
-		reader: io.MultiReader(&buf, bytes.NewReader(remaining), conn),
+		reader: io.MultiReader(&buf, conn),
 	}
 	return wrapped, banner, nil
 }

--- a/internal/protocol/smtp/banner.go
+++ b/internal/protocol/smtp/banner.go
@@ -1,0 +1,117 @@
+// Package smtp provides shared SMTP protocol utilities used across discover and enumerate modules.
+package smtp
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"strings"
+)
+
+// ParseBanner extracts server name and software info from a 220 banner.
+// Common formats:
+//
+//	"220 mail.example.com ESMTP Postfix"
+//	"220 mail.example.com ESMTP hMailServer 5.6.9"
+//	"220-mail.example.com ESMTP"
+func ParseBanner(banner string) (serverName, softwareName, softwareVersion string) {
+	line := banner
+	if strings.HasPrefix(line, "220-") {
+		line = line[4:]
+	} else if strings.HasPrefix(line, "220 ") {
+		line = line[4:]
+	} else {
+		return
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) == 0 {
+		return
+	}
+
+	serverName = parts[0]
+
+	// Skip ESMTP/SMTP marker to find software name
+	idx := 1
+	for idx < len(parts) {
+		upper := strings.ToUpper(parts[idx])
+		if upper == "ESMTP" || upper == "SMTP" {
+			idx++
+			break
+		}
+		idx++
+	}
+
+	if idx < len(parts) {
+		remaining := parts[idx:]
+		// Try to find version-like token (starts with digit)
+		for i, token := range remaining {
+			if len(token) > 0 && token[0] >= '0' && token[0] <= '9' {
+				softwareName = strings.Join(remaining[:i], " ")
+				softwareVersion = strings.Join(remaining[i:], " ")
+				return
+			}
+		}
+		softwareName = strings.Join(remaining, " ")
+	}
+
+	return
+}
+
+// ReadBannerFromConn reads the SMTP 220 banner using a bufio.Reader for reliable
+// line-oriented reading, then wraps the connection so the banner bytes can be
+// replayed by net/smtp.NewClient.
+func ReadBannerFromConn(conn net.Conn) (net.Conn, string, error) {
+	var buf bytes.Buffer
+	tee := io.TeeReader(conn, &buf)
+	reader := bufio.NewReader(tee)
+
+	banner := ""
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return conn, "", err
+		}
+		trimmed := strings.TrimSpace(line)
+
+		if !strings.HasPrefix(trimmed, "220") {
+			break
+		}
+		if banner == "" {
+			banner = trimmed
+		}
+
+		// "220 " (space at index 3) is the final banner line
+		if len(trimmed) >= 4 && trimmed[3] == ' ' {
+			break
+		}
+		if len(trimmed) < 4 {
+			break
+		}
+	}
+
+	// Wrap connection: replay buffered data, then continue reading from conn
+	// The bufio.Reader may have buffered extra bytes beyond what TeeReader wrote,
+	// so we need to include any remaining buffered data too.
+	remaining := make([]byte, reader.Buffered())
+	if len(remaining) > 0 {
+		_, _ = reader.Read(remaining)
+	}
+
+	wrapped := &replayConn{
+		Conn:   conn,
+		reader: io.MultiReader(&buf, bytes.NewReader(remaining), conn),
+	}
+	return wrapped, banner, nil
+}
+
+// replayConn wraps a net.Conn, replaying buffered data before reading from the real connection.
+type replayConn struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (c *replayConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}


### PR DESCRIPTION
## Summary
- Adds a custom SMTP fingerprinter plugin for service discovery, fixing detection failures on non-standard SMTP ports (e.g., 8025) where fingerprintx's FastMode skips SMTP
- Reads 220 banner on connect, sends EHLO to discover capabilities (STARTTLS, AUTH methods, extensions), and parses server software/version from the banner
- Adds `SmtpServerInfo` Fern protocol type with banner, server name, software, ESMTP support, TLS, auth methods, and extensions

## Test plan
- [x] Verified against live SMTP service on `51.81.0.149:8025` (hMailServer) — correctly detects protocol, software version, ESMTP support, and extensions
- [x] `./godelw verify` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new network probing logic (banner/EHLO parsing) and new typed metadata surfaced through generated Fern models, which could affect service detection accuracy/timeouts on scanned ports.
> 
> **Overview**
> Adds first-class SMTP support to service discovery by introducing a custom `SMTPFingerprinter` that connects, validates/records the `220` banner, issues `EHLO`, and extracts `STARTTLS`, `AUTH` methods, and advertised extensions (including default probing on ports `25/587/2525/8025`).
> 
> Introduces a shared Fern protocol model (`SmtpServerInfo` + `SmtpAuthCommand`) and wires it into `discover` service metadata; SMTP enumeration is updated to reuse the shared model, capture banner/software info via new `internal/protocol/smtp` utilities, and report supported auth/extension capabilities via `serverInfo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fbb912d6d19da209065e06f7ecbfd780a61a813. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->