### PR TITLE
Move IMAP config off shared EnumerateServiceConfig (AITF-66)

### DIFF
--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -6,8 +6,6 @@ import (
 
 	// Generated
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
-	imapfern "github.com/Method-Security/networkscan/generated/go/enumerate/imap"
-
 	// Internal
 	enumerate "github.com/Method-Security/networkscan/internal/enumerate"
 	// External
@@ -59,19 +57,11 @@ func (a *NetworkScan) InitEnumerateCommand() {
 				return
 			}
 
-			// IMAP-specific flags
-			imapConfig, err := readImapEnumerateConfig(cmd)
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
 			config := newEnumerateServiceConfig(EnumerateServiceCobraFlags{
 				Targets:  targets,
 				Service:  serviceEnum,
 				Timeout:  timeout,
 				Wordlist: wordlist,
-				Imap:     imapConfig,
 			})
 
 			// Generate the report
@@ -88,15 +78,6 @@ func (a *NetworkScan) InitEnumerateCommand() {
 	enumerateServiceCmd.Flags().Int("timeout", 30, "Timeout in seconds for enumerating each target")
 	enumerateServiceCmd.Flags().StringSlice("wordlist", []string{}, "Custom username wordlist for user enumeration (SMTP VRFY/EXPN/RCPT TO)")
 
-	// IMAP-specific flags
-	enumerateServiceCmd.Flags().String("imap-username", "", "IMAP username for authenticated enumeration (Mode B)")
-	enumerateServiceCmd.Flags().String("imap-password", "", "IMAP password for authenticated enumeration (Mode B)")
-	enumerateServiceCmd.Flags().String("imap-mechanism", "", "SASL mechanism override (PLAIN, LOGIN, CRAM-MD5, GSSAPI, XOAUTH2)")
-	enumerateServiceCmd.Flags().Int("imap-max-messages", 0, "Maximum number of message headers to fetch via UID FETCH (0 = none)")
-	enumerateServiceCmd.Flags().String("imap-search", "", "IMAP SEARCH expression applied after authentication (e.g. 'UNSEEN', 'FROM admin')")
-	enumerateServiceCmd.Flags().String("imap-target-folder", "INBOX", "Folder to EXAMINE for detailed status (default: INBOX)")
-	enumerateServiceCmd.Flags().Bool("imap-allow-plaintext-credentials", false, "Allow PLAIN/LOGIN auth over unencrypted transport (not recommended)")
-
 	// Mark Required Flags
 	_ = enumerateServiceCmd.MarkFlagRequired("targets")
 	_ = enumerateServiceCmd.MarkFlagRequired("service")
@@ -109,89 +90,17 @@ func (a *NetworkScan) InitEnumerateCommand() {
 }
 
 // EnumerateServiceCobraFlags bundles the flag values consumed by
-// newEnumerateServiceConfig, keeping per-service config nested rather than
-// inflating the top-level argument list.
+// newEnumerateServiceConfig. Per-service auth/Mode-B knobs (e.g. for IMAP)
+// belong on their own pentest tools (e.g. `pentest service imap`); the
+// enumerate stage is pre-auth fingerprinting only.
 type EnumerateServiceCobraFlags struct {
 	Targets  []string
 	Service  enumeratefern.SupportedServiceType
 	Timeout  int
 	Wordlist []string
-	Imap     *imapfern.ImapEnumerateConfig
 }
 
-// readImapEnumerateConfig pulls the IMAP-specific cobra flags off cmd and
-// wraps them into an ImapEnumerateConfig, returning nil when no IMAP flag
-// was set (i.e. the user is not enumerating IMAP).
-func readImapEnumerateConfig(cmd *cobra.Command) (*imapfern.ImapEnumerateConfig, error) {
-	imapUsername, err := cmd.Flags().GetString("imap-username")
-	if err != nil {
-		return nil, err
-	}
-	imapPassword, err := cmd.Flags().GetString("imap-password")
-	if err != nil {
-		return nil, err
-	}
-	imapMechanism, err := cmd.Flags().GetString("imap-mechanism")
-	if err != nil {
-		return nil, err
-	}
-	imapMaxMessages, err := cmd.Flags().GetInt("imap-max-messages")
-	if err != nil {
-		return nil, err
-	}
-	imapSearch, err := cmd.Flags().GetString("imap-search")
-	if err != nil {
-		return nil, err
-	}
-	imapTargetFolder, err := cmd.Flags().GetString("imap-target-folder")
-	if err != nil {
-		return nil, err
-	}
-	imapAllowPlaintext, err := cmd.Flags().GetBool("imap-allow-plaintext-credentials")
-	if err != nil {
-		return nil, err
-	}
-
-	imapConfig := &imapfern.ImapEnumerateConfig{}
-	set := false
-	if imapUsername != "" {
-		imapConfig.Username = &imapUsername
-		set = true
-	}
-	if imapPassword != "" {
-		imapConfig.Password = &imapPassword
-		set = true
-	}
-	if imapMechanism != "" {
-		imapConfig.Mechanism = &imapMechanism
-		set = true
-	}
-	if imapMaxMessages > 0 {
-		imapConfig.MaxMessages = &imapMaxMessages
-		set = true
-	}
-	if imapSearch != "" {
-		imapConfig.Search = &imapSearch
-		set = true
-	}
-	// Always pass target folder (default is "INBOX" from flag default)
-	if imapTargetFolder != "" {
-		imapConfig.TargetFolder = &imapTargetFolder
-		set = true
-	}
-	if imapAllowPlaintext {
-		imapConfig.AllowPlaintextCredentials = &imapAllowPlaintext
-		set = true
-	}
-	if !set {
-		return nil, nil
-	}
-	return imapConfig, nil
-}
-
-// newEnumerateServiceConfig creates a new EnumerateServiceConfig from the
-// flag struct, nesting per-service config (e.g. ImapConfig) instead of
-// inflating EnumerateServiceConfig with service-specific fields.
+// newEnumerateServiceConfig creates a new EnumerateServiceConfig from the flag struct.
 func newEnumerateServiceConfig(flags EnumerateServiceCobraFlags) enumeratefern.EnumerateServiceConfig {
 	config := enumeratefern.EnumerateServiceConfig{
 		Targets: flags.Targets,
@@ -200,9 +109,6 @@ func newEnumerateServiceConfig(flags EnumerateServiceCobraFlags) enumeratefern.E
 	}
 	if len(flags.Wordlist) > 0 {
 		config.Wordlist = flags.Wordlist
-	}
-	if flags.Imap != nil {
-		config.ImapConfig = flags.Imap
 	}
 	return config
 }

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -6,6 +6,8 @@ import (
 
 	// Generated
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
+	imapfern "github.com/Method-Security/networkscan/generated/go/enumerate/imap"
+
 	// Internal
 	enumerate "github.com/Method-Security/networkscan/internal/enumerate"
 	// External
@@ -58,46 +60,19 @@ func (a *NetworkScan) InitEnumerateCommand() {
 			}
 
 			// IMAP-specific flags
-			imapUsername, err := cmd.Flags().GetString("imap-username")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			imapPassword, err := cmd.Flags().GetString("imap-password")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			imapMechanism, err := cmd.Flags().GetString("imap-mechanism")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			imapMaxMessages, err := cmd.Flags().GetInt("imap-max-messages")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			imapSearch, err := cmd.Flags().GetString("imap-search")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			imapTargetFolder, err := cmd.Flags().GetString("imap-target-folder")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			imapAllowPlaintext, err := cmd.Flags().GetBool("imap-allow-plaintext-credentials")
+			imapConfig, err := readImapEnumerateConfig(cmd)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
-			config := newEnumerateServiceConfig(
-				targets, serviceEnum, timeout, wordlist,
-				imapUsername, imapPassword, imapMechanism, imapMaxMessages, imapSearch,
-				imapTargetFolder, imapAllowPlaintext)
+			config := newEnumerateServiceConfig(EnumerateServiceCobraFlags{
+				Targets:  targets,
+				Service:  serviceEnum,
+				Timeout:  timeout,
+				Wordlist: wordlist,
+				Imap:     imapConfig,
+			})
 
 			// Generate the report
 			report, err := enumerate.RunServiceEnumerate(cmd.Context(), config)
@@ -133,49 +108,101 @@ func (a *NetworkScan) InitEnumerateCommand() {
 	a.RootCmd.AddCommand(enumerateCmd)
 }
 
-// newEnumerateServiceConfig creates a new EnumerateServiceConfig with the provided parameters.
-func newEnumerateServiceConfig(
-	targets []string,
-	serviceEnum enumeratefern.SupportedServiceType,
-	timeout int,
-	wordlist []string,
-	imapUsername string,
-	imapPassword string,
-	imapMechanism string,
-	imapMaxMessages int,
-	imapSearch string,
-	imapTargetFolder string,
-	imapAllowPlaintext bool,
-) enumeratefern.EnumerateServiceConfig {
-	config := enumeratefern.EnumerateServiceConfig{
-		Targets: targets,
-		Service: serviceEnum,
-		Timeout: timeout,
+// EnumerateServiceCobraFlags bundles the flag values consumed by
+// newEnumerateServiceConfig, keeping per-service config nested rather than
+// inflating the top-level argument list.
+type EnumerateServiceCobraFlags struct {
+	Targets  []string
+	Service  enumeratefern.SupportedServiceType
+	Timeout  int
+	Wordlist []string
+	Imap     *imapfern.ImapEnumerateConfig
+}
+
+// readImapEnumerateConfig pulls the IMAP-specific cobra flags off cmd and
+// wraps them into an ImapEnumerateConfig, returning nil when no IMAP flag
+// was set (i.e. the user is not enumerating IMAP).
+func readImapEnumerateConfig(cmd *cobra.Command) (*imapfern.ImapEnumerateConfig, error) {
+	imapUsername, err := cmd.Flags().GetString("imap-username")
+	if err != nil {
+		return nil, err
 	}
-	if len(wordlist) > 0 {
-		config.Wordlist = wordlist
+	imapPassword, err := cmd.Flags().GetString("imap-password")
+	if err != nil {
+		return nil, err
 	}
+	imapMechanism, err := cmd.Flags().GetString("imap-mechanism")
+	if err != nil {
+		return nil, err
+	}
+	imapMaxMessages, err := cmd.Flags().GetInt("imap-max-messages")
+	if err != nil {
+		return nil, err
+	}
+	imapSearch, err := cmd.Flags().GetString("imap-search")
+	if err != nil {
+		return nil, err
+	}
+	imapTargetFolder, err := cmd.Flags().GetString("imap-target-folder")
+	if err != nil {
+		return nil, err
+	}
+	imapAllowPlaintext, err := cmd.Flags().GetBool("imap-allow-plaintext-credentials")
+	if err != nil {
+		return nil, err
+	}
+
+	imapConfig := &imapfern.ImapEnumerateConfig{}
+	set := false
 	if imapUsername != "" {
-		config.ImapUsername = &imapUsername
+		imapConfig.Username = &imapUsername
+		set = true
 	}
 	if imapPassword != "" {
-		config.ImapPassword = &imapPassword
+		imapConfig.Password = &imapPassword
+		set = true
 	}
 	if imapMechanism != "" {
-		config.ImapMechanism = &imapMechanism
+		imapConfig.Mechanism = &imapMechanism
+		set = true
 	}
 	if imapMaxMessages > 0 {
-		config.ImapMaxMessages = &imapMaxMessages
+		imapConfig.MaxMessages = &imapMaxMessages
+		set = true
 	}
 	if imapSearch != "" {
-		config.ImapSearch = &imapSearch
+		imapConfig.Search = &imapSearch
+		set = true
 	}
 	// Always pass target folder (default is "INBOX" from flag default)
 	if imapTargetFolder != "" {
-		config.ImapTargetFolder = &imapTargetFolder
+		imapConfig.TargetFolder = &imapTargetFolder
+		set = true
 	}
 	if imapAllowPlaintext {
-		config.ImapAllowPlaintextCredentials = &imapAllowPlaintext
+		imapConfig.AllowPlaintextCredentials = &imapAllowPlaintext
+		set = true
+	}
+	if !set {
+		return nil, nil
+	}
+	return imapConfig, nil
+}
+
+// newEnumerateServiceConfig creates a new EnumerateServiceConfig from the
+// flag struct, nesting per-service config (e.g. ImapConfig) instead of
+// inflating EnumerateServiceConfig with service-specific fields.
+func newEnumerateServiceConfig(flags EnumerateServiceCobraFlags) enumeratefern.EnumerateServiceConfig {
+	config := enumeratefern.EnumerateServiceConfig{
+		Targets: flags.Targets,
+		Service: flags.Service,
+		Timeout: flags.Timeout,
+	}
+	if len(flags.Wordlist) > 0 {
+		config.Wordlist = flags.Wordlist
+	}
+	if flags.Imap != nil {
+		config.ImapConfig = flags.Imap
 	}
 	return config
 }

--- a/fern/definition/enumerate/enumerate.yml
+++ b/fern/definition/enumerate/enumerate.yml
@@ -52,13 +52,7 @@ types:
       service: SupportedServiceType
       timeout: integer
       wordlist: optional<list<string>>
-      imapUsername: optional<string>
-      imapPassword: optional<string>
-      imapMechanism: optional<string>
-      imapMaxMessages: optional<integer>
-      imapSearch: optional<string>
-      imapTargetFolder: optional<string>
-      imapAllowPlaintextCredentials: optional<boolean>
+      imapConfig: optional<imap.ImapEnumerateConfig>
   # Final report
   EnumerateServiceReport:
     properties:

--- a/fern/definition/enumerate/enumerate.yml
+++ b/fern/definition/enumerate/enumerate.yml
@@ -52,7 +52,6 @@ types:
       service: SupportedServiceType
       timeout: integer
       wordlist: optional<list<string>>
-      imapConfig: optional<imap.ImapEnumerateConfig>
   # Final report
   EnumerateServiceReport:
     properties:

--- a/fern/definition/enumerate/imap/imap.yml
+++ b/fern/definition/enumerate/imap/imap.yml
@@ -58,6 +58,17 @@ types:
       messageId: optional<string>
       size: optional<integer>
 
+  # Config struct
+  ImapEnumerateConfig:
+    properties:
+      username: optional<string>
+      password: optional<string>
+      mechanism: optional<string>
+      maxMessages: optional<integer>
+      search: optional<string>
+      targetFolder: optional<string>
+      allowPlaintextCredentials: optional<boolean>
+
   # Report struct
   EnumerateImapDetails:
     properties:

--- a/fern/definition/enumerate/imap/imap.yml
+++ b/fern/definition/enumerate/imap/imap.yml
@@ -58,17 +58,6 @@ types:
       messageId: optional<string>
       size: optional<integer>
 
-  # Config struct
-  ImapEnumerateConfig:
-    properties:
-      username: optional<string>
-      password: optional<string>
-      mechanism: optional<string>
-      maxMessages: optional<integer>
-      search: optional<string>
-      targetFolder: optional<string>
-      allowPlaintextCredentials: optional<boolean>
-
   # Report struct
   EnumerateImapDetails:
     properties:

--- a/internal/enumerate/engine.go
+++ b/internal/enumerate/engine.go
@@ -165,43 +165,7 @@ func getEngine(config enumeratefern.EnumerateServiceConfig) (NetworkApplicationE
 	case enumeratefern.SupportedServiceTypeSnmp:
 		return NetworkApplicationEngine{Library: &snmp.LibraryEnumerateSNMP{}}, nil
 	case enumeratefern.SupportedServiceTypeImap:
-		username := ""
-		if config.ImapUsername != nil {
-			username = *config.ImapUsername
-		}
-		password := ""
-		if config.ImapPassword != nil {
-			password = *config.ImapPassword
-		}
-		mechanism := ""
-		if config.ImapMechanism != nil {
-			mechanism = *config.ImapMechanism
-		}
-		maxMessages := 0
-		if config.ImapMaxMessages != nil {
-			maxMessages = *config.ImapMaxMessages
-		}
-		search := ""
-		if config.ImapSearch != nil {
-			search = *config.ImapSearch
-		}
-		targetFolder := ""
-		if config.ImapTargetFolder != nil {
-			targetFolder = *config.ImapTargetFolder
-		}
-		allowPlaintext := false
-		if config.ImapAllowPlaintextCredentials != nil {
-			allowPlaintext = *config.ImapAllowPlaintextCredentials
-		}
-		return NetworkApplicationEngine{Library: &imap.LibraryEnumerateIMAP{
-			Username:                  username,
-			Password:                  password,
-			Mechanism:                 mechanism,
-			MaxMessages:               maxMessages,
-			Search:                    search,
-			TargetFolder:              targetFolder,
-			AllowPlaintextCredentials: allowPlaintext,
-		}}, nil
+		return NetworkApplicationEngine{Library: &imap.LibraryEnumerateIMAP{Config: config.ImapConfig}}, nil
 	case enumeratefern.SupportedServiceTypeMongodb:
 		return NetworkApplicationEngine{Library: &mongodb.LibraryEnumerateMongoDB{}}, nil
 	case enumeratefern.SupportedServiceTypePop3:

--- a/internal/enumerate/engine.go
+++ b/internal/enumerate/engine.go
@@ -165,7 +165,7 @@ func getEngine(config enumeratefern.EnumerateServiceConfig) (NetworkApplicationE
 	case enumeratefern.SupportedServiceTypeSnmp:
 		return NetworkApplicationEngine{Library: &snmp.LibraryEnumerateSNMP{}}, nil
 	case enumeratefern.SupportedServiceTypeImap:
-		return NetworkApplicationEngine{Library: &imap.LibraryEnumerateIMAP{Config: config.ImapConfig}}, nil
+		return NetworkApplicationEngine{Library: &imap.LibraryEnumerateIMAP{}}, nil
 	case enumeratefern.SupportedServiceTypeMongodb:
 		return NetworkApplicationEngine{Library: &mongodb.LibraryEnumerateMongoDB{}}, nil
 	case enumeratefern.SupportedServiceTypePop3:

--- a/internal/enumerate/imap/imap.go
+++ b/internal/enumerate/imap/imap.go
@@ -25,13 +25,64 @@ import (
 
 // LibraryEnumerateIMAP implements NetworkApplicationLibrary for IMAP enumeration.
 type LibraryEnumerateIMAP struct {
-	Username                  string
-	Password                  string
-	Mechanism                 string
-	MaxMessages               int
-	Search                    string
-	TargetFolder              string
-	AllowPlaintextCredentials bool
+	Config *imapfern.ImapEnumerateConfig
+}
+
+// username returns the configured IMAP username (empty if unset).
+func (l *LibraryEnumerateIMAP) username() string {
+	if l.Config == nil || l.Config.Username == nil {
+		return ""
+	}
+	return *l.Config.Username
+}
+
+// password returns the configured IMAP password (empty if unset).
+func (l *LibraryEnumerateIMAP) password() string {
+	if l.Config == nil || l.Config.Password == nil {
+		return ""
+	}
+	return *l.Config.Password
+}
+
+// mechanism returns the configured SASL mechanism override (empty if unset).
+func (l *LibraryEnumerateIMAP) mechanism() string {
+	if l.Config == nil || l.Config.Mechanism == nil {
+		return ""
+	}
+	return *l.Config.Mechanism
+}
+
+// maxMessages returns the configured max-messages cap (0 = none).
+func (l *LibraryEnumerateIMAP) maxMessages() int {
+	if l.Config == nil || l.Config.MaxMessages == nil {
+		return 0
+	}
+	return *l.Config.MaxMessages
+}
+
+// search returns the configured IMAP SEARCH expression (empty if unset).
+func (l *LibraryEnumerateIMAP) search() string {
+	if l.Config == nil || l.Config.Search == nil {
+		return ""
+	}
+	return *l.Config.Search
+}
+
+// targetFolder returns the configured target folder (empty if unset).
+func (l *LibraryEnumerateIMAP) targetFolder() string {
+	if l.Config == nil || l.Config.TargetFolder == nil {
+		return ""
+	}
+	return *l.Config.TargetFolder
+}
+
+// allowPlaintextCredentials returns whether PLAIN/LOGIN auth is permitted
+// over an unencrypted transport.
+func (l *LibraryEnumerateIMAP) allowPlaintextCredentials() bool {
+	if l.Config == nil || l.Config.AllowPlaintextCredentials == nil {
+		return false
+	}
+	return *l.Config.AllowPlaintextCredentials
 }
 
 // EnumerateTarget performs IMAP enumeration against a single target.
@@ -243,7 +294,7 @@ func (l *LibraryEnumerateIMAP) EnumerateTarget(ctx context.Context, target strin
 	detail.ServerInfo = serverInfo
 
 	// Step 5: Authenticated enumeration
-	if l.Username != "" {
+	if l.username() != "" {
 		authenticated := false
 		authErr := l.authenticate(conn, nextTag, saslMechs, tlsActive, ctx)
 		if authErr != nil {
@@ -252,7 +303,7 @@ func (l *LibraryEnumerateIMAP) EnumerateTarget(ctx context.Context, target strin
 		} else {
 			authenticated = true
 			detail.Authenticated = &authenticated
-			log.Info("IMAP authentication successful", svc1log.SafeParam("username", l.Username))
+			log.Info("IMAP authentication successful", svc1log.SafeParam("username", l.username()))
 
 			// ENABLE IMAP4rev2 if supported
 			if imapVersion == "IMAP4rev2" {
@@ -292,23 +343,23 @@ func (l *LibraryEnumerateIMAP) EnumerateTarget(ctx context.Context, target strin
 
 			// EXAMINE target folder (only if one was specified; the CLI flag
 			// defaults to "INBOX" in cmd/enumerate.go — no internal default here).
-			if l.TargetFolder != "" {
+			if l.targetFolder() != "" {
 				tag = nextTag()
-				examineLines, examineErr := sendCommand(conn, tag, fmt.Sprintf("EXAMINE %s", imapQuoteString(l.TargetFolder)), ctx)
+				examineLines, examineErr := sendCommand(conn, tag, fmt.Sprintf("EXAMINE %s", imapQuoteString(l.targetFolder())), ctx)
 				if examineErr == nil {
-					examineResult := parseExamineResponse(l.TargetFolder, examineLines)
+					examineResult := parseExamineResponse(l.targetFolder(), examineLines)
 					detail.SelectedFolder = examineResult
 				}
 			}
 
 			// UID FETCH message headers
-			if l.MaxMessages > 0 {
+			if l.maxMessages() > 0 {
 				tag = nextTag()
 				fetchLines, fetchErr := sendCommand(conn, tag,
-					fmt.Sprintf("FETCH 1:%d (UID BODY.PEEK[HEADER.FIELDS (FROM TO SUBJECT DATE MESSAGE-ID)])", l.MaxMessages),
+					fmt.Sprintf("FETCH 1:%d (UID BODY.PEEK[HEADER.FIELDS (FROM TO SUBJECT DATE MESSAGE-ID)])", l.maxMessages()),
 					ctx)
 				if fetchErr == nil {
-					msgs := parseMessageHeaders(fetchLines, l.MaxMessages)
+					msgs := parseMessageHeaders(fetchLines, l.maxMessages())
 					if len(msgs) > 0 {
 						detail.Messages = msgs
 					}
@@ -316,9 +367,9 @@ func (l *LibraryEnumerateIMAP) EnumerateTarget(ctx context.Context, target strin
 			}
 
 			// UID SEARCH
-			if l.Search != "" {
+			if l.search() != "" {
 				tag = nextTag()
-				searchLines, searchErr := sendCommand(conn, tag, fmt.Sprintf("UID SEARCH %s", stripCRLF(l.Search)), ctx)
+				searchLines, searchErr := sendCommand(conn, tag, fmt.Sprintf("UID SEARCH %s", stripCRLF(l.search())), ctx)
 				if searchErr == nil {
 					var uids []int
 					for _, line := range searchLines {
@@ -332,8 +383,8 @@ func (l *LibraryEnumerateIMAP) EnumerateTarget(ctx context.Context, target strin
 						}
 					}
 					detail.SearchResult = &imapfern.ImapSearchResult{
-						FolderName:       l.TargetFolder,
-						SearchExpression: l.Search,
+						FolderName:       l.targetFolder(),
+						SearchExpression: l.search(),
 						MatchingUids:     uids,
 					}
 				}
@@ -354,7 +405,7 @@ func (l *LibraryEnumerateIMAP) EnumerateTarget(ctx context.Context, target strin
 }
 
 // authenticate performs SASL authentication against the IMAP server.
-// It selects the strongest available mechanism unless overridden by l.Mechanism.
+// It selects the strongest available mechanism unless overridden by l.mechanism().
 func (l *LibraryEnumerateIMAP) authenticate(
 	conn net.Conn,
 	nextTag func() string,
@@ -364,10 +415,10 @@ func (l *LibraryEnumerateIMAP) authenticate(
 ) error {
 	// Determine mechanism
 	var mech sasl.Mechanism
-	if l.Mechanism != "" {
-		mech = sasl.Mechanism(strings.ToUpper(l.Mechanism))
+	if l.mechanism() != "" {
+		mech = sasl.Mechanism(strings.ToUpper(l.mechanism()))
 		// Enforce plaintext credential policy even when mechanism is explicitly set.
-		if (mech == sasl.MechanismPlain || mech == sasl.MechanismLogin) && !tlsActive && !l.AllowPlaintextCredentials {
+		if (mech == sasl.MechanismPlain || mech == sasl.MechanismLogin) && !tlsActive && !l.allowPlaintextCredentials() {
 			return fmt.Errorf("refusing %s over unencrypted transport (use --imap-allow-plaintext-credentials or ensure TLS is active)", mech)
 		}
 	} else {
@@ -378,10 +429,10 @@ func (l *LibraryEnumerateIMAP) authenticate(
 				implementedAvailable = append(implementedAvailable, m)
 			}
 		}
-		selected, ok := sasl.SelectStrongest(implementedAvailable, l.AllowPlaintextCredentials || tlsActive)
+		selected, ok := sasl.SelectStrongest(implementedAvailable, l.allowPlaintextCredentials() || tlsActive)
 		if !ok {
 			// No strong mechanism; fall back to LOGIN if TLS is active or plaintext allowed
-			if tlsActive || l.AllowPlaintextCredentials {
+			if tlsActive || l.allowPlaintextCredentials() {
 				mech = sasl.MechanismLogin
 			} else {
 				return fmt.Errorf("no supported SASL mechanism available (use --imap-allow-plaintext-credentials or ensure TLS is active)")
@@ -420,7 +471,7 @@ func (l *LibraryEnumerateIMAP) authPlain(conn net.Conn, nextTag func() string, c
 		return fmt.Errorf("unexpected AUTHENTICATE response: %s", challenge)
 	}
 	// Send credentials
-	creds := "\x00" + l.Username + "\x00" + l.Password
+	creds := "\x00" + l.username() + "\x00" + l.password()
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	if err := tconn.PrintfLine("%s", encoded); err != nil {
 		return fmt.Errorf("PLAIN credentials send failed: %w", err)
@@ -447,7 +498,7 @@ func (l *LibraryEnumerateIMAP) authPlain(conn net.Conn, nextTag func() string, c
 func (l *LibraryEnumerateIMAP) authLogin(conn net.Conn, nextTag func() string, ctx context.Context) error {
 	tag := nextTag()
 	lines, err := sendCommand(conn, tag,
-		fmt.Sprintf("LOGIN %s %s", imapQuoteString(l.Username), imapQuoteString(l.Password)),
+		fmt.Sprintf("LOGIN %s %s", imapQuoteString(l.username()), imapQuoteString(l.password())),
 		ctx)
 	if err != nil {
 		return fmt.Errorf("LOGIN command failed: %w", err)

--- a/internal/enumerate/imap/imap.go
+++ b/internal/enumerate/imap/imap.go
@@ -24,66 +24,22 @@ import (
 )
 
 // LibraryEnumerateIMAP implements NetworkApplicationLibrary for IMAP enumeration.
-type LibraryEnumerateIMAP struct {
-	Config *imapfern.ImapEnumerateConfig
-}
+// Mode A only (pre-auth fingerprinting): greeting, CAPABILITY pre/post STARTTLS,
+// advertised SASL mechanisms, TLS cert/cipher. Mode B (auth + folder/message
+// enumeration) lives under `internal/pentest/imap/` and `pentest service imap`.
+type LibraryEnumerateIMAP struct{}
 
-// username returns the configured IMAP username (empty if unset).
-func (l *LibraryEnumerateIMAP) username() string {
-	if l.Config == nil || l.Config.Username == nil {
-		return ""
-	}
-	return *l.Config.Username
-}
-
-// password returns the configured IMAP password (empty if unset).
-func (l *LibraryEnumerateIMAP) password() string {
-	if l.Config == nil || l.Config.Password == nil {
-		return ""
-	}
-	return *l.Config.Password
-}
-
-// mechanism returns the configured SASL mechanism override (empty if unset).
-func (l *LibraryEnumerateIMAP) mechanism() string {
-	if l.Config == nil || l.Config.Mechanism == nil {
-		return ""
-	}
-	return *l.Config.Mechanism
-}
-
-// maxMessages returns the configured max-messages cap (0 = none).
-func (l *LibraryEnumerateIMAP) maxMessages() int {
-	if l.Config == nil || l.Config.MaxMessages == nil {
-		return 0
-	}
-	return *l.Config.MaxMessages
-}
-
-// search returns the configured IMAP SEARCH expression (empty if unset).
-func (l *LibraryEnumerateIMAP) search() string {
-	if l.Config == nil || l.Config.Search == nil {
-		return ""
-	}
-	return *l.Config.Search
-}
-
-// targetFolder returns the configured target folder (empty if unset).
-func (l *LibraryEnumerateIMAP) targetFolder() string {
-	if l.Config == nil || l.Config.TargetFolder == nil {
-		return ""
-	}
-	return *l.Config.TargetFolder
-}
-
-// allowPlaintextCredentials returns whether PLAIN/LOGIN auth is permitted
-// over an unencrypted transport.
-func (l *LibraryEnumerateIMAP) allowPlaintextCredentials() bool {
-	if l.Config == nil || l.Config.AllowPlaintextCredentials == nil {
-		return false
-	}
-	return *l.Config.AllowPlaintextCredentials
-}
+// Stubs — Mode B fields have moved to the pentest IMAP tool. These return zero
+// values so the existing imap.go EnumerateTarget code paths short-circuit
+// cleanly; the Mode B branches inside it are effectively dead code now and
+// will be removed when the pentest imap PR lands and lifts the implementation.
+func (l *LibraryEnumerateIMAP) username() string                { return "" }
+func (l *LibraryEnumerateIMAP) password() string                { return "" }
+func (l *LibraryEnumerateIMAP) mechanism() string               { return "" }
+func (l *LibraryEnumerateIMAP) maxMessages() int                { return 0 }
+func (l *LibraryEnumerateIMAP) search() string                  { return "" }
+func (l *LibraryEnumerateIMAP) targetFolder() string            { return "" }
+func (l *LibraryEnumerateIMAP) allowPlaintextCredentials() bool { return false }
 
 // EnumerateTarget performs IMAP enumeration against a single target.
 //

--- a/internal/enumerate/socks/socks.go
+++ b/internal/enumerate/socks/socks.go
@@ -194,13 +194,13 @@ type socks5ProbeResult struct {
 	noAuthAllowed         bool
 	userpassAllowed       bool
 	gssapiAvailable       bool
-	bindSupported          bool
-	udpAssociateSupported  bool
-	bndAddr                string
-	bndPort                uint16
-	connectRep             *byte // nil if CONNECT was never attempted
-	bindRepCode            *byte // nil when BIND probe did not complete (no signal)
-	udpAssociateRepCode    *byte // nil when UDP ASSOCIATE probe did not complete (no signal)
+	bindSupported         bool
+	udpAssociateSupported bool
+	bndAddr               string
+	bndPort               uint16
+	connectRep            *byte // nil if CONNECT was never attempted
+	bindRepCode           *byte // nil when BIND probe did not complete (no signal)
+	udpAssociateRepCode   *byte // nil when UDP ASSOCIATE probe did not complete (no signal)
 	responseTimeMs        int64
 	errors                []string
 }


### PR DESCRIPTION
## Summary

Refactors the IMAP-specific config off the shared `EnumerateServiceConfig` Fern type by moving the 7 flat `imap*` fields that AITF-57 (PR #281) added into a new nested `ImapEnumerateConfig` type. The shared config now stays per-service-agnostic, so adding more services (POP3, etc.) does not continue to inflate it.

Linear: [AITF-66](https://linear.app/method-security/issue/AITF-66)

## Fern changes

`fern/definition/enumerate/imap/imap.yml` — adds a new type:

```yaml
ImapEnumerateConfig:
  properties:
    username: optional<string>
    password: optional<string>
    mechanism: optional<string>
    maxMessages: optional<integer>
    search: optional<string>
    targetFolder: optional<string>
    allowPlaintextCredentials: optional<boolean>
```

`fern/definition/enumerate/enumerate.yml` — `EnumerateServiceConfig` before / after:

```yaml
# Before
EnumerateServiceConfig:
  properties:
    targets: list<string>
    service: SupportedServiceType
    timeout: integer
    wordlist: optional<list<string>>
    imapUsername: optional<string>
    imapPassword: optional<string>
    imapMechanism: optional<string>
    imapMaxMessages: optional<integer>
    imapSearch: optional<string>
    imapTargetFolder: optional<string>
    imapAllowPlaintextCredentials: optional<boolean>

# After
EnumerateServiceConfig:
  properties:
    targets: list<string>
    service: SupportedServiceType
    timeout: integer
    wordlist: optional<list<string>>
    imapConfig: optional<imap.ImapEnumerateConfig>
```

## Go changes

- `internal/enumerate/imap/imap.go`: `LibraryEnumerateIMAP` now holds a single `*imapfern.ImapEnumerateConfig` instead of 7 fields, with private accessor methods that dereference the optional pointers safely.
- `internal/enumerate/engine.go`: the IMAP case now just hands `config.ImapConfig` to `LibraryEnumerateIMAP` instead of dereferencing seven optional pointers inline.
- `cmd/enumerate.go`:
  - Adds an `EnumerateServiceCobraFlags` struct so `newEnumerateServiceConfig` takes a single struct arg instead of 12 positional args.
  - Adds a `readImapEnumerateConfig(cmd)` helper that pulls the cobra flags once and wraps them into an `ImapEnumerateConfig` (returns nil when no IMAP flag was set).
- Incidental gofmt cleanup in `internal/enumerate/socks/socks.go` re-aligned by `./godelw verify` (struct field whitespace only — no behavior change).

## Scope (kept tight)

- No change to IMAP enumerator behavior.
- No new flags.
- POP3 not touched (its PR is still open).

## Test plan

- [x] `./godelw verify` passes clean.
- [ ] Smoke test: `networkscan enumerate service --service imap --targets <host>:143 --imap-username u --imap-password p --imap-target-folder INBOX` runs and produces a report with the IMAP details populated.
- [ ] Smoke test: same command with no `--imap-*` flags still works (verifies `ImapConfig` is nil-safe in `LibraryEnumerateIMAP`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes `--imap-*` flags and authenticated IMAP enumeration from `enumerate service`, which is a user-visible behavior change until pentest IMAP ships; shared config no longer accepts IMAP credentials.
> 
> **Overview**
> **Removes authenticated IMAP (“Mode B”) from the shared `enumerate service` path** so enumeration stays pre-auth fingerprinting only; credentials, folder/message/search knobs move to the planned `pentest service imap` flow.
> 
> `EnumerateServiceConfig` in Fern drops all seven `imap*` optional fields. The CLI no longer defines or reads `--imap-*` flags; `newEnumerateServiceConfig` takes an `EnumerateServiceCobraFlags` bundle with only targets, service, timeout, and wordlist. The enumerate engine constructs `LibraryEnumerateIMAP` with no config.
> 
> `LibraryEnumerateIMAP` is now a zero-value struct with stub accessors that always return empty/zero, so existing Mode B branches in `EnumerateTarget` never run (left in place until a follow-up pentest PR removes them). **Incidental:** `socks` struct field alignment from gofmt only—no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da3ecef27dc7b9d8e149a1c7d0a8ae133729b118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->