### PR TITLE
Add SMTP user enumeration and FTP directory listing

### DIFF
--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -51,7 +51,13 @@ func (a *NetworkScan) InitEnumerateCommand() {
 				return
 			}
 
-			config := newEnumerateServiceConfig(targets, serviceEnum, timeout)
+			wordlist, err := cmd.Flags().GetStringSlice("wordlist")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			config := newEnumerateServiceConfig(targets, serviceEnum, timeout, wordlist)
 
 			// Generate the report
 			report, err := enumerate.RunServiceEnumerate(cmd.Context(), config)
@@ -65,6 +71,7 @@ func (a *NetworkScan) InitEnumerateCommand() {
 	enumerateServiceCmd.Flags().StringSlice("targets", []string{}, "List of target addresses (IP:port or hostname:port) to enumerate")
 	enumerateServiceCmd.Flags().String("service", "", "Service to enumerate (ftp, grpc, ldap, smb, smtp, snmp, ssh)")
 	enumerateServiceCmd.Flags().Int("timeout", 30, "Timeout in seconds for enumerating each target")
+	enumerateServiceCmd.Flags().StringSlice("wordlist", []string{}, "Custom username wordlist for user enumeration (SMTP VRFY/EXPN/RCPT TO)")
 
 	// Mark Required Flags
 	_ = enumerateServiceCmd.MarkFlagRequired("targets")
@@ -78,10 +85,14 @@ func (a *NetworkScan) InitEnumerateCommand() {
 }
 
 // newEnumerateServiceConfig creates a new EnumerateServiceConfig with the provided parameters.
-func newEnumerateServiceConfig(targets []string, serviceEnum enumeratefern.SupportedServiceType, timeout int) enumeratefern.EnumerateServiceConfig {
-	return enumeratefern.EnumerateServiceConfig{
+func newEnumerateServiceConfig(targets []string, serviceEnum enumeratefern.SupportedServiceType, timeout int, wordlist []string) enumeratefern.EnumerateServiceConfig {
+	config := enumeratefern.EnumerateServiceConfig{
 		Targets: targets,
 		Service: serviceEnum,
 		Timeout: timeout,
 	}
+	if len(wordlist) > 0 {
+		config.Wordlist = wordlist
+	}
+	return config
 }

--- a/fern/definition/enumerate/enumerate.yml
+++ b/fern/definition/enumerate/enumerate.yml
@@ -39,6 +39,7 @@ types:
       targets: list<string>
       service: SupportedServiceType
       timeout: integer
+      wordlist: optional<list<string>>
   # Final report
   EnumerateServiceReport:
     properties:

--- a/fern/definition/enumerate/ftp/ftp.yml
+++ b/fern/definition/enumerate/ftp/ftp.yml
@@ -1,4 +1,21 @@
 types:
+  # ENUMs
+  FtpEntryType:
+    enum:
+      - FILE
+      - DIRECTORY
+      - LINK
+      - UNKNOWN
+
+  # Common Objects
+  FtpDirectoryEntry:
+    properties:
+      name: string
+      type: FtpEntryType
+      size: optional<long>
+      permissions: optional<string>
+      lastModified: optional<string>
+
   # Report structs
   EnumerateFtpDetails:
     properties:
@@ -8,4 +25,5 @@ types:
       tlsImplemented: optional<boolean>
       tlsForced: optional<boolean>
       allowsAnonymousLogin: optional<boolean>
+      directoryListing: optional<list<FtpDirectoryEntry>>
       error: optional<string>

--- a/fern/definition/enumerate/smtp/smtp.yml
+++ b/fern/definition/enumerate/smtp/smtp.yml
@@ -2,6 +2,21 @@ imports:
   smtpProtocol: ../../common/protocol/smtp.yml
 
 types:
+  # ENUMs
+  SmtpUserEnumerationMethod:
+    enum:
+      - VRFY
+      - EXPN
+      - RCPT_TO
+
+  # Common Objects
+  SmtpEnumeratedUser:
+    properties:
+      username: string
+      exists: boolean
+      method: SmtpUserEnumerationMethod
+      response: optional<string>
+
   # Report structs
   EnumerateSmtpDetails:
     properties:
@@ -10,3 +25,4 @@ types:
       serverInfo: optional<smtpProtocol.SmtpServerInfo>
       forceTLS: optional<boolean>
       allowsUnauthenticatedEmail: optional<boolean>
+      enumeratedUsers: optional<list<SmtpEnumeratedUser>>

--- a/internal/enumerate/engine.go
+++ b/internal/enumerate/engine.go
@@ -46,7 +46,7 @@ func RunServiceEnumerate(ctx context.Context, config enumeratefern.EnumerateServ
 		svc1log.SafeParam("timeout", config.Timeout))
 	resource := enumeratefern.EnumerateServiceReport{Config: &config}
 
-	engine, err := getEngine(config.Service)
+	engine, err := getEngine(config)
 	if err != nil {
 		return enumeratefern.EnumerateServiceReport{}, err
 	}
@@ -131,14 +131,14 @@ func RunServiceEnumerate(ctx context.Context, config enumeratefern.EnumerateServ
 
 // getEngine creates and returns the appropriate enumeration engine for the specified service type.
 // It acts as a factory function to instantiate service-specific enumeration libraries.
-func getEngine(serviceType enumeratefern.SupportedServiceType) (NetworkApplicationEngine, error) {
-	switch serviceType {
+func getEngine(config enumeratefern.EnumerateServiceConfig) (NetworkApplicationEngine, error) {
+	switch config.Service {
 	case enumeratefern.SupportedServiceTypeSsh:
 		return NetworkApplicationEngine{Library: &ssh.LibraryEnumerateSSH{}}, nil
 	case enumeratefern.SupportedServiceTypeFtp:
 		return NetworkApplicationEngine{Library: &ftp.LibraryEnumerateFTP{}}, nil
 	case enumeratefern.SupportedServiceTypeSmtp:
-		return NetworkApplicationEngine{Library: &smtp.LibraryEnumerateSMTP{}}, nil
+		return NetworkApplicationEngine{Library: &smtp.LibraryEnumerateSMTP{Wordlist: config.Wordlist}}, nil
 	case enumeratefern.SupportedServiceTypeGrpc:
 		return NetworkApplicationEngine{Library: &grpc.LibraryEnumerateGRPC{}}, nil
 	case enumeratefern.SupportedServiceTypeSmb:
@@ -150,6 +150,6 @@ func getEngine(serviceType enumeratefern.SupportedServiceType) (NetworkApplicati
 	case enumeratefern.SupportedServiceTypeSnmp:
 		return NetworkApplicationEngine{Library: &snmp.LibraryEnumerateSNMP{}}, nil
 	default:
-		return NetworkApplicationEngine{}, fmt.Errorf("unsupported network application: %v", serviceType)
+		return NetworkApplicationEngine{}, fmt.Errorf("unsupported network application: %v", config.Service)
 	}
 }

--- a/internal/enumerate/ftp/ftp.go
+++ b/internal/enumerate/ftp/ftp.go
@@ -99,6 +99,18 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 		errors = append(errors, errs...)
 	}
 
+	// If anonymous login succeeded, retrieve directory listing
+	if details.AllowsAnonymousLogin != nil && *details.AllowsAnonymousLogin {
+		log.Info("Anonymous login succeeded, retrieving directory listing")
+		entries, listErrs := listDirectory(ctx, conn)
+		if len(listErrs) > 0 {
+			errors = append(errors, listErrs...)
+		}
+		if len(entries) > 0 {
+			details.DirectoryListing = entries
+		}
+	}
+
 	err = conn.Close()
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("failed to close connection: %v", err))

--- a/internal/enumerate/ftp/ftp.go
+++ b/internal/enumerate/ftp/ftp.go
@@ -94,13 +94,13 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 	}
 
 	// Check if anonymous login is supported
-	errs := checkAnonymousLoginWithRetry(ctx, target, conn, &details)
+	conn, errs := checkAnonymousLoginWithRetry(ctx, target, conn, &details)
 	if len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
 
 	// If anonymous login succeeded, retrieve directory listing
-	if details.AllowsAnonymousLogin != nil && *details.AllowsAnonymousLogin {
+	if conn != nil && details.AllowsAnonymousLogin != nil && *details.AllowsAnonymousLogin {
 		log.Info("Anonymous login succeeded, retrieving directory listing")
 		entries, listErrs := listDirectory(ctx, conn)
 		if len(listErrs) > 0 {
@@ -109,6 +109,10 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 		if len(entries) > 0 {
 			details.DirectoryListing = entries
 		}
+	}
+
+	if conn == nil {
+		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
 	}
 
 	err = conn.Close()

--- a/internal/enumerate/ftp/helpers.go
+++ b/internal/enumerate/ftp/helpers.go
@@ -169,6 +169,198 @@ func checkAnonymousLogin(ctx context.Context, conn net.Conn, details *ftp.Enumer
 	return nil
 }
 
+// listDirectory retrieves the directory listing using PASV + LIST after a successful anonymous login.
+func listDirectory(ctx context.Context, conn net.Conn) ([]*ftp.FtpDirectoryEntry, []string) {
+	log := svc1log.FromContext(ctx)
+	var errors []string
+
+	// Enter passive mode
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return nil, []string{fmt.Sprintf("failed to set read deadline for PASV: %v", err)}
+	}
+
+	_, err := conn.Write([]byte("PASV\r\n"))
+	if err != nil {
+		return nil, []string{fmt.Sprintf("failed to send PASV command: %v", err)}
+	}
+
+	response := make([]byte, bufferSize)
+	n, err := conn.Read(response)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("failed to read PASV response: %v", err)}
+	}
+
+	pasvResponse := string(response[:n])
+	log.Debug("PASV response", svc1log.SafeParam("response", pasvResponse))
+
+	if !containsFTPCode(pasvResponse, "227") {
+		return nil, []string{fmt.Sprintf("PASV not supported: %s", strings.TrimSpace(pasvResponse))}
+	}
+
+	// Parse PASV response to get data connection address
+	dataAddr, err := parsePASVResponse(pasvResponse)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("failed to parse PASV response: %v", err)}
+	}
+
+	// Open data connection
+	dataConn, err := net.DialTimeout("tcp", dataAddr, 5*time.Second)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("failed to connect to data port %s: %v", dataAddr, err)}
+	}
+	defer func() { _ = dataConn.Close() }()
+
+	// Send LIST command on control connection
+	_, err = conn.Write([]byte("LIST\r\n"))
+	if err != nil {
+		return nil, []string{fmt.Sprintf("failed to send LIST command: %v", err)}
+	}
+
+	// Read LIST response code from control connection
+	n, err = conn.Read(response)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("failed to read LIST response: %v", err))
+	} else {
+		listResponse := string(response[:n])
+		log.Debug("LIST response", svc1log.SafeParam("response", listResponse))
+		if !containsFTPCode(listResponse, "150") && !containsFTPCode(listResponse, "125") {
+			return nil, []string{fmt.Sprintf("LIST command failed: %s", strings.TrimSpace(listResponse))}
+		}
+	}
+
+	// Read directory data from data connection
+	if err := dataConn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return nil, []string{fmt.Sprintf("failed to set data read deadline: %v", err)}
+	}
+
+	var listingData strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		rn, readErr := dataConn.Read(buf)
+		if rn > 0 {
+			listingData.Write(buf[:rn])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+
+	// Read transfer complete from control connection
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _ = conn.Read(response)
+	_ = conn.SetReadDeadline(time.Time{})
+
+	// Parse directory listing
+	entries := parseDirectoryListing(listingData.String())
+	log.Info("Directory listing retrieved", svc1log.SafeParam("entries", len(entries)))
+
+	return entries, errors
+}
+
+// parsePASVResponse extracts the data connection address from a 227 PASV response.
+// Format: 227 Entering Passive Mode (h1,h2,h3,h4,p1,p2)
+func parsePASVResponse(response string) (string, error) {
+	start := strings.Index(response, "(")
+	end := strings.Index(response, ")")
+	if start == -1 || end == -1 || end <= start {
+		return "", fmt.Errorf("invalid PASV response format: %s", response)
+	}
+
+	parts := strings.Split(response[start+1:end], ",")
+	if len(parts) != 6 {
+		return "", fmt.Errorf("invalid PASV address parts: %s", response)
+	}
+
+	host := fmt.Sprintf("%s.%s.%s.%s", parts[0], parts[1], parts[2], parts[3])
+	p1 := 0
+	p2 := 0
+	if _, err := fmt.Sscanf(parts[4], "%d", &p1); err != nil {
+		return "", fmt.Errorf("invalid PASV port high byte: %v", err)
+	}
+	if _, err := fmt.Sscanf(parts[5], "%d", &p2); err != nil {
+		return "", fmt.Errorf("invalid PASV port low byte: %v", err)
+	}
+	port := p1*256 + p2
+
+	return fmt.Sprintf("%s:%d", host, port), nil
+}
+
+// parseDirectoryListing parses Unix-style FTP LIST output into FtpDirectoryEntry structs.
+func parseDirectoryListing(data string) []*ftp.FtpDirectoryEntry {
+	var entries []*ftp.FtpDirectoryEntry
+	lines := strings.Split(strings.TrimSpace(data), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "total ") {
+			continue
+		}
+
+		entry := parseListLine(line)
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
+}
+
+// parseListLine parses a single Unix-style ls -l line into an FtpDirectoryEntry.
+// Format: drwxr-xr-x  2 user group  4096 Jan  1 12:00 dirname
+func parseListLine(line string) *ftp.FtpDirectoryEntry {
+	fields := strings.Fields(line)
+	if len(fields) < 9 {
+		// Try to at least extract the name from short lines
+		if len(fields) > 0 {
+			return &ftp.FtpDirectoryEntry{
+				Name: fields[len(fields)-1],
+				Type: ftp.FtpEntryTypeUnknown,
+			}
+		}
+		return nil
+	}
+
+	perms := fields[0]
+	name := strings.Join(fields[8:], " ")
+
+	// Determine entry type from permission string
+	entryType := ftp.FtpEntryTypeFile
+	if len(perms) > 0 {
+		switch perms[0] {
+		case 'd':
+			entryType = ftp.FtpEntryTypeDirectory
+		case 'l':
+			entryType = ftp.FtpEntryTypeLink
+			// Strip symlink target (name -> target)
+			if idx := strings.Index(name, " -> "); idx != -1 {
+				name = name[:idx]
+			}
+		case '-':
+			entryType = ftp.FtpEntryTypeFile
+		default:
+			entryType = ftp.FtpEntryTypeUnknown
+		}
+	}
+
+	// Parse size
+	var size *int64
+	var sizeVal int64
+	if _, err := fmt.Sscanf(fields[4], "%d", &sizeVal); err == nil {
+		size = &sizeVal
+	}
+
+	// Construct last modified from date fields
+	lastModified := fmt.Sprintf("%s %s %s", fields[5], fields[6], fields[7])
+
+	return &ftp.FtpDirectoryEntry{
+		Name:         name,
+		Type:         entryType,
+		Size:         size,
+		Permissions:  &perms,
+		LastModified: &lastModified,
+	}
+}
+
 // containsFTPCode checks if any line in a multi-line FTP response starts with the given code.
 func containsFTPCode(response string, code string) bool {
 	for _, line := range strings.Split(response, "\n") {

--- a/internal/enumerate/ftp/helpers.go
+++ b/internal/enumerate/ftp/helpers.go
@@ -68,37 +68,39 @@ func grabBanner(ctx context.Context, conn net.Conn) (string, error) {
 	return bannerStr, nil
 }
 
-// Function to check for anonymous login with retry on failure
-func checkAnonymousLoginWithRetry(ctx context.Context, target string, conn net.Conn, details *ftp.EnumerateFtpDetails) []string {
+// checkAnonymousLoginWithRetry checks for anonymous login, reconnecting on failure.
+// Returns the active connection (which may be a new one if a retry occurred) and any errors.
+func checkAnonymousLoginWithRetry(ctx context.Context, target string, conn net.Conn, details *ftp.EnumerateFtpDetails) (net.Conn, []string) {
 	log := svc1log.FromContext(ctx)
 
 	errors := []string{}
 	if err := checkAnonymousLogin(ctx, conn, details); err != nil {
 		log.Warn("Error checking anonymous login, retrying...", svc1log.SafeParam("error", err.Error()))
 
-		conn, err = attemptConnection(ctx, target)
+		// Close the broken connection
+		_ = conn.Close()
+
+		newConn, err := attemptConnection(ctx, target)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to reconnect: %v", err))
-			return errors
+			return nil, errors
 		}
 
 		// Consume the banner from the new connection before retrying
-		if _, bannerErr := grabBanner(ctx, conn); bannerErr != nil {
+		if _, bannerErr := grabBanner(ctx, newConn); bannerErr != nil {
 			errors = append(errors, fmt.Sprintf("failed to read banner after reconnect: %v", bannerErr))
-			_ = conn.Close()
-			return errors
+			_ = newConn.Close()
+			return nil, errors
 		}
 
-		err = checkAnonymousLogin(ctx, conn, details)
+		err = checkAnonymousLogin(ctx, newConn, details)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("anonymous login check failed after retry: %v", err))
 		}
-		if closeErr := conn.Close(); closeErr != nil {
-			errors = append(errors, fmt.Sprintf("failed to close connection: %v", closeErr))
-		}
+		return newConn, errors
 	}
 
-	return errors
+	return conn, errors
 }
 
 // Function to check for anonymous login
@@ -190,6 +192,11 @@ func listDirectory(ctx context.Context, conn net.Conn) ([]*ftp.FtpDirectoryEntry
 		return nil, []string{fmt.Sprintf("failed to read PASV response: %v", err)}
 	}
 
+	// Clear the PASV read deadline before proceeding
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return nil, []string{fmt.Sprintf("failed to clear PASV read deadline: %v", err)}
+	}
+
 	pasvResponse := string(response[:n])
 	log.Debug("PASV response", svc1log.SafeParam("response", pasvResponse))
 
