### PR TITLE
Remove No Longer Needed FQDN Validate Flag from Port Scan

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -157,20 +157,10 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			var validateHostname *string
 			var validateAttemptTimeout *int
 			var validateThreads *int
 			var maxOpenPortsValidationThreshold *int
 			if validate {
-				// Validate hostname
-				validateHostnameString, err := cmd.Flags().GetString("validate-hostname")
-				if err != nil {
-					a.OutputSignal.AddError(err)
-					return
-				}
-				if validateHostnameString != "" {
-					validateHostname = &validateHostnameString
-				}
 				// Validate attempt timeout
 				validateAttemptTimeoutInt, err := cmd.Flags().GetInt("validate-attempt-timeout")
 				if err != nil {
@@ -216,7 +206,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPortConfig(target, ports, topPorts, threads, packetsPerSecond, scanTypeEnum, validate, validateHostname, validateAttemptTimeout, validateThreads, maxOpenPortsValidationThreshold, sleep, jitter)
+			config := getDiscoverPortConfig(target, ports, topPorts, threads, packetsPerSecond, scanTypeEnum, validate, validateAttemptTimeout, validateThreads, maxOpenPortsValidationThreshold, sleep, jitter)
 
 			// Generate the report
 			report, err := discoverport.RunPortScan(cmd.Context(), config)
@@ -234,7 +224,6 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverPortCmd.Flags().String("scan-type", "SYN", "Port scan type: SYN (default, requires root) or CONNECT")
 	discoverPortCmd.Flags().Int("packets-per-second", 1000, "Packets per second to send (default: 1000)")
 	discoverPortCmd.Flags().Bool("validate", false, "Validate open ports by using service detection techniques")
-	discoverPortCmd.Flags().String("validate-hostname", "", "Hostname to validate against (e.g., example.com)")
 	discoverPortCmd.Flags().Int("validate-attempt-timeout", 10, "Timeout in seconds for each service detection attempt")
 	discoverPortCmd.Flags().Int("validate-threads", 0, "Number of concurrent threads to use during service detection")
 	discoverPortCmd.Flags().Int("max-open-ports-validation-threshold", 50, "Trigger validation warning when more than this many ports are open (default: 50)")
@@ -503,7 +492,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 
 // getDiscoverPortConfig creates a configuration for port scanning with the provided parameters.
 // It handles both specific port ranges and top ports scanning modes.
-func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, packetsPerSecond int, scanType discoverfern.PortScanType, validate bool, validateHostname *string, validateAttemptTimeout *int, validateThreads *int, maxOpenPortsValidationThreshold *int, sleep int, jitter int) discoverfern.DiscoverPortConfig {
+func getDiscoverPortConfig(target string, ports string, topPorts string, threads int, packetsPerSecond int, scanType discoverfern.PortScanType, validate bool, validateAttemptTimeout *int, validateThreads *int, maxOpenPortsValidationThreshold *int, sleep int, jitter int) discoverfern.DiscoverPortConfig {
 	// Start with common fields that apply to both stealth and regular scans
 	config := discoverfern.DiscoverPortConfig{
 		Target:           target,
@@ -529,9 +518,6 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 		config.Validate = validate
 
 		// Validation-related fields only apply to regular scans
-		if validateHostname != nil {
-			config.ValidateHostname = validateHostname
-		}
 		if validateAttemptTimeout != nil {
 			config.ValidateAttemptTimeout = validateAttemptTimeout
 		}

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -103,7 +103,7 @@ networkscan discover port --target 192.168.1.0/24 --top-ports 100
 #### Port Validation
 Validate discovered ports with service detection:
 ```bash
-networkscan discover port --target example.com --top-ports 100 --validate --validate-hostname example.com
+networkscan discover port --target example.com --top-ports 100 --validate
 ```
 
 #### Stealth Mode
@@ -132,7 +132,6 @@ Flags:
       --top-ports string                Scan the top N most common TCP ports (options: full, 100, 1000)
       --validate                                    Validate open ports by using service detection techniques
       --validate-attempt-timeout int               Timeout in seconds for each service detection attempt (default 10)
-      --validate-hostname string                   Hostname to validate against (e.g., example.com)
       --validate-threads int                       Number of concurrent threads to use during service detection
       --max-open-ports-validation-threshold int    Trigger validation warning when more than this many ports are open (default 50)
 

--- a/fern/definition/discover/port.yml
+++ b/fern/definition/discover/port.yml
@@ -34,7 +34,6 @@ types:
       packetsPerSecond: integer
       scanType: PortScanType
       validate: boolean
-      validateHostname: optional<string>
       validateAttemptTimeout: optional<integer>
       validateThreads: optional<integer>
       maxOpenPortsValidationThreshold: optional<integer>

--- a/internal/discover/port/validate.go
+++ b/internal/discover/port/validate.go
@@ -3,7 +3,6 @@ package discover
 import (
 	// Standard
 	"context"
-	"fmt"
 	"runtime"
 	"strings"
 	"sync"
@@ -45,24 +44,6 @@ func validatePortScan(ctx context.Context, config discoverfern.DiscoverPortConfi
 		maxThreads = *config.ValidateThreads
 	}
 
-	// Resolve validation hostname once before processing all ports
-	// This avoids repeated DNS lookups for every single port
-	var resolvedValidationIP string
-	if config.ValidateHostname != nil {
-		log.Info("Resolving validation hostname once", svc1log.SafeParam("hostname", *config.ValidateHostname))
-		// Import needed: "github.com/Method-Security/networkscan/utils"
-		ips, err := utils.GetIPs(*config.ValidateHostname)
-		if err != nil {
-			errorsMutex.Lock()
-			errors = append(errors, fmt.Sprintf("failed to resolve validation hostname %s: %v", *config.ValidateHostname, err))
-			errorsMutex.Unlock()
-			// Continue with IP-based validation only
-		} else if len(ips) > 0 {
-			resolvedValidationIP = ips[0].String()
-			log.Info("Resolved validation hostname", svc1log.SafeParam("hostname", *config.ValidateHostname), svc1log.SafeParam("ip", resolvedValidationIP))
-		}
-	}
-
 	for _, socket := range sockets {
 		if socket == nil || socket.Ports == nil {
 			continue
@@ -89,13 +70,7 @@ func validatePortScan(ctx context.Context, config discoverfern.DiscoverPortConfi
 					log.Info("Validating port", svc1log.SafeParam("port", port.Port))
 
 					// Use RunServiceFingerprint to check if there's a service on this port
-					// Use pre-resolved IP to avoid repeated DNS lookups
-					var targetStr string
-					if resolvedValidationIP != "" {
-						targetStr = utils.FormatHostPort(resolvedValidationIP, port.Port)
-					} else {
-						targetStr = utils.FormatHostPort(socket.Ip, port.Port)
-					}
+					targetStr := utils.FormatHostPort(socket.Ip, port.Port)
 					serviceConfig := discoverfern.DiscoverServiceConfig{
 						Target:  targetStr,
 						Timeout: *config.ValidateAttemptTimeout,


### PR DESCRIPTION
## Summary
* CDN detection makes this flag no longer needed


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public CLI/API contract by removing `validate-hostname`, which may break existing automation and slightly alters how port validation targets are resolved.
> 
> **Overview**
> Removes the `--validate-hostname` flag and the corresponding `validateHostname` field from `DiscoverPortConfig`, simplifying port validation to always fingerprint services against the discovered socket IP.
> 
> Updates the validation implementation to drop the one-time DNS resolution and the docs/Fern definition to reflect the reduced validation options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a062b381fc1b59efe7884bdecedd0dfade861d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->