### PR TITLE
fix: switch cosign to new bundle format (--bundle) for cosign v2.5+ compat

### DIFF
--- a/.goreleaser/goreleaser-publish.yml
+++ b/.goreleaser/goreleaser-publish.yml
@@ -79,12 +79,10 @@ sboms:
 
 signs:
   - cmd: cosign
-    signature: "${artifact}.sig"
-    certificate: '${artifact}.pem'
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: all

--- a/.goreleaser/goreleaser-publish.yml
+++ b/.goreleaser/goreleaser-publish.yml
@@ -79,6 +79,7 @@ sboms:
 
 signs:
   - cmd: cosign
+    signature: "${artifact}.sig"
     certificate: '${artifact}.pem'
     args:
       - sign-blob


### PR DESCRIPTION
## Summary
- Switches `signs` config from deprecated `--output-signature`/`--output-certificate` to `--bundle`
- cosign v2.5+ enables new bundle format by default, ignoring `--output-signature` entirely and crashing with an empty bundle path
- `.sigstore.json` replaces the separate `.sig` + `.pem` files

## Why the previous fix wasn't enough
PR #255 added `signature: "${artifact}.sig"` back, but cosign v2.5+ ignores `--output-signature` regardless of the value — it needs `--bundle=<path>` to know where to write

## Test plan
- [ ] Verify next release signs artifacts without error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release signing configuration; a misconfiguration could cause builds/releases to fail or produce differently named signature artifacts, but it doesn’t affect runtime behavior.
> 
> **Overview**
> Updates GoReleaser’s `cosign sign-blob` configuration to use the new bundle output (`--bundle`) and emit a single `${artifact}.sigstore.json` file instead of the deprecated separate signature/certificate outputs, improving compatibility with cosign v2.5+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca501162e38b55b44e84b0ff7a49c44d11d4e2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->