@@ -217,6 +224,9 @@ func listDirectory(ctx context.Context, conn net.Conn) ([]*ftp.FtpDirectoryEntry
 	}
 
 	// Read LIST response code from control connection
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return nil, []string{fmt.Sprintf("failed to set LIST read deadline: %v", err)}
+	}
 	n, err = conn.Read(response)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("failed to read LIST response: %v", err))

--- a/internal/enumerate/smtp/constants.go
+++ b/internal/enumerate/smtp/constants.go
@@ -12,3 +12,11 @@ var authCommands = map[string]protocol.SmtpAuthCommand{
 	"CRAM_MD5": protocol.SmtpAuthCommandCrammd5,
 	"NTLM":     protocol.SmtpAuthCommandNtlm,
 }
+
+var defaultUsernames = []string{
+	"root", "admin", "administrator", "postmaster", "webmaster",
+	"info", "support", "sales", "contact", "abuse",
+	"noc", "security", "hostmaster", "mailer-daemon",
+	"nobody", "mail", "ftp", "www", "www-data",
+	"test", "guest", "user", "operator",
+}

--- a/internal/enumerate/smtp/helpers.go
+++ b/internal/enumerate/smtp/helpers.go
@@ -86,12 +86,11 @@ func enumerateUsers(ctx context.Context, c *netsmtp.Client, hostname string, ext
 
 	// Try EXPN if supported (for mailing list expansion)
 	if expnSupported {
-		log.Info("EXPN supported, probing common list names")
-		listNames := []string{"all", "staff", "users", "employees", "team"}
-		for _, listName := range listNames {
-			exists, response := probeEXPN(c, listName)
+		log.Info("EXPN supported, probing via EXPN")
+		for _, username := range usernames {
+			exists, response := probeEXPN(c, username)
 			results = append(results, &smtp.SmtpEnumeratedUser{
-				Username: listName,
+				Username: username,
 				Exists:   exists,
 				Method:   smtp.SmtpUserEnumerationMethodExpn,
 				Response: &response,
@@ -145,7 +144,7 @@ func probeVRFY(c *netsmtp.Client, username string) (bool, string) {
 }
 
 // probeEXPN sends an EXPN command for the given mailing list name.
-// 250 = list exists and members returned, 550 = list does not exist.
+// 250 = list exists and members returned (possibly multi-line), 550 = list does not exist.
 func probeEXPN(c *netsmtp.Client, listName string) (bool, string) {
 	id, err := c.Text.Cmd("EXPN %s", listName)
 	if err != nil {
@@ -153,13 +152,9 @@ func probeEXPN(c *netsmtp.Client, listName string) (bool, string) {
 	}
 	c.Text.StartResponse(id)
 	defer c.Text.EndResponse(id)
-	code, msg, err := c.Text.ReadCodeLine(-1)
+	// Use ReadResponse to properly drain multi-line 250 responses (one member per line)
+	code, msg, err := c.Text.ReadResponse(-1)
 	if err != nil {
-		// Multi-line 250 responses (list members) come back as an error from ReadCodeLine
-		// but that's actually a success — check if it starts with 250
-		if code == 250 {
-			return true, fmt.Sprintf("%d %s", code, msg)
-		}
 		return false, fmt.Sprintf("%d %s", code, msg)
 	}
 	response := fmt.Sprintf("%d %s", code, msg)

--- a/internal/enumerate/smtp/helpers.go
+++ b/internal/enumerate/smtp/helpers.go
@@ -134,7 +134,7 @@ func probeVRFY(c *netsmtp.Client, username string) (bool, string) {
 	}
 	c.Text.StartResponse(id)
 	defer c.Text.EndResponse(id)
-	code, msg, err := c.Text.ReadCodeLine(-1)
+	code, msg, err := c.Text.ReadResponse(-1)
 	if err != nil {
 		return false, fmt.Sprintf("%d %s", code, msg)
 	}

--- a/internal/enumerate/smtp/helpers.go
+++ b/internal/enumerate/smtp/helpers.go
@@ -45,7 +45,7 @@ func parseAuthMethods(methods []string) []protocol.SmtpAuthCommand {
 func collectExtensions(c *netsmtp.Client) []string {
 	knownExtensions := []string{
 		"8BITMIME", "AUTH", "BINARYMIME", "CHUNKING", "DSN",
-		"ENHANCEDSTATUSCODES", "ETRN", "PIPELINING", "SIZE",
+		"ENHANCEDSTATUSCODES", "ETRN", "EXPN", "PIPELINING", "SIZE",
 		"STARTTLS", "TURN", "VRFY",
 	}
 	var found []string

--- a/internal/enumerate/smtp/helpers.go
+++ b/internal/enumerate/smtp/helpers.go
@@ -11,6 +11,8 @@ import (
 
 	// Generated
 	"github.com/Method-Security/networkscan/generated/go/common/protocol"
+	smtp "github.com/Method-Security/networkscan/generated/go/enumerate/smtp"
+
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -57,6 +59,135 @@ func collectExtensions(c *netsmtp.Client) []string {
 		}
 	}
 	return found
+}
+
+// enumerateUsers probes for valid users using VRFY, EXPN, and RCPT TO methods.
+// It tries VRFY first if supported, then EXPN, then falls back to RCPT TO.
+func enumerateUsers(ctx context.Context, c *netsmtp.Client, hostname string, extensions []string, usernames []string) []*smtp.SmtpEnumeratedUser {
+	log := svc1log.FromContext(ctx)
+	var results []*smtp.SmtpEnumeratedUser
+
+	vrfySupported := extensionSupported(extensions, "VRFY")
+	expnSupported := extensionSupported(extensions, "EXPN")
+
+	// Try VRFY if supported
+	if vrfySupported {
+		log.Info("VRFY supported, enumerating users via VRFY")
+		for _, username := range usernames {
+			exists, response := probeVRFY(c, username)
+			results = append(results, &smtp.SmtpEnumeratedUser{
+				Username: username,
+				Exists:   exists,
+				Method:   smtp.SmtpUserEnumerationMethodVrfy,
+				Response: &response,
+			})
+		}
+	}
+
+	// Try EXPN if supported (for mailing list expansion)
+	if expnSupported {
+		log.Info("EXPN supported, probing common list names")
+		listNames := []string{"all", "staff", "users", "employees", "team"}
+		for _, listName := range listNames {
+			exists, response := probeEXPN(c, listName)
+			results = append(results, &smtp.SmtpEnumeratedUser{
+				Username: listName,
+				Exists:   exists,
+				Method:   smtp.SmtpUserEnumerationMethodExpn,
+				Response: &response,
+			})
+		}
+	}
+
+	// Fall back to RCPT TO probing if VRFY is not supported
+	if !vrfySupported {
+		log.Info("VRFY not supported, falling back to RCPT TO enumeration")
+		for _, username := range usernames {
+			exists, response := probeRCPTTO(c, username, hostname)
+			results = append(results, &smtp.SmtpEnumeratedUser{
+				Username: username,
+				Exists:   exists,
+				Method:   smtp.SmtpUserEnumerationMethodRcptTo,
+				Response: &response,
+			})
+		}
+	}
+
+	return results
+}
+
+// extensionSupported checks if a given extension name is in the collected extensions list.
+func extensionSupported(extensions []string, name string) bool {
+	for _, ext := range extensions {
+		if strings.HasPrefix(ext, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// probeVRFY sends a VRFY command for the given username and interprets the response.
+// 250/251 = user exists, 252 = cannot verify but will attempt delivery, 550/551/553 = does not exist.
+func probeVRFY(c *netsmtp.Client, username string) (bool, string) {
+	id, err := c.Text.Cmd("VRFY %s", username)
+	if err != nil {
+		return false, fmt.Sprintf("error: %v", err)
+	}
+	c.Text.StartResponse(id)
+	defer c.Text.EndResponse(id)
+	code, msg, err := c.Text.ReadCodeLine(-1)
+	if err != nil {
+		return false, fmt.Sprintf("%d %s", code, msg)
+	}
+	response := fmt.Sprintf("%d %s", code, msg)
+	// 250 = exact match, 251 = will forward
+	return code == 250 || code == 251, response
+}
+
+// probeEXPN sends an EXPN command for the given mailing list name.
+// 250 = list exists and members returned, 550 = list does not exist.
+func probeEXPN(c *netsmtp.Client, listName string) (bool, string) {
+	id, err := c.Text.Cmd("EXPN %s", listName)
+	if err != nil {
+		return false, fmt.Sprintf("error: %v", err)
+	}
+	c.Text.StartResponse(id)
+	defer c.Text.EndResponse(id)
+	code, msg, err := c.Text.ReadCodeLine(-1)
+	if err != nil {
+		// Multi-line 250 responses (list members) come back as an error from ReadCodeLine
+		// but that's actually a success — check if it starts with 250
+		if code == 250 {
+			return true, fmt.Sprintf("%d %s", code, msg)
+		}
+		return false, fmt.Sprintf("%d %s", code, msg)
+	}
+	response := fmt.Sprintf("%d %s", code, msg)
+	return code == 250, response
+}
+
+// probeRCPTTO uses MAIL FROM + RCPT TO to check if a user exists.
+// 250 = accepted, 550/551/553 = rejected. Resets the session after each probe.
+func probeRCPTTO(c *netsmtp.Client, username string, hostname string) (bool, string) {
+	email := fmt.Sprintf("%s@%s", username, hostname)
+
+	err := c.Mail(fmt.Sprintf("probe@%s", hostname))
+	if err != nil {
+		return false, fmt.Sprintf("MAIL FROM error: %v", err)
+	}
+
+	err = c.Rcpt(email)
+	response := ""
+	exists := false
+	if err != nil {
+		response = err.Error()
+	} else {
+		exists = true
+		response = "250 OK"
+	}
+
+	_ = c.Reset()
+	return exists, response
 }
 
 func testUnauthenticatedEmail(ctx context.Context, c *netsmtp.Client, hostname string) bool {

--- a/internal/enumerate/smtp/helpers.go
+++ b/internal/enumerate/smtp/helpers.go
@@ -168,6 +168,7 @@ func probeRCPTTO(c *netsmtp.Client, username string, hostname string) (bool, str
 
 	err := c.Mail(fmt.Sprintf("probe@%s", hostname))
 	if err != nil {
+		_ = c.Reset()
 		return false, fmt.Sprintf("MAIL FROM error: %v", err)
 	}
 

--- a/internal/enumerate/smtp/smtp.go
+++ b/internal/enumerate/smtp/smtp.go
@@ -21,7 +21,9 @@ import (
 )
 
 // LibraryEnumerateSMTP implements NetworkApplicationLibrary for SMTP enumeration.
-type LibraryEnumerateSMTP struct{}
+type LibraryEnumerateSMTP struct {
+	Wordlist []string
+}
 
 // EnumerateTarget Overview
 //  1. Try to connect to service
@@ -143,6 +145,16 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	}
 
 	detail.ServerInfo = serverInfo
+
+	// Enumerate users via VRFY, EXPN, and RCPT TO
+	wordlist := s.Wordlist
+	if len(wordlist) == 0 {
+		wordlist = defaultUsernames
+	}
+	enumeratedUsers := enumerateUsers(ctx, client, hostname, extensions, wordlist)
+	if len(enumeratedUsers) > 0 {
+		detail.EnumeratedUsers = enumeratedUsers
+	}
 
 	// Test if unauthenticated email is allowed
 	log.Debug("Testing unauthenticated email")


### PR DESCRIPTION
## Summary
- **SMTP user enumeration**: `enumerate service --service smtp` now probes for valid users using VRFY (when supported), EXPN (for mailing list expansion), and RCPT TO (fallback). Includes a default wordlist of 23 common usernames and a `--wordlist` flag for custom lists.
- **FTP directory listing**: `enumerate service --service ftp` now retrieves directory contents via PASV + LIST when anonymous login succeeds. Parses Unix ls -l format into structured entries with name, type, size, permissions, and last modified.

## Test plan
- [x] `./godelw verify` passes clean
- [x] SMTP signal generated against MailHog (RCPT TO fallback path)
- [x] FTP signal generated against vsftpd (anonymous login + directory listing with files)
- [x] `fern generate --group local` and `--group pypi-local` both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends enumeration behavior and output schemas (Fern-generated types) for SMTP and FTP, which may affect downstream consumers and increases network interactions/timeouts against targets.
> 
> **Overview**
> **Adds deeper SMTP and FTP enumeration output.** `enumerate service` now accepts an optional `--wordlist` and passes it through `EnumerateServiceConfig` into the SMTP enumerator.
> 
> For **SMTP**, enumeration now probes usernames via `VRFY`, `EXPN`, and `RCPT TO` (with a built-in default username list) and reports results as structured `enumeratedUsers` entries.
> 
> For **FTP**, successful anonymous login now triggers a `PASV` + `LIST` directory listing, parsed into structured `directoryListing` entries (name/type/size/permissions/lastModified), and the anonymous-login retry logic now returns the active connection for subsequent use.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca19c539757163c0a7cde644dedcd26661f05946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->