### PR TITLE
Upgrade Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.78.1"
+  "version": "4.68.4"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,9 +3,9 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.38.0
+        version: 1.34.8
         config:
-          importpath: github.com/Method-Security/networkscan/generated/go
+          importPath: github.com/Method-Security/networkscan/generated/go
         output:
           location: local-file-system
           path: ../generated/go

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,7 +3,7 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.34.8
+        version: 1.34.9
         config:
           importPath: github.com/Method-Security/networkscan/generated/go
         output:

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c // indirect
@@ -207,6 +208,7 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/projectdiscovery/dsl v0.5.0 // indirect
 	github.com/projectdiscovery/fasttemplate v0.0.2 // indirect
 	github.com/projectdiscovery/gcache v0.0.0-20241015120333-12546c6e3f4c // indirect
@@ -287,7 +289,6 @@ require (
 	github.com/charmbracelet/glamour v0.10.0 // indirect
 	github.com/cheggaaa/pb/v3 v3.1.7 // indirect
 	github.com/cnf/structhash v0.0.0-20250313080605-df4c6cc74a9a // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -331,7 +332,6 @@ require (
 	github.com/palantir/witchcraft-go-tracing v1.40.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/projectdiscovery/asnmap v1.1.1 // indirect
 	github.com/projectdiscovery/blackrock v0.0.1 // indirect

--- a/internal/discover/service/plugins/ard.go
+++ b/internal/discover/service/plugins/ard.go
@@ -138,7 +138,7 @@ func (ArdFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeArd,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromArd(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Ard: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/atg.go
+++ b/internal/discover/service/plugins/atg.go
@@ -134,7 +134,7 @@ func (AtgFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeAtg,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromAtg(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Atg: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/bgp.go
+++ b/internal/discover/service/plugins/bgp.go
@@ -222,7 +222,7 @@ func createBGPServiceDetails(ip net.IP, port int, host, version, messageType str
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeBgp,
 		Version:   &version,
-		Metadata:  discoverfern.NewServiceMetadataFromBgp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Bgp: metadata},
 	}
 }
 

--- a/internal/discover/service/plugins/dcerpc.go
+++ b/internal/discover/service/plugins/dcerpc.go
@@ -90,7 +90,7 @@ func (DCERPCFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeDcerpc,
 		Version:   &version,
-		Metadata:  discoverfern.NewServiceMetadataFromDcerpc(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Dcerpc: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/dhcp.go
+++ b/internal/discover/service/plugins/dhcp.go
@@ -96,7 +96,7 @@ func (DHCPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeDhcp,
 		Version:   &version,
-		Metadata:  discoverfern.NewServiceMetadataFromGeneric(&discoverfern.GenericServiceMetadata{Metadata: meta}),
+		Metadata:  &discoverfern.ServiceMetadata{Generic: &discoverfern.GenericServiceMetadata{Metadata: meta}},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/dns.go
+++ b/internal/discover/service/plugins/dns.go
@@ -96,7 +96,7 @@ func (DNSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeDns,
 		Version:   dnsVersion,
-		Metadata:  discoverfern.NewServiceMetadataFromDns(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Dns: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/fins.go
+++ b/internal/discover/service/plugins/fins.go
@@ -146,7 +146,7 @@ func (FinsFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeFins,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromFins(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Fins: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/fortigate.go
+++ b/internal/discover/service/plugins/fortigate.go
@@ -119,7 +119,7 @@ func detectFortiGateService(ctx context.Context, ip net.IP, port int, host strin
 			Transport: common.TransportTypeTcp,
 			Protocol:  common.ProtocolTypeFgfm,
 			Version:   &version,
-			Metadata:  discoverfern.NewServiceMetadataFromFgfm(metadata),
+			Metadata:  &discoverfern.ServiceMetadata{Fgfm: metadata},
 		}
 
 		return result, nil

--- a/internal/discover/service/plugins/fox.go
+++ b/internal/discover/service/plugins/fox.go
@@ -118,7 +118,7 @@ func (FoxFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeFox,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromFox(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Fox: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/gesrtp.go
+++ b/internal/discover/service/plugins/gesrtp.go
@@ -130,7 +130,7 @@ func (GesrtpFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeGesrtp,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromGesrtp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Gesrtp: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/grpc.go
+++ b/internal/discover/service/plugins/grpc.go
@@ -138,6 +138,6 @@ func buildResult(host string, ip net.IP, port int, tlsUsed bool, statusStr strin
 			return common.TransportTypeTcp
 		}(),
 		Protocol: common.ProtocolTypeGrpc,
-		Metadata: discoverfern.NewServiceMetadataFromGrpc(metadata),
+		Metadata: &discoverfern.ServiceMetadata{Grpc: metadata},
 	}
 }

--- a/internal/discover/service/plugins/hart.go
+++ b/internal/discover/service/plugins/hart.go
@@ -131,7 +131,7 @@ func (HartFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Transport: transport,
 		Protocol:  common.ProtocolTypeHart,
 		Version:   versionStr,
-		Metadata:  discoverfern.NewServiceMetadataFromHart(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Hart: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/http.go
+++ b/internal/discover/service/plugins/http.go
@@ -87,9 +87,9 @@ func (HTTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 				}
 				return common.ProtocolTypeUnknown
 			}(),
-			Metadata: discoverfern.NewServiceMetadataFromGeneric(&discoverfern.GenericServiceMetadata{
+			Metadata: &discoverfern.ServiceMetadata{Generic: &discoverfern.GenericServiceMetadata{
 				Metadata: metadata,
-			}),
+			}},
 		}, nil
 	}
 

--- a/internal/discover/service/plugins/iec104.go
+++ b/internal/discover/service/plugins/iec104.go
@@ -137,7 +137,7 @@ func (Iec104Fingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeIec104,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromIec104(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Iec104: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/ike.go
+++ b/internal/discover/service/plugins/ike.go
@@ -99,7 +99,7 @@ func (IKEFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeIke,
 		Version:   &version,
-		Metadata:  discoverfern.NewServiceMetadataFromIke(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Ike: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/ipmi.go
+++ b/internal/discover/service/plugins/ipmi.go
@@ -109,7 +109,7 @@ func (IPMIFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeIpmi,
 		Version:   &version,
-		Metadata:  discoverfern.NewServiceMetadataFromIpmi(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Ipmi: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/ipp.go
+++ b/internal/discover/service/plugins/ipp.go
@@ -161,7 +161,7 @@ func detectIPPWithScheme(ctx context.Context, ip net.IP, port int, host string, 
 		Transport: transport,
 		Protocol:  common.ProtocolTypeIpp,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromIpp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Ipp: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/kerberos.go
+++ b/internal/discover/service/plugins/kerberos.go
@@ -89,7 +89,7 @@ func (KerberosFingerprinter) Detect(ctx context.Context, ip net.IP, port int, ho
 		Transport: transport,
 		Protocol:  common.ProtocolTypeKerberos,
 		Version:   &version,
-		Metadata:  discoverfern.NewServiceMetadataFromKerberos(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Kerberos: metadata},
 	}, nil
 }
 

--- a/internal/discover/service/plugins/ldap.go
+++ b/internal/discover/service/plugins/ldap.go
@@ -47,7 +47,7 @@ func (LDAPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 				Tls:       false,
 				Transport: common.TransportTypeTcp,
 				Protocol:  common.ProtocolTypeLdap,
-				Metadata:  discoverfern.NewServiceMetadataFromLdap(metadata),
+				Metadata:  &discoverfern.ServiceMetadata{Ldap: metadata},
 			}, nil
 		}
 		return nil, err
@@ -65,6 +65,6 @@ func (LDAPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Tls:       false,
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeLdap,
-		Metadata:  discoverfern.NewServiceMetadataFromLdap(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Ldap: metadata},
 	}, nil
 }

--- a/internal/discover/service/plugins/memcached.go
+++ b/internal/discover/service/plugins/memcached.go
@@ -107,7 +107,7 @@ func (MemcachedFingerprinter) Detect(ctx context.Context, ip net.IP, port int, h
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeMemcached,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromMemcached(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Memcached: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/mms.go
+++ b/internal/discover/service/plugins/mms.go
@@ -125,7 +125,7 @@ func (MmsFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeMms,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromMms(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Mms: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/mongodb.go
+++ b/internal/discover/service/plugins/mongodb.go
@@ -129,6 +129,6 @@ func buildMongoDBResult(host string, ip net.IP, port int, version string, buildI
 		Version:   &version,
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeMongodb,
-		Metadata:  discoverfern.NewServiceMetadataFromMongodb(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Mongodb: metadata},
 	}
 }

--- a/internal/discover/service/plugins/msmq.go
+++ b/internal/discover/service/plugins/msmq.go
@@ -169,7 +169,7 @@ func (MsmqFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeMsmq,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromMsmq(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Msmq: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/netbios.go
+++ b/internal/discover/service/plugins/netbios.go
@@ -85,7 +85,7 @@ func (NetBIOSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, hos
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeNetbios,
 		Version:   nil, // NetBIOS has no version field
-		Metadata:  discoverfern.NewServiceMetadataFromNetbios(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Netbios: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/ntp.go
+++ b/internal/discover/service/plugins/ntp.go
@@ -102,7 +102,7 @@ func (NTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeNtp,
 		Version:   &version,
-		Metadata:  discoverfern.NewServiceMetadataFromNtp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Ntp: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/opcua.go
+++ b/internal/discover/service/plugins/opcua.go
@@ -206,7 +206,7 @@ func buildOpcuaResult(host string, ip net.IP, port int, version, serverName, app
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeOpcua,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromOpcua(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Opcua: metadata},
 	}
 
 	return result

--- a/internal/discover/service/plugins/pcom.go
+++ b/internal/discover/service/plugins/pcom.go
@@ -255,7 +255,7 @@ func parsePcomResponse(response string, ip net.IP, port int, host string) (*disc
 		}
 
 		if extracted {
-			metadata.Metadata = discoverfern.NewServiceMetadataFromPcom(pcomInfo)
+			metadata.Metadata = &discoverfern.ServiceMetadata{Pcom: pcomInfo}
 		}
 	}
 

--- a/internal/discover/service/plugins/pcworx.go
+++ b/internal/discover/service/plugins/pcworx.go
@@ -119,7 +119,7 @@ func (PcworxFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypePcworx,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromPcworx(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Pcworx: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/pptp.go
+++ b/internal/discover/service/plugins/pptp.go
@@ -144,7 +144,7 @@ func (PptpFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypePptp,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromPptp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Pptp: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/sip.go
+++ b/internal/discover/service/plugins/sip.go
@@ -117,7 +117,7 @@ func (SIPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeSip,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromSip(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Sip: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/slp.go
+++ b/internal/discover/service/plugins/slp.go
@@ -154,7 +154,7 @@ func (SlpFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: transport,
 		Protocol:  common.ProtocolTypeSlp,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromSlp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Slp: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/smb.go
+++ b/internal/discover/service/plugins/smb.go
@@ -167,7 +167,7 @@ func detectSMBService(ctx context.Context, ip net.IP, port int, host string) (*d
 			Transport: common.TransportTypeTcp,
 			Protocol:  common.ProtocolTypeSmb,
 			Version:   osVersion,
-			Metadata:  discoverfern.NewServiceMetadataFromSmb(metadata),
+			Metadata:  &discoverfern.ServiceMetadata{Smb: metadata},
 		}
 
 		// Close connection if it was established
@@ -196,7 +196,7 @@ func detectSMBService(ctx context.Context, ip net.IP, port int, host string) (*d
 		Tls:       false,
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeSmb,
-		Metadata:  discoverfern.NewServiceMetadataFromSmb(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Smb: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/smtp.go
+++ b/internal/discover/service/plugins/smtp.go
@@ -169,6 +169,6 @@ func buildSMTPResult(host string, ip net.IP, port int, banner, serverName, softw
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeSmtp,
 		Version:   &version,
-		Metadata:  discoverfern.NewServiceMetadataFromSmtp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Smtp: metadata},
 	}
 }

--- a/internal/discover/service/plugins/snmp.go
+++ b/internal/discover/service/plugins/snmp.go
@@ -113,6 +113,6 @@ func createSNMPResult(ip net.IP, port int, host string, versions []string, commu
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeSnmp,
 		Version:   &versionStr,
-		Metadata:  discoverfern.NewServiceMetadataFromSnmp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Snmp: metadata},
 	}
 }

--- a/internal/discover/service/plugins/ssdp.go
+++ b/internal/discover/service/plugins/ssdp.go
@@ -103,7 +103,7 @@ func (SSDPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeSsdp,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromSsdp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Ssdp: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/ssh.go
+++ b/internal/discover/service/plugins/ssh.go
@@ -81,7 +81,7 @@ func (SSHFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeSsh,
 		Version:   &banner,
-		Metadata:  discoverfern.NewServiceMetadataFromSsh(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Ssh: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/tftp.go
+++ b/internal/discover/service/plugins/tftp.go
@@ -115,7 +115,7 @@ func (TFTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeTftp,
 		Version:   nil, // TFTP has no version field
-		Metadata:  discoverfern.NewServiceMetadataFromTftp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Tftp: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/ubiquiti.go
+++ b/internal/discover/service/plugins/ubiquiti.go
@@ -116,7 +116,7 @@ func (UbiquitiFingerprinter) Detect(ctx context.Context, ip net.IP, port int, ho
 		Version:   &deviceVersion,
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeUbiquiti,
-		Metadata:  discoverfern.NewServiceMetadataFromUbiquiti(ubiquitiInfo),
+		Metadata:  &discoverfern.ServiceMetadata{Ubiquiti: ubiquitiInfo},
 	}, nil
 }
 

--- a/internal/discover/service/plugins/unistream.go
+++ b/internal/discover/service/plugins/unistream.go
@@ -164,7 +164,7 @@ func (UnistreamFingerprinter) Detect(ctx context.Context, ip net.IP, port int, h
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeEthernetip,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromUnistream(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Unistream: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/winrm.go
+++ b/internal/discover/service/plugins/winrm.go
@@ -161,7 +161,7 @@ func detectWinRMWithScheme(ctx context.Context, ip net.IP, port int, host string
 		Transport: transport,
 		Protocol:  common.ProtocolTypeWinrm,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromWinrm(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Winrm: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/x11.go
+++ b/internal/discover/service/plugins/x11.go
@@ -167,7 +167,7 @@ func (X11Fingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 		Transport: common.TransportTypeTcp,
 		Protocol:  common.ProtocolTypeX11,
 		Version:   version,
-		Metadata:  discoverfern.NewServiceMetadataFromX11(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{X11: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/plugins/xdmcp.go
+++ b/internal/discover/service/plugins/xdmcp.go
@@ -124,7 +124,7 @@ func (XdmcpFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host 
 		Transport: common.TransportTypeUdp,
 		Protocol:  common.ProtocolTypeXdmcp,
 		Version:   &versionStr,
-		Metadata:  discoverfern.NewServiceMetadataFromXdmcp(metadata),
+		Metadata:  &discoverfern.ServiceMetadata{Xdmcp: metadata},
 	}
 
 	return result, nil

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -350,7 +350,7 @@ func fxToServiceDetails(result *plugins.Service) *discoverfern.ServiceDetails {
 			return common.ProtocolTypeUnknown
 		}(),
 		Version:  &result.Version,
-		Metadata: discoverfern.NewServiceMetadataFromGeneric(&discoverfern.GenericServiceMetadata{Metadata: metadataMap}),
+		Metadata: &discoverfern.ServiceMetadata{Generic: &discoverfern.GenericServiceMetadata{Metadata: metadataMap}},
 	}
 
 	return serviceDetails

--- a/internal/enumerate/ftp/ftp.go
+++ b/internal/enumerate/ftp/ftp.go
@@ -59,7 +59,7 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 	if err != nil {
 		log.Error("Failed to connect to FTP target", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
 		errors = append(errors, fmt.Sprintf("Failed to connect to %s: %v", target, err))
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateFtpDetails: &details}, errors
 	}
 
 	log.Debug("FTP connection established", svc1log.SafeParam("target", target))
@@ -68,7 +68,7 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 	bannerStr, err := grabBanner(ctx, conn)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("error reading banner from %s: %v", target, err))
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateFtpDetails: &details}, errors
 	}
 	details.Banner = &bannerStr
 	successFulConnection := true
@@ -112,7 +112,7 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 	}
 
 	if conn == nil {
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateFtpDetails: &details}, errors
 	}
 
 	err = conn.Close()
@@ -121,5 +121,5 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 	}
 
 	log.Info("FTP enumeration completed", svc1log.SafeParam("target", target))
-	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateFtpDetails(&details), errors
+	return &enumeratefern.EnumerateServiceDetails{EnumerateFtpDetails: &details}, errors
 }

--- a/internal/enumerate/grpc/grpc.go
+++ b/internal/enumerate/grpc/grpc.go
@@ -39,7 +39,7 @@ func (lib *LibraryEnumerateGRPC) EnumerateTarget(ctx context.Context, target str
 		details.ServerInfo = &commonprotocolfern.GrpcServerInfo{
 			ReflectionSupported: false,
 		}
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateGrpcDetails: &details}, errors
 	}
 	defer closeConnection(conn)
 
@@ -50,7 +50,7 @@ func (lib *LibraryEnumerateGRPC) EnumerateTarget(ctx context.Context, target str
 		details.ServerInfo = &commonprotocolfern.GrpcServerInfo{
 			ReflectionSupported: false,
 		}
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateGrpcDetails: &details}, errors
 	}
 
 	services, err := requestAndReceiveServices(stream)
@@ -60,7 +60,7 @@ func (lib *LibraryEnumerateGRPC) EnumerateTarget(ctx context.Context, target str
 		details.ServerInfo = &commonprotocolfern.GrpcServerInfo{
 			ReflectionSupported: false,
 		}
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateGrpcDetails: &details}, errors
 	}
 
 	// Build serverInfo with discovered services
@@ -73,17 +73,17 @@ func (lib *LibraryEnumerateGRPC) EnumerateTarget(ctx context.Context, target str
 	if err != nil {
 		errors = append(errors, err.Error())
 		details.ServerInfo = serverInfo
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateGrpcDetails: &details}, errors
 	}
 
 	if err := encodeRawDescriptors(rawDescriptors, serverInfo); err != nil {
 		errors = append(errors, err.Error())
 		details.ServerInfo = serverInfo
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateGrpcDetails: &details}, errors
 	}
 
 	details.ServerInfo = serverInfo
-	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateGrpcDetails(&details), errors
+	return &enumeratefern.EnumerateServiceDetails{EnumerateGrpcDetails: &details}, errors
 }
 
 // connectToGRPCServer dials the target with a timeout.

--- a/internal/enumerate/ike/ike.go
+++ b/internal/enumerate/ike/ike.go
@@ -31,12 +31,12 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 	host, portStr, err := net.SplitHostPort(target)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("invalid target %q: %v", target, err))
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateIkeDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateIkeDetails: &details}, errors
 	}
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("invalid port in target %q: %v", target, err))
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateIkeDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateIkeDetails: &details}, errors
 	}
 	details.Target = host
 	details.Port = port
@@ -160,5 +160,5 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 		serverInfo.DhGroups,
 	)
 	details.ServerInfo = &serverInfo
-	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateIkeDetails(&details), errors
+	return &enumeratefern.EnumerateServiceDetails{EnumerateIkeDetails: &details}, errors
 }

--- a/internal/enumerate/ldap/ldap.go
+++ b/internal/enumerate/ldap/ldap.go
@@ -347,5 +347,5 @@ func (l *LibraryEnumerateLDAP) EnumerateTarget(ctx context.Context, target strin
 
 	log.Info("LDAP enumeration completed", svc1log.SafeParam("target", target))
 
-	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateLdapDetails(&details), errors
+	return &enumeratefern.EnumerateServiceDetails{EnumerateLdapDetails: &details}, errors
 }

--- a/internal/enumerate/smb/smb.go
+++ b/internal/enumerate/smb/smb.go
@@ -297,7 +297,7 @@ func (s *LibraryEnumerateSMB) EnumerateTarget(ctx context.Context, target string
 
 	log.Info("SMB enumeration completed", svc1log.SafeParam("target", target))
 
-	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmbDetails(&details), errors
+	return &enumeratefern.EnumerateServiceDetails{EnumerateSmbDetails: &details}, errors
 }
 
 // convertToSmbServerInfo converts protocol library ServerInfo to common SMB ServerInfo

--- a/internal/enumerate/smtp/smtp.go
+++ b/internal/enumerate/smtp/smtp.go
@@ -50,7 +50,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	hostname, _, err := net.SplitHostPort(target)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("invalid target format: %v", err))
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSmtpDetails: &detail}, errors
 	}
 	tlsConfig := &tls.Config{
 		ServerName:         hostname,
@@ -73,7 +73,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 			canConnect := false
 			detail.CanConnect = &canConnect
 			errors = append(errors, fmt.Sprintf("both TCP and TLS connections failed: %v", err))
-			return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
+			return &enumeratefern.EnumerateServiceDetails{EnumerateSmtpDetails: &detail}, errors
 		}
 		log.Debug("TLS connection successful")
 		tlsSupported := true
@@ -109,7 +109,7 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("SMTP client creation failed: %v", err))
 		detail.ServerInfo = serverInfo
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSmtpDetails: &detail}, errors
 	}
 
 	// Try STARTTLS if TLS connection established above
@@ -167,5 +167,5 @@ func (s *LibraryEnumerateSMTP) EnumerateTarget(ctx context.Context, target strin
 		errors = append(errors, fmt.Sprintf("failed to close connection: %v", err))
 	}
 
-	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSmtpDetails(&detail), errors
+	return &enumeratefern.EnumerateServiceDetails{EnumerateSmtpDetails: &detail}, errors
 }

--- a/internal/enumerate/snmp/snmp.go
+++ b/internal/enumerate/snmp/snmp.go
@@ -28,16 +28,16 @@ func (s *LibraryEnumerateSNMP) EnumerateTarget(ctx context.Context, target strin
 	host, portStr, err := net.SplitHostPort(target)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("invalid target format %q: %v", target, err))
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSnmpDetails: &details}, errors
 	}
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("invalid port %q: %v", portStr, err))
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSnmpDetails: &details}, errors
 	}
 	if port < 1 || port > 65535 {
 		errors = append(errors, fmt.Sprintf("port %d out of range (1-65535)", port))
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSnmpDetails: &details}, errors
 	}
 	snmpPort := uint16(port)
 
@@ -46,7 +46,7 @@ func (s *LibraryEnumerateSNMP) EnumerateTarget(ctx context.Context, target strin
 		ips, err := net.LookupIP(host)
 		if err != nil || len(ips) == 0 {
 			errors = append(errors, fmt.Sprintf("cannot resolve host %q: %v", host, err))
-			return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+			return &enumeratefern.EnumerateServiceDetails{EnumerateSnmpDetails: &details}, errors
 		}
 		ip = ips[0]
 	}
@@ -62,7 +62,7 @@ func (s *LibraryEnumerateSNMP) EnumerateTarget(ctx context.Context, target strin
 		} else {
 			errors = append(errors, "SNMPv3 not detected on target")
 		}
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSnmpDetails: &details}, errors
 	}
 
 	// Test if NoAuthNoPriv grants actual read access with common usernames
