### PR TITLE
Align FTP pentest CLI flags with Fern config

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -899,18 +899,23 @@ file download (DOWNLOAD), and file upload (UPLOAD).`,
 				return
 			}
 
-			username, err := cmd.Flags().GetString("username")
+			usernames, err := cmd.Flags().GetStringSlice("usernames")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			password, err := cmd.Flags().GetString("password")
+			passwords, err := cmd.Flags().GetStringSlice("passwords")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			domain, err := cmd.Flags().GetString("domain")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
-			listPaths, err := cmd.Flags().GetStringSlice("list-paths")
+			paths, err := cmd.Flags().GetStringSlice("paths")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -926,29 +931,19 @@ file download (DOWNLOAD), and file upload (UPLOAD).`,
 				return
 			}
 
-			writeTestPaths, err := cmd.Flags().GetStringSlice("write-test-paths")
+			remotePaths, err := cmd.Flags().GetStringSlice("remote-paths")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
-			downloadPaths, err := cmd.Flags().GetStringSlice("download")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			maxDownloadSize, err := cmd.Flags().GetInt64("max-download-size")
+			contents, err := cmd.Flags().GetStringSlice("contents")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
-			uploadContents, err := cmd.Flags().GetStringSlice("upload-content")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			maxUploadSize, err := cmd.Flags().GetInt64("max-upload-size")
+			maxFileSize, err := cmd.Flags().GetInt64("max-file-size")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -961,11 +956,11 @@ file download (DOWNLOAD), and file upload (UPLOAD).`,
 			}
 
 			// Set Config
-			config := getFTPPentestConfig(targets, actions, username, password, timeout,
-				listPaths, recursive, maxDepth,
-				writeTestPaths,
-				downloadPaths, maxDownloadSize,
-				uploadContents, maxUploadSize)
+			config := getFTPPentestConfig(targets, actions, usernames, passwords, domain, timeout,
+				paths, recursive, maxDepth,
+				remotePaths,
+				contents,
+				maxFileSize)
 
 			// Generate the report
 			report, err := ftppentest.RunPentest(cmd.Context(), config)
@@ -978,16 +973,15 @@ file download (DOWNLOAD), and file upload (UPLOAD).`,
 	}
 	pentestFTPCmd.Flags().StringSlice("targets", []string{}, "Target hosts")
 	pentestFTPCmd.Flags().StringSlice("actions", []string{}, fmt.Sprintf("Actions to perform: %s", strings.Join(utils.GetFTPParser().GetValidActions(), ",")))
-	pentestFTPCmd.Flags().StringP("username", "u", "", "Username for authentication")
-	pentestFTPCmd.Flags().StringP("password", "p", "", "Password for authentication")
-	pentestFTPCmd.Flags().StringSlice("list-paths", []string{}, "Directories to list (defaults to landing directory)")
-	pentestFTPCmd.Flags().Bool("recursive", false, "Recursively list subdirectories")
-	pentestFTPCmd.Flags().Int("max-depth", 5, "Max recursion depth for listing")
-	pentestFTPCmd.Flags().StringSlice("write-test-paths", []string{}, "Directories to test write permissions (defaults to landing directory)")
-	pentestFTPCmd.Flags().StringSlice("download", []string{}, "Remote file paths to download")
-	pentestFTPCmd.Flags().Int64("max-download-size", 1048576, "Max file size in bytes to download (default 1MB)")
-	pentestFTPCmd.Flags().StringSlice("upload-content", []string{}, "Files to upload as remote_path:base64content")
-	pentestFTPCmd.Flags().Int64("max-upload-size", 1048576, "Max file size in bytes to upload (default 1MB)")
+	pentestFTPCmd.Flags().StringSlice("usernames", []string{}, "Usernames for authentication")
+	pentestFTPCmd.Flags().StringSlice("passwords", []string{}, "Passwords for authentication")
+	pentestFTPCmd.Flags().String("domain", "", "Domain for authentication")
+	pentestFTPCmd.Flags().StringSlice("paths", []string{}, "Directories for LIST or WRITE_TEST actions (defaults to landing directory)")
+	pentestFTPCmd.Flags().Bool("recursive", false, "Recursively list subdirectories (LIST action)")
+	pentestFTPCmd.Flags().Int("max-depth", 5, "Max recursion depth for listing (LIST action)")
+	pentestFTPCmd.Flags().StringSlice("remote-paths", []string{}, "Remote file paths to download (DOWNLOAD action)")
+	pentestFTPCmd.Flags().StringSlice("contents", []string{}, "Files to upload as remote_path:base64content (UPLOAD action)")
+	pentestFTPCmd.Flags().Int64("max-file-size", 1048576, "Max file size in bytes for DOWNLOAD/UPLOAD (default 1MB)")
 	pentestFTPCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	_ = pentestFTPCmd.MarkFlagRequired("targets")
 
