### PR TITLE
Kick NetworkScan

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -99,7 +99,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverHostCmd.Flags().String("target", "", "Target IP address, hostname, or CIDR range to scan for live hosts")
 	discoverHostCmd.Flags().String("scan-type", "ICMP_ECHO", "Discovery scan type: TCP_SYN, ICMP_ECHO, ICMP_TIMESTAMP, ARP, or ICMP_ADDRESS_MASK (not needed for stealth mode)")
 	discoverHostCmd.Flags().Int("sleep", 0, "Sleep delay in seconds between hosts for stealth scan (stealth mode enabled when sleep > 0)")
-	discoverHostCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delay for stealth scan")
+	discoverHostCmd.Flags().Int("jitter", 0, "Jitter percentage (0 to 100) to randomize sleep delay for stealth scan")
 	discoverHostCmd.Flags().Bool("reverse-lookup", false, "Perform reverse DNS lookup sweep first to identify potential targets")
 
 	// Mark Required Flags


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Help-string only change with no effect on scanning logic or validation.
> 
> **Overview**
> Updates the **`discover host --jitter`** flag help text so the allowed range reads **"0 to 100"** instead of **"0-100"**, matching how the same range is described elsewhere (e.g. validation errors). **No runtime or scanning behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2888bc2371c53b90200650fa6ab87b9a4a6eee04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->