@@ -84,5 +84,5 @@ func (s *LibraryEnumerateSNMP) EnumerateTarget(ctx context.Context, target strin
 		details.V3RequiredSecurityLevel = &level
 	}
 
-	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSnmpDetails(&details), errors
+	return &enumeratefern.EnumerateServiceDetails{EnumerateSnmpDetails: &details}, errors
 }

--- a/internal/enumerate/ssh/ssh.go
+++ b/internal/enumerate/ssh/ssh.go
@@ -44,7 +44,7 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 	conn, err := dialer.DialContext(ctx, "tcp", target)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSshDetails: &details}, errors
 	}
 	defer func() { _ = conn.Close() }()
 
@@ -52,11 +52,11 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 	version, versionASCII, err := getSSHVersion(ctx, conn)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSshDetails: &details}, errors
 	}
 	if version == nil {
 		errors = append(errors, "SSH version is nil")
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSshDetails: &details}, errors
 	}
 	serverInfo.ServerVersion = version
 
@@ -64,7 +64,7 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 	rawASCII, err := getSSHAlgorithms(ctx, conn)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
+		return &enumeratefern.EnumerateServiceDetails{EnumerateSshDetails: &details}, errors
 	}
 
 	fullASCII := rawASCII
@@ -92,5 +92,5 @@ func (s *LibraryEnumerateSSH) EnumerateTarget(ctx context.Context, target string
 	// Set the server info in the details
 	details.ServerInfo = &serverInfo
 
-	return enumeratefern.NewEnumerateServiceDetailsFromEnumerateSshDetails(&details), errors
+	return &enumeratefern.EnumerateServiceDetails{EnumerateSshDetails: &details}, errors
 }

