### PR TITLE
fix: restore signature field in goreleaser signs to fix cosign bundle path

### DIFF
--- a/.goreleaser/goreleaser-publish.yml
+++ b/.goreleaser/goreleaser-publish.yml
@@ -79,6 +79,7 @@ sboms:
 
 signs:
   - cmd: cosign
+    signature: "${artifact}.sig"
     certificate: '${artifact}.pem'
     args:
       - sign-blob


### PR DESCRIPTION
## Summary
- Restores `signature: "${artifact}.sig"` to the goreleaser `signs` config
- cosign v2.x switched to new bundle format by default, making `--output-signature` deprecated/ignored — without the `signature:` field, `${signature}` resolves to an empty string causing `create bundle file: open : no such file or directory` during release signing

## Test plan
- [ ] Re-run release pipeline to verify signing completes successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small Goreleaser config change affecting only release artifact signing; main impact is the release pipeline behavior if misconfigured.
> 
> **Overview**
> Restores the `signature: "${artifact}.sig"` field in `.goreleaser/goreleaser-publish.yml` under `signs` so cosign signing produces a deterministic signature file path and avoids failures when `--output-signature=${signature}` would otherwise resolve to an empty value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035b50b7a66f890b7a58c4c8c2d549dfb79b5591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->