### PR TITLE
version bump

### DIFF
--- a/fern/.fernignore
+++ b/fern/.fernignore
@@ -1,0 +1,9 @@
+# SDK unit tests - not needed since we only use generated types
+client/client_test.go
+internal/caller_test.go
+internal/error_decoder_test.go
+internal/extra_properties_test.go
+internal/query_test.go
+internal/retrier_test.go
+pointer_test.go
+internal/explicit_fields_test.go

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.78.1"
+  "version": "4.79.3"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,7 +3,7 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.38.0
+        version: 1.34.9
         config:
           importpath: github.com/Method-Security/networkscan/generated/go
         output:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrading Fern and the Go SDK generator may change generated client/type code and downstream compilation behavior. Risk is limited to build-time/codegen differences, with no runtime logic changes in this PR.
> 
> **Overview**
> Bumps the Fern CLI version in `fern.config.json` and upgrades the `fernapi/fern-go-sdk` generator in `generators.yml`.
> 
> Adds a new `fern/.fernignore` to exclude generated Go SDK unit test files from the Fern workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b16bf13d677b1f5410e8555994005540f07d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->