--- a/internal/pentest/engine.go
+++ b/internal/pentest/engine.go
@@ -114,12 +114,12 @@ func (e *Engine) runSMBPentestForTargetPhased(ctx context.Context, target string
 		// Check if probe result indicates complete failure (no server info extracted)
 		// PROBE is considered successful if server info was extracted, even if there were connection errors
 		if (probeResult.Errors != nil && len(probeResult.Errors) > 0) && probeResult.ServerInfo == nil {
-			results = append(results, smbfern.NewPentestSmbResultFromProbeResult(probeResult))
+			results = append(results, &smbfern.PentestSmbResult{ProbeResult: probeResult})
 			errors = append(errors, "PROBE stage failed - cannot continue to AUTH/ACTION stages")
 			return results, errors // Fail fast - probe failed completely
 		}
 
-		results = append(results, smbfern.NewPentestSmbResultFromProbeResult(probeResult))
+		results = append(results, &smbfern.PentestSmbResult{ProbeResult: probeResult})
 
 		// If only PROBE was requested, return early
 		if !needsAuth && !needsOtherAction {
@@ -150,7 +150,7 @@ func (e *Engine) runSMBPentestForTargetPhased(ctx context.Context, target string
 			}
 		}
 
-		results = append(results, smbfern.NewPentestSmbResultFromAuthResult(authResult))
+		results = append(results, &smbfern.PentestSmbResult{AuthResult: authResult})
 
 		// If no successful authentication and ACTION is needed, fail fast
 		if needsOtherAction && len(successfulAuths) == 0 {
@@ -208,7 +208,7 @@ func (e *Engine) executeSMBActionsWithAuthenticatedClient(ctx context.Context, t
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionSamdump), err))
 			} else {
-				results = append(results, smbfern.NewPentestSmbResultFromSamdumpResult(samdumpResult))
+				results = append(results, &smbfern.PentestSmbResult{SamdumpResult: samdumpResult})
 			}
 		case smbfern.PentestSmbActionLsadump:
 			log.Debug("Performing " + string(smbfern.PentestSmbActionLsadump))