@@ -1825,22 +1819,14 @@ func getScanCVEConfig(targets []string, protocol string, years []string, timeout
 // getFTPPentestConfig creates a configuration for FTP pentest operations with the provided parameters.
 func getFTPPentestConfig(
 	targets []string, actions []ftpfern.PentestFtpAction,
-	username, password string,
+	usernames, passwords []string,
+	domain string,
 	timeout int,
-	listPaths []string, recursive bool, maxDepth int,
-	writeTestPaths []string,
-	downloadPaths []string, maxDownloadSize int64,
-	uploadContents []string, maxUploadSize int64,
+	paths []string, recursive bool, maxDepth int,
+	remotePaths []string,
+	contents []string,
+	maxFileSize int64,
 ) *ftpfern.PentestFtpConfig {
-	var usernames []string
-	var passwords []string
-	if username != "" {
-		usernames = []string{username}
-	}
-	if password != "" {
-		passwords = []string{password}
-	}
-
 	config := &ftpfern.PentestFtpConfig{
 		Targets:   targets,
 		Actions:   actions,
@@ -1848,32 +1834,49 @@ func getFTPPentestConfig(
 		Passwords: passwords,
 		Timeout:   timeout,
 	}
+	if domain != "" {
+		config.Domain = &domain
+	}
 
-	if len(listPaths) > 0 || recursive {
+	hasList := false
+	hasWriteTest := false
+	hasDownload := false
+	hasUpload := false
+	for _, action := range actions {
+		switch action {
+		case ftpfern.PentestFtpActionList:
+			hasList = true
+		case ftpfern.PentestFtpActionWriteTest:
+			hasWriteTest = true
+		case ftpfern.PentestFtpActionDownload:
+			hasDownload = true
+		case ftpfern.PentestFtpActionUpload:
+			hasUpload = true
+		}
+	}
+
+	if hasList {
 		config.ListConfig = &ftpfern.ListConfig{
-			Paths:     listPaths,
+			Paths:     paths,
 			Recursive: &recursive,
 			MaxDepth:  &maxDepth,
 		}
 	}
-
-	if len(writeTestPaths) > 0 {
+	if hasWriteTest {
 		config.WriteTestConfig = &ftpfern.WriteTestConfig{
-			Paths: writeTestPaths,
+			Paths: paths,
 		}
 	}
-
-	if len(downloadPaths) > 0 {
+	if hasDownload {
 		config.DownloadConfig = &ftpfern.DownloadConfig{
-			RemotePaths: downloadPaths,
-			MaxFileSize: &maxDownloadSize,
+			RemotePaths: remotePaths,
+			MaxFileSize: &maxFileSize,
 		}
 	}
-
-	if len(uploadContents) > 0 {
+	if hasUpload {
 		config.UploadConfig = &ftpfern.UploadConfig{
-			Contents:    uploadContents,
-			MaxFileSize: &maxUploadSize,
+			Contents:    contents,
+			MaxFileSize: &maxFileSize,
 		}
 	}
 


### PR DESCRIPTION
## Summary
The FTP pentest CLI flags didn't match the field names in `PentestFtpConfig`. Ontology compilers serialize that Fern struct via `generate_flags_from_config`, so the CLI was effectively unreachable from the platform — it errored out on `--usernames`, and would also have errored on `--paths`, `--remote-paths`, `--contents`, `--max-file-size` once those tools (file_lister, file_downloader) land.

Renamed the cobra flags to match the Fern field names rather than patching the Fern types:
- `--username`/`--password` (singular String) → `--usernames`/`--passwords` (StringSlice) — matches the inherited `PentestAuthConfig` plurals and the convention every other pentest tool already follows (WinRM, SMB, etc.)
- `--list-paths` and `--write-test-paths` → shared `--paths` (matches `ListConfig.paths` / `WriteTestConfig.paths`; interpreted per action)
- `--download` → `--remote-paths` (matches `DownloadConfig.remotePaths`)
- `--upload-content` → `--contents` (matches `UploadConfig.contents`)
- `--max-download-size` and `--max-upload-size` → shared `--max-file-size` (matches `DownloadConfig.maxFileSize` / `UploadConfig.maxFileSize`)
- added `--domain` (matches `PentestAuthConfig.domain`)

Sub-config selection is now driven by the `--actions` list (`hasList`/`hasWriteTest`/`hasDownload`/`hasUpload`) rather than "any of these flags is set". This avoids inadvertently populating an unrequested `ListConfig` when only `--recursive` is passed for some other reason.

## Relation to #260
PR #260 takes the opposite approach — keeps the CLI singular and adds singular `username`/`password` fields to `PentestFtpConfig`. This PR supersedes #260's goal by aligning at the CLI layer instead, which:
- Doesn't fork the Fern auth shape away from `PentestAuthConfig` (every other pentest tool stays consistent)
- Fixes the same `--usernames` error the ontology write-test compiler hits
- Additionally fixes the analogous mismatches for `paths`/`remote-paths`/`contents`/`max-file-size` that the upcoming file_lister and file_downloader ontology tools would have hit
- @pgibert's mock-FTP integration tests in #260 are still valuable — happy to either pull them in here or land them as a follow-up against the renamed flags

## Test plan
- [x] `./godelw verify` passes
- [x] `./godelw build` produces a working binary
- [x] `networkscan pentest service ftp --help` shows the new flag set
- [ ] Confirm ontology `pentestftp_write_test_workflow_app_creds_test` passes with the new CLI version (test already expects `--usernames`/`--passwords`)
- [ ] Smoke-test end-to-end against a real FTP target via ontology compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames and reshapes FTP pentest CLI flags (including auth and file actions), which is backward-incompatible for existing scripts and could change which sub-configs get populated based on the `--actions` list.
> 
> **Overview**
> Aligns the `pentest service ftp` CLI surface with `ftpfern.PentestFtpConfig` by renaming/restructuring flags (e.g., `--usernames/--passwords`, `--paths`, `--remote-paths`, `--contents`, and unified `--max-file-size`) and adding optional `--domain`.
> 
> Updates `getFTPPentestConfig` to populate `ListConfig`/`WriteTestConfig`/`DownloadConfig`/`UploadConfig` *only* when the corresponding action is present in `--actions`, rather than inferring config from whether related flags were set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e676dca8e782d143d40fc082785687facdd963ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->