### PR TITLE
fix: use singular username/password in FTP fern

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -1832,21 +1832,20 @@ func getFTPPentestConfig(
 	downloadPaths []string, maxDownloadSize int64,
 	uploadContents []string, maxUploadSize int64,
 ) *ftpfern.PentestFtpConfig {
-	var usernames []string
-	var passwords []string
+	var usernamePtr, passwordPtr *string
 	if username != "" {
-		usernames = []string{username}
+		usernamePtr = &username
 	}
 	if password != "" {
-		passwords = []string{password}
+		passwordPtr = &password
 	}
 
 	config := &ftpfern.PentestFtpConfig{
-		Targets:   targets,
-		Actions:   actions,
-		Usernames: usernames,
-		Passwords: passwords,
-		Timeout:   timeout,
+		Targets:  targets,
+		Actions:  actions,
+		Username: usernamePtr,
+		Password: passwordPtr,
+		Timeout:  timeout,
 	}
 
 	if len(listPaths) > 0 || recursive {

--- a/fern/definition/pentest/ftp/ftp.yml
+++ b/fern/definition/pentest/ftp/ftp.yml
@@ -28,10 +28,13 @@ types:
       results: optional<list<PentestFtpResult>>
 
   # Config for FTP pentest operations - extends general config
+  # Note: FTP uses singular username/password (not the inherited plural usernames/passwords from PentestAuthConfig)
   PentestFtpConfig:
     extends: common.PentestGeneralConfig
     properties:
       actions: list<PentestFtpAction>
+      username: optional<string>
+      password: optional<string>
       listConfig: optional<list.ListConfig>
       writeTestConfig: optional<writetest.WriteTestConfig>
       downloadConfig: optional<download.DownloadConfig>

--- a/internal/pentest/ftp/run.go
+++ b/internal/pentest/ftp/run.go
@@ -57,9 +57,9 @@ func runForTarget(ctx context.Context, target string, config *ftpfern.PentestFtp
 		hasAction(ftpfern.PentestFtpActionUpload)
 
 	if needsAuth {
-		if len(config.Usernames) > 0 && len(config.Passwords) > 0 {
-			username = config.Usernames[0]
-			password = config.Passwords[0]
+		if config.Username != nil && config.Password != nil {
+			username = *config.Username
+			password = *config.Password
 		} else {
 			errors = append(errors, "no credentials available for post-auth actions")
 			return results, errors

--- a/internal/pentest/ftp/run_test.go
+++ b/internal/pentest/ftp/run_test.go
@@ -1,0 +1,432 @@
+package ftp
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ftpfern "github.com/Method-Security/networkscan/generated/go/pentest/ftp"
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	filedriver "goftp.io/server/v2/driver/file"
+	ftpserver "goftp.io/server/v2"
+)
+
+// testServer holds a running FTP server for tests.
+type testServer struct {
+	server  *ftpserver.Server
+	addr    string
+	rootDir string
+}
+
+func newTestServer(t *testing.T) *testServer {
+	t.Helper()
+
+	rootDir := t.TempDir()
+
+	driver, err := filedriver.NewDriver(rootDir)
+	if err != nil {
+		t.Fatalf("failed to create file driver: %v", err)
+	}
+
+	// Find a free port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	_ = listener.Close()
+
+	srv, err := ftpserver.NewServer(&ftpserver.Options{
+		Driver: driver,
+		Auth: &ftpserver.SimpleAuth{
+			Name:     "testuser",
+			Password: "testpass",
+		},
+		Perm:     ftpserver.NewSimplePerm("testuser", "testgroup"),
+		Port:     port,
+		Hostname: "127.0.0.1",
+		Logger:   &ftpserver.DiscardLogger{},
+	})
+	if err != nil {
+		t.Fatalf("failed to create FTP server: %v", err)
+	}
+
+	go func() { _ = srv.ListenAndServe() }()
+
+	// Wait for server to be ready
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	return &testServer{
+		server:  srv,
+		addr:    addr,
+		rootDir: rootDir,
+	}
+}
+
+func (ts *testServer) shutdown() {
+	_ = ts.server.Shutdown()
+}
+
+func testCtx() context.Context {
+	logger := svc1log.New(os.Stderr, wlog.InfoLevel)
+	return svc1log.WithLogger(context.Background(), logger)
+}
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+func boolPtr(b bool) *bool    { return &b }
+func int64Ptr(i int64) *int64 { return &i }
+
+// --- Unit tests (no server needed) ---
+
+func TestRunForTarget_NoCredentials(t *testing.T) {
+	config := &ftpfern.PentestFtpConfig{
+		Targets: []string{"127.0.0.1:21"},
+		Actions: []ftpfern.PentestFtpAction{ftpfern.PentestFtpActionList},
+		Timeout: 5000,
+	}
+
+	results, errors := runForTarget(testCtx(), "127.0.0.1:21", config)
+	if len(results) != 0 {
+		t.Errorf("expected no results, got %d", len(results))
+	}
+	if len(errors) != 1 || errors[0] != "no credentials available for post-auth actions" {
+		t.Errorf("expected credential error, got: %v", errors)
+	}
+}
+
+func TestRunForTarget_NoActions(t *testing.T) {
+	config := &ftpfern.PentestFtpConfig{
+		Targets:  []string{"127.0.0.1:21"},
+		Actions:  []ftpfern.PentestFtpAction{},
+		Username: strPtr("user"),
+		Password: strPtr("pass"),
+		Timeout:  5000,
+	}
+
+	results, errors := runForTarget(testCtx(), "127.0.0.1:21", config)
+	if len(results) != 0 {
+		t.Errorf("expected no results, got %d", len(results))
+	}
+	if len(errors) != 0 {
+		t.Errorf("expected no errors, got: %v", errors)
+	}
+}
+
+func TestRunPentest_MultipleTargets(t *testing.T) {
+	config := &ftpfern.PentestFtpConfig{
+		Targets: []string{"127.0.0.1:9999", "127.0.0.1:9998"},
+		Actions: []ftpfern.PentestFtpAction{ftpfern.PentestFtpActionList},
+		Timeout: 5000,
+	}
+
+	report, err := RunPentest(testCtx(), config)
+	if err != nil {
+		t.Fatalf("RunPentest returned error: %v", err)
+	}
+	// Should get errors for both targets (no credentials)
+	if len(report.Errors) != 2 {
+		t.Errorf("expected 2 errors, got %d: %v", len(report.Errors), report.Errors)
+	}
+}
+
+// --- Integration tests (mock FTP server) ---
+
+func TestList_BasicDirectory(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.shutdown()
+
+	// Create test files on disk
+	if err := os.WriteFile(filepath.Join(ts.rootDir, "hello.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(ts.rootDir, "subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &ftpfern.PentestFtpConfig{
+		Targets:  []string{ts.addr},
+		Actions:  []ftpfern.PentestFtpAction{ftpfern.PentestFtpActionList},
+		Username: strPtr("testuser"),
+		Password: strPtr("testpass"),
+		Timeout:  5000,
+	}
+
+	result, err := PerformListWithContext(testCtx(), ts.addr, "testuser", "testpass", config)
+	if err != nil {
+		t.Fatalf("PerformListWithContext failed: %v", err)
+	}
+
+	if len(result.Entries) < 2 {
+		t.Fatalf("expected at least 2 entries, got %d", len(result.Entries))
+	}
+
+	names := map[string]bool{}
+	for _, e := range result.Entries {
+		names[e.Name] = true
+	}
+	if !names["hello.txt"] {
+		t.Error("expected hello.txt in listing")
+	}
+	if !names["subdir"] {
+		t.Error("expected subdir in listing")
+	}
+}
+
+func TestList_Recursive(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.shutdown()
+
+	// Create nested structure
+	nested := filepath.Join(ts.rootDir, "a", "b")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "deep.txt"), []byte("deep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &ftpfern.PentestFtpConfig{
+		Targets:  []string{ts.addr},
+		Actions:  []ftpfern.PentestFtpAction{ftpfern.PentestFtpActionList},
+		Username: strPtr("testuser"),
+		Password: strPtr("testpass"),
+		Timeout:  5000,
+		ListConfig: &ftpfern.ListConfig{
+			Paths:     []string{"/"},
+			Recursive: boolPtr(true),
+			MaxDepth:  intPtr(10),
+		},
+	}
+
+	result, err := PerformListWithContext(testCtx(), ts.addr, "testuser", "testpass", config)
+	if err != nil {
+		t.Fatalf("PerformListWithContext failed: %v", err)
+	}
+
+	foundDeep := false
+	for _, e := range result.Entries {
+		if e.Name == "deep.txt" {
+			foundDeep = true
+		}
+	}
+	if !foundDeep {
+		t.Error("expected deep.txt in recursive listing")
+	}
+}
+
+func TestWriteTest_Permissions(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.shutdown()
+
+	config := &ftpfern.PentestFtpConfig{
+		Targets:  []string{ts.addr},
+		Actions:  []ftpfern.PentestFtpAction{ftpfern.PentestFtpActionWriteTest},
+		Username: strPtr("testuser"),
+		Password: strPtr("testpass"),
+		Timeout:  5000,
+	}
+
+	result, err := PerformWriteTestWithContext(testCtx(), ts.addr, "testuser", "testpass", config)
+	if err != nil {
+		t.Fatalf("PerformWriteTestWithContext failed: %v", err)
+	}
+
+	if len(result.WriteTests) == 0 {
+		t.Fatal("expected at least one write test entry")
+	}
+
+	entry := result.WriteTests[0]
+	if entry.CanMkdir == nil || !*entry.CanMkdir {
+		t.Error("expected CanMkdir to be true")
+	}
+	if entry.CanUpload == nil || !*entry.CanUpload {
+		t.Error("expected CanUpload to be true")
+	}
+	if entry.CanRename == nil || !*entry.CanRename {
+		t.Error("expected CanRename to be true")
+	}
+}
+
+func TestDownload_Success(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.shutdown()
+
+	content := []byte("download me")
+	if err := os.WriteFile(filepath.Join(ts.rootDir, "file.txt"), content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &ftpfern.PentestFtpConfig{
+		Targets:  []string{ts.addr},
+		Actions:  []ftpfern.PentestFtpAction{ftpfern.PentestFtpActionDownload},
+		Username: strPtr("testuser"),
+		Password: strPtr("testpass"),
+		Timeout:  5000,
+		DownloadConfig: &ftpfern.DownloadConfig{
+			RemotePaths: []string{"/file.txt"},
+		},
+	}
+
+	result, err := PerformDownloadWithContext(testCtx(), ts.addr, "testuser", "testpass", config)
+	if err != nil {
+		t.Fatalf("PerformDownloadWithContext failed: %v", err)
+	}
+
+	if len(result.Downloads) != 1 {
+		t.Fatalf("expected 1 download, got %d", len(result.Downloads))
+	}
+
+	dl := result.Downloads[0]
+	if !dl.Success {
+		t.Fatalf("download not successful: %v", dl.Message)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(*dl.Content)
+	if err != nil {
+		t.Fatalf("failed to decode content: %v", err)
+	}
+	if string(decoded) != "download me" {
+		t.Errorf("expected 'download me', got %q", string(decoded))
+	}
+}
+
+func TestDownload_MaxSizeExceeded(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.shutdown()
+
+	bigContent := make([]byte, 1024)
+	if err := os.WriteFile(filepath.Join(ts.rootDir, "big.txt"), bigContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &ftpfern.PentestFtpConfig{
+		Targets:  []string{ts.addr},
+		Actions:  []ftpfern.PentestFtpAction{ftpfern.PentestFtpActionDownload},
+		Username: strPtr("testuser"),
+		Password: strPtr("testpass"),
+		Timeout:  5000,
+		DownloadConfig: &ftpfern.DownloadConfig{
+			RemotePaths: []string{"/big.txt"},
+			MaxFileSize: int64Ptr(100),
+		},
+	}
+
+	result, err := PerformDownloadWithContext(testCtx(), ts.addr, "testuser", "testpass", config)
+	if err != nil {
+		t.Fatalf("PerformDownloadWithContext failed: %v", err)
+	}
+
+	if len(result.Downloads) != 1 {
+		t.Fatalf("expected 1 download entry, got %d", len(result.Downloads))
+	}
+	if result.Downloads[0].Success {
+		t.Error("expected download to fail due to size limit")
+	}
+}
+
+func TestUpload_Success(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.shutdown()
+
+	content := base64.StdEncoding.EncodeToString([]byte("upload content"))
+	uploadStr := fmt.Sprintf("/uploaded.txt:%s", content)
+
+	config := &ftpfern.PentestFtpConfig{
+		Targets:  []string{ts.addr},
+		Actions:  []ftpfern.PentestFtpAction{ftpfern.PentestFtpActionUpload},
+		Username: strPtr("testuser"),
+		Password: strPtr("testpass"),
+		Timeout:  5000,
+		UploadConfig: &ftpfern.UploadConfig{
+			Contents: []string{uploadStr},
+		},
+	}
+
+	result, err := PerformUploadWithContext(testCtx(), ts.addr, "testuser", "testpass", config)
+	if err != nil {
+		t.Fatalf("PerformUploadWithContext failed: %v", err)
+	}
+
+	if len(result.Uploads) != 1 {
+		t.Fatalf("expected 1 upload, got %d", len(result.Uploads))
+	}
+	if !result.Uploads[0].Success {
+		t.Errorf("upload not successful: %v", result.Uploads[0].Message)
+	}
+
+	// Verify file exists on disk
+	data, err := os.ReadFile(filepath.Join(ts.rootDir, "uploaded.txt"))
+	if err != nil {
+		t.Fatalf("uploaded file not found: %v", err)
+	}
+	if string(data) != "upload content" {
+		t.Errorf("expected 'upload content', got %q", string(data))
+	}
+}
+
+func TestRunPentest_FullIntegration(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.shutdown()
+
+	// Seed a file for listing
+	if err := os.WriteFile(filepath.Join(ts.rootDir, "test.txt"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &ftpfern.PentestFtpConfig{
+		Targets: []string{ts.addr},
+		Actions: []ftpfern.PentestFtpAction{
+			ftpfern.PentestFtpActionList,
+			ftpfern.PentestFtpActionWriteTest,
+		},
+		Username: strPtr("testuser"),
+		Password: strPtr("testpass"),
+		Timeout:  5000,
+	}
+
+	report, err := RunPentest(testCtx(), config)
+	if err != nil {
+		t.Fatalf("RunPentest failed: %v", err)
+	}
+
+	if len(report.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", report.Errors)
+	}
+
+	if report.Result == nil || len(report.Result.Results) < 2 {
+		t.Fatalf("expected at least 2 results (list + writetest), got %v", report.Result)
+	}
+}
+
+func TestConnectAndLogin_BadCredentials(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.shutdown()
+
+	_, err := ConnectAndLogin(testCtx(), ts.addr, "wrong", "wrong", 5000)
+	if err == nil {
+		t.Error("expected auth failure for bad credentials")
+	}
+}
+
+func TestConnectAndLogin_BadAddress(t *testing.T) {
+	_, err := ConnectAndLogin(testCtx(), "127.0.0.1:1", "user", "pass", 1000)
+	if err == nil {
+		t.Error("expected connection failure for bad address")
+	}
+}


### PR DESCRIPTION
The fern definition for FTP pentest inherited plural usernames/passwords from PentestAuthConfig, but the CLI accepts singular username/password. Added singular fields to PentestFtpConfig and updated Go code to match. Added integration tests with a mock FTP server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Fern schema and Go code for FTP pentest authentication fields, which can affect generated client/server compatibility and any consumers expecting `usernames/passwords`. Added integration tests reduce regression risk but schema changes still require coordinated rollout.
> 
> **Overview**
> Aligns FTP pentest configuration with the CLI by **replacing plural credential fields with singular optional `username`/`password`** in `PentestFtpConfig`, and updates the CLI config builder plus FTP runner auth selection to use these new fields.
> 
> Adds a comprehensive `internal/pentest/ftp/run_test.go` suite, including a lightweight in-process FTP server, to cover credential handling and LIST/WRITE_TEST/DOWNLOAD/UPLOAD flows (success and failure cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56c6f381b1ddc67658176a281fa7b97c9bedf941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->