@@ -216,7 +216,7 @@ func (e *Engine) executeSMBActionsWithAuthenticatedClient(ctx context.Context, t
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionLsadump), err))
 			} else {
-				results = append(results, smbfern.NewPentestSmbResultFromLsadumpResult(lsadumpResult))
+				results = append(results, &smbfern.PentestSmbResult{LsadumpResult: lsadumpResult})
 			}
 		case smbfern.PentestSmbActionSharesMap:
 			log.Debug("Performing " + string(smbfern.PentestSmbActionSharesMap))
@@ -224,7 +224,7 @@ func (e *Engine) executeSMBActionsWithAuthenticatedClient(ctx context.Context, t
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionSharesMap), err))
 			} else {
-				results = append(results, smbfern.NewPentestSmbResultFromSharesMapResult(sharesResult))
+				results = append(results, &smbfern.PentestSmbResult{SharesMapResult: sharesResult})
 			}
 		case smbfern.PentestSmbActionShareDownload:
 			log.Debug("Performing " + string(smbfern.PentestSmbActionShareDownload))
@@ -232,7 +232,7 @@ func (e *Engine) executeSMBActionsWithAuthenticatedClient(ctx context.Context, t
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionShareDownload), err))
 			} else {
-				results = append(results, smbfern.NewPentestSmbResultFromShareDownloadResult(shareDownloadResult))
+				results = append(results, &smbfern.PentestSmbResult{ShareDownloadResult: shareDownloadResult})
 			}
 		case smbfern.PentestSmbActionExec:
 			log.Debug("Performing " + string(smbfern.PentestSmbActionExec))
@@ -240,7 +240,7 @@ func (e *Engine) executeSMBActionsWithAuthenticatedClient(ctx context.Context, t
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("%s failed: %v", string(smbfern.PentestSmbActionExec), err))
 			} else {
-				results = append(results, smbfern.NewPentestSmbResultFromExecResult(execResult))
+				results = append(results, &smbfern.PentestSmbResult{ExecResult: execResult})
 			}
 		default:
 			errors = append(errors, fmt.Sprintf("unsupported action: %s", string(action)))
@@ -365,7 +365,7 @@ func (e *Engine) runSSHPentestForTarget(ctx context.Context, target string, conf
 		return &sshfern.PentestSshReport{
 			Config: config,
 			Result: &sshfern.PentestSshResultContainer{
-				Result: sshfern.NewPentestSshResultFromAuthResult(authResult),
+				Result: &sshfern.PentestSshResult{AuthResult: authResult},
 			},
 			Errors: []string{err.Error()},
 		}, err
@@ -384,7 +384,7 @@ func (e *Engine) runSSHPentestForTarget(ctx context.Context, target string, conf
 		return &sshfern.PentestSshReport{
 			Config: config,
 			Result: &sshfern.PentestSshResultContainer{
-				Result: sshfern.NewPentestSshResultFromAuthResult(authResult),
+				Result: &sshfern.PentestSshResult{AuthResult: authResult},
 			},
 			Errors: authResult.Errors,
 		}, nil
@@ -395,7 +395,7 @@ func (e *Engine) runSSHPentestForTarget(ctx context.Context, target string, conf
 		return &sshfern.PentestSshReport{
 			Config: config,
 			Result: &sshfern.PentestSshResultContainer{
-				Result: sshfern.NewPentestSshResultFromAuthResult(authResult),
+				Result: &sshfern.PentestSshResult{AuthResult: authResult},
 			},
 			Errors: append(authResult.Errors, "AUTH stage failed - no successful authentication for ACTION stage"),
 		}, nil
@@ -412,7 +412,7 @@ func (e *Engine) runSSHPentestForTarget(ctx context.Context, target string, conf
 				return &sshfern.PentestSshReport{
 					Config: config,
 					Result: &sshfern.PentestSshResultContainer{
-						Result: sshfern.NewPentestSshResultFromExecResult(execResult),
+						Result: &sshfern.PentestSshResult{ExecResult: execResult},
 					},
 					Errors: append(authResult.Errors, fmt.Sprintf("%s failed: %v", string(sshfern.PentestSshActionExec), err)),
 				}, nil
@@ -420,7 +420,7 @@ func (e *Engine) runSSHPentestForTarget(ctx context.Context, target string, conf
 			return &sshfern.PentestSshReport{
 				Config: config,
 				Result: &sshfern.PentestSshResultContainer{
-					Result: sshfern.NewPentestSshResultFromExecResult(execResult),
+					Result: &sshfern.PentestSshResult{ExecResult: execResult},
 				},
 				Errors: authResult.Errors,
 			}, nil
@@ -436,7 +436,7 @@ func (e *Engine) runSSHPentestForTarget(ctx context.Context, target string, conf
 	return &sshfern.PentestSshReport{
 		Config: config,
 		Result: &sshfern.PentestSshResultContainer{
-			Result: sshfern.NewPentestSshResultFromAuthResult(authResult),
+			Result: &sshfern.PentestSshResult{AuthResult: authResult},
 		},
 		Errors: authResult.Errors,
 	}, nil
@@ -494,7 +494,7 @@ func (e *Engine) runTelnetPentestForTarget(ctx context.Context, target string, c
 		return &telnetfern.PentestTelnetReport{
 			Config: config,
 			Result: &telnetfern.PentestTelnetResultContainer{
-				Result: telnetfern.NewPentestTelnetResultFromAuthResult(authResult),
+				Result: &telnetfern.PentestTelnetResult{AuthResult: authResult},
 			},
 			Errors: []string{err.Error()},
 		}, err
@@ -503,7 +503,7 @@ func (e *Engine) runTelnetPentestForTarget(ctx context.Context, target string, c
 	return &telnetfern.PentestTelnetReport{
 		Config: config,
 		Result: &telnetfern.PentestTelnetResultContainer{
-			Result: telnetfern.NewPentestTelnetResultFromAuthResult(authResult),
+			Result: &telnetfern.PentestTelnetResult{AuthResult: authResult},
 		},
 		Errors: authResult.Errors,
 	}, nil
@@ -582,12 +582,12 @@ func (e *Engine) runLDAPPentestForTargetPhased(ctx context.Context, target strin
 		// Check if probe result indicates complete failure (no server info extracted)
 		// PROBE is considered successful if server info was extracted, even if there were connection errors
 		if (probeResult.Errors != nil && len(probeResult.Errors) > 0) && probeResult.ServerInfo == nil {
-			results = append(results, ldapfern.NewPentestLdapResultFromProbeResult(probeResult))
+			results = append(results, &ldapfern.PentestLdapResult{ProbeResult: probeResult})
 			errors = append(errors, "PROBE stage failed - cannot continue to AUTH/ACTION stages")
 			return results, errors // Fail fast - probe failed completely
 		}
 
-		results = append(results, ldapfern.NewPentestLdapResultFromProbeResult(probeResult))
+		results = append(results, &ldapfern.PentestLdapResult{ProbeResult: probeResult})
 
 		// If only PROBE was requested, return early
 		if !needsAuth && !needsOtherAction {
@@ -623,7 +623,7 @@ func (e *Engine) runLDAPPentestForTargetPhased(ctx context.Context, target strin
 			}
 		}
 
-		results = append(results, ldapfern.NewPentestLdapResultFromAuthResult(authResult))
+		results = append(results, &ldapfern.PentestLdapResult{AuthResult: authResult})
 
 		// If no successful authentication and ACTION is needed, fail fast
 		if needsOtherAction && len(successfulAuths) == 0 {
@@ -680,7 +680,7 @@ func (e *Engine) executeLDAPActionsWithAuthenticatedConnection(ctx context.Conte
 				errors = append(errors, actionErrors...)
 			}
 			if domainResult != nil {
-				result := ldapfern.NewPentestLdapResultFromDomainDumpResult(domainResult)
+				result := &ldapfern.PentestLdapResult{DomainDumpResult: domainResult}
 				results = append(results, result)
 			}
 		}
@@ -713,7 +713,7 @@ func (e *Engine) RunKerberosPentest(ctx context.Context, config *kerberosfern.Pe
 				continue
 			}
 
-			result = kerberosfern.NewPentestKerberosResultFromServiceTicketResult(serviceTicketResult)
+			result = &kerberosfern.PentestKerberosResult{ServiceTicketResult: serviceTicketResult}
 
 		default:
 			allErrors = append(allErrors, fmt.Sprintf("unsupported Kerberos action: %s", string(action)))
@@ -760,7 +760,7 @@ func (e *Engine) RunMSRPCPentest(ctx context.Context, config *msrpcfern.PentestM
 
 			// Always create result from dcsyncResult, even on error, to maintain report structure
 			if dcsyncResult != nil {
-				result = msrpcfern.NewPentestMsrpcResultFromDcSyncResult(dcsyncResult)
+				result = &msrpcfern.PentestMsrpcResult{DcSyncResult: dcsyncResult}
 			}
 
 		default:
@@ -844,13 +844,13 @@ func (e *Engine) runWinRMPentestForTarget(ctx context.Context, target string, co
 	if err != nil {
 		errors = append(errors, err.Error())
 		if authResult != nil {
-			results = append(results, winrmfern.NewPentestWinrmResultFromAuthResult(authResult))
+			results = append(results, &winrmfern.PentestWinrmResult{AuthResult: authResult})
 		}
 		return results, errors
 	}
 
 	// Add auth result to results
-	results = append(results, winrmfern.NewPentestWinrmResultFromAuthResult(authResult))
+	results = append(results, &winrmfern.PentestWinrmResult{AuthResult: authResult})
 
 	// Find successful auth attempts
 	successfulAuths := make([]*pentestfern.AuthAttempt, 0)
@@ -888,7 +888,7 @@ func (e *Engine) runWinRMPentestForTarget(ctx context.Context, target string, co
 				errors = append(errors, fmt.Sprintf("%s failed: %v", string(winrmfern.PentestWinrmActionExec), err))
 			}
 			if execResult != nil {
-				results = append(results, winrmfern.NewPentestWinrmResultFromExecResult(execResult))
+				results = append(results, &winrmfern.PentestWinrmResult{ExecResult: execResult})
 			}
 		default:
 			log.Warn("Unsupported WinRM action", svc1log.SafeParam("action", string(action)))
@@ -970,7 +970,7 @@ func (e *Engine) runFTPPentestForTarget(ctx context.Context, target string, conf
 			errors = append(errors, fmt.Sprintf("FTP LIST failed for %s: %v", target, err))
 		}
 		if listResult != nil {
-			results = append(results, ftpfern.NewPentestFtpResultFromListResult(listResult))
+			results = append(results, &ftpfern.PentestFtpResult{ListResult: listResult})
 		}
 	}
 
@@ -981,7 +981,7 @@ func (e *Engine) runFTPPentestForTarget(ctx context.Context, target string, conf
 			errors = append(errors, fmt.Sprintf("FTP WRITE_TEST failed for %s: %v", target, err))
 		}
 		if writeTestResult != nil {
-			results = append(results, ftpfern.NewPentestFtpResultFromWriteTestResult(writeTestResult))
+			results = append(results, &ftpfern.PentestFtpResult{WriteTestResult: writeTestResult})
 		}
 	}
 
@@ -992,7 +992,7 @@ func (e *Engine) runFTPPentestForTarget(ctx context.Context, target string, conf
 			errors = append(errors, fmt.Sprintf("FTP DOWNLOAD failed for %s: %v", target, err))
 		}
 		if downloadResult != nil {
-			results = append(results, ftpfern.NewPentestFtpResultFromDownloadResult(downloadResult))
+			results = append(results, &ftpfern.PentestFtpResult{DownloadResult: downloadResult})
 		}
 	}
 
@@ -1003,7 +1003,7 @@ func (e *Engine) runFTPPentestForTarget(ctx context.Context, target string, conf
 			errors = append(errors, fmt.Sprintf("FTP UPLOAD failed for %s: %v", target, err))
 		}
 		if uploadResult != nil {
-			results = append(results, ftpfern.NewPentestFtpResultFromUploadResult(uploadResult))
+			results = append(results, &ftpfern.PentestFtpResult{UploadResult: uploadResult})
 		}
 	}
 

--- a/internal/pentest/ldap/domaindump.go
+++ b/internal/pentest/ldap/domaindump.go
@@ -167,7 +167,7 @@ func (l *LibraryPentestLdap) performLdapActions(ctx context.Context, config ldap
 	errors = append(errors, actionErrors...)
 
 	// Create the union result
-	result := ldapfern.NewPentestLdapResultFromDomainDumpResult(domainResult)
+	result := &ldapfern.PentestLdapResult{DomainDumpResult: domainResult}
 	return result, errors
 }
 
@@ -2126,7 +2126,7 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 			Target: connectionTarget,
 			Errors: []string{err.Error()},
 		}
-		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
+		result := &ldapfern.PentestLdapResult{AuthResult: authResult}
 		return result, []string{err.Error()}
 	}
 
@@ -2140,7 +2140,7 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 			Target: connectionTarget,
 			Errors: []string{err.Error()},
 		}
-		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
+		result := &ldapfern.PentestLdapResult{AuthResult: authResult}
 		return result, []string{err.Error()}
 	}
 
@@ -2176,7 +2176,7 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 			AuthAttempts: []*pentestfern.AuthAttempt{authAttempt},
 			Errors:       []string{err.Error()},
 		}
-		result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
+		result := &ldapfern.PentestLdapResult{AuthResult: authResult}
 		return result, []string{err.Error()}
 	}
 
@@ -2209,6 +2209,6 @@ func (l *LibraryPentestLdap) performAuthAction(ctx context.Context, config ldapf
 		Errors:       nil,
 	}
 
-	result := ldapfern.NewPentestLdapResultFromAuthResult(authResult)
+	result := &ldapfern.PentestLdapResult{AuthResult: authResult}
 	return result, errors
 }

--- a/utils/nuclei/engine.go
+++ b/utils/nuclei/engine.go
@@ -3,7 +3,6 @@ package nuclei
 import (
 	// Standard
 	"context"
-
 	// Generated
 	nuclei "github.com/Method-Security/networkscan/generated/go/common/nuclei"
 	// Utils


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrades Fern/codegen tooling and updates many discovery/enumeration/pentest results to match new generated union struct shapes; runtime behavior should be largely unchanged but broad surface-area changes could cause subtle serialization or nil-field regressions.
> 
> **Overview**
> Upgrades Fern tooling (`fern` config to `4.68.4`, Go SDK generator to `1.34.9`) and adjusts generator config (`importPath` → `importPath`).
> 
> Updates service discovery, enumeration, and pentest code to match the new Fern-generated union types by replacing helper constructors like `NewServiceMetadataFromX` / `New…From…` with direct struct-field wrappers (e.g., `&discoverfern.ServiceMetadata{Dns: …}`, `&enumeratefern.EnumerateServiceDetails{EnumerateSshDetails: …}`, `&smbfern.PentestSmbResult{AuthResult: …}`), plus minor go.mod indirect dependency reordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd976d04ed7bb079d2c9b8f41e534323fe97ffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->