### PR TITLE
Add stealth (sleep/jitter) to discover route

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -310,8 +310,28 @@ func (a *NetworkScan) InitDiscoverCommand() {
 				port = 0 // ICMP doesn't use ports
 			}
 
+			// Stealth flags
+			sleep, err := cmd.Flags().GetInt("sleep")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			jitter, err := cmd.Flags().GetInt("jitter")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if jitter > 0 && sleep == 0 {
+				a.OutputSignal.AddError(fmt.Errorf("jitter parameter can only be used when sleep is also specified"))
+				return
+			}
+			if jitter < 0 || jitter > 100 {
+				a.OutputSignal.AddError(fmt.Errorf("jitter must be between 0 and 100 (percentage), got %d", jitter))
+				return
+			}
+
 			// Set Config
-			config := getDiscoverRouteConfig(targets, hostIP, excludeTimeoutHops, probesPerHop, probeDelay, maxHops, timeout, probeType, port)
+			config := getDiscoverRouteConfig(targets, hostIP, excludeTimeoutHops, probesPerHop, probeDelay, maxHops, timeout, probeType, port, sleep, jitter)
 
 			// Generate the report
 			report, err := discoverroute.RunRouteDiscovery(cmd.Context(), config)
@@ -331,6 +351,8 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverRouteCmd.Flags().Int("timeout", 5, "Timeout in seconds for each probe (default: 5)")
 	discoverRouteCmd.Flags().String("probe-type", "ICMP", "Probe packet type: UDP or ICMP (default: ICMP)")
 	discoverRouteCmd.Flags().Int("port", 0, "Port number for UDP probes (default: 33434 for UDP)")
+	discoverRouteCmd.Flags().Int("sleep", 0, "Sleep duration in seconds between targets")
+	discoverRouteCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep")
 
 	// Mark Required Flags
 	_ = discoverRouteCmd.MarkFlagRequired("targets")
@@ -615,7 +637,7 @@ func getDiscoverPortConfig(target string, ports string, topPorts string, threads
 
 // getDiscoverRouteConfig creates a configuration for traceroute with the provided parameters.
 // It sets up the targets, probe settings, and timing configurations.
-func getDiscoverRouteConfig(targets []string, hostIP string, excludeTimeoutHops bool, probesPerHop, probeDelay, maxHops, timeout int, probeType discoverfern.ProbeType, port int) discoverfern.DiscoverRouteConfig {
+func getDiscoverRouteConfig(targets []string, hostIP string, excludeTimeoutHops bool, probesPerHop, probeDelay, maxHops, timeout int, probeType discoverfern.ProbeType, port int, sleep int, jitter int) discoverfern.DiscoverRouteConfig {
 	config := discoverfern.DiscoverRouteConfig{
 		Targets:            targets,
 		ExcludeTimeoutHops: excludeTimeoutHops,
@@ -625,6 +647,13 @@ func getDiscoverRouteConfig(targets []string, hostIP string, excludeTimeoutHops 
 		Timeout:            timeout,
 		ProbeType:          probeType,
 		Port:               port,
+	}
+
+	if sleep > 0 {
+		config.Stealth = &discoverfern.RouteStealthConfig{
+			Sleep:  &sleep,
+			Jitter: &jitter,
+		}
 	}
 
 	if hostIP != "" {

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -18,6 +18,11 @@ types:
       targetIp: string
       hops: list<TracerouteHop>
       completed: boolean
+  # Stealth config
+  RouteStealthConfig:
+    properties:
+      sleep: optional<integer> # Sleep delay in seconds between targets
+      jitter: optional<integer> # Jitter percentage (0-100) to randomize sleep
   # Config
   DiscoverRouteConfig:
     properties:
@@ -30,6 +35,7 @@ types:
       timeout: integer
       probeType: ProbeType
       port: integer
+      stealth: optional<RouteStealthConfig>
   # Result  
   DiscoverRouteResult:
     properties:

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -62,7 +62,14 @@ func RunRouteDiscovery(ctx context.Context, config discoverfern.DiscoverRouteCon
 	var tracerouteResults []*discoverfern.TracerouteResult
 
 	// Process each target
-	for _, target := range config.Targets {
+	for i, target := range config.Targets {
+		if i > 0 && config.Stealth != nil {
+			if delay := utils.CalculateStealthDelay(config.Stealth.Sleep, config.Stealth.Jitter); delay > 0 {
+				log.Info("Applying stealth delay between targets", svc1log.SafeParam("delay", delay))
+				time.Sleep(delay)
+			}
+		}
+
 		log.Info("Processing target", svc1log.SafeParam("target", target))
 
 		// Resolve target to IP

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -66,7 +66,17 @@ func RunRouteDiscovery(ctx context.Context, config discoverfern.DiscoverRouteCon
 		if i > 0 && config.Stealth != nil {
 			if delay := utils.CalculateStealthDelay(config.Stealth.Sleep, config.Stealth.Jitter); delay > 0 {
 				log.Info("Applying stealth delay between targets", svc1log.SafeParam("delay", delay))
-				time.Sleep(delay)
+				select {
+				case <-ctx.Done():
+					return &discoverfern.DiscoverRouteReport{
+						Config: &config,
+						Result: &discoverfern.DiscoverRouteResult{
+							Traceroutes: tracerouteResults,
+						},
+						Errors: append(errors, ctx.Err().Error()),
+					}, nil
+				case <-time.After(delay):
+				}
 			}
 		}
 

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -61,22 +61,36 @@ func RunRouteDiscovery(ctx context.Context, config discoverfern.DiscoverRouteCon
 
 	var tracerouteResults []*discoverfern.TracerouteResult
 
+	// partialReport returns the report accumulated so far; used when the
+	// context is cancelled between targets.
+	partialReport := func(err error) *discoverfern.DiscoverRouteReport {
+		return &discoverfern.DiscoverRouteReport{
+			Config: &config,
+			Result: &discoverfern.DiscoverRouteResult{
+				Traceroutes: tracerouteResults,
+			},
+			Errors: append(errors, err.Error()),
+		}
+	}
+
 	// Process each target
 	for i, target := range config.Targets {
-		if i > 0 && config.Stealth != nil {
-			if delay := utils.CalculateStealthDelay(config.Stealth.Sleep, config.Stealth.Jitter); delay > 0 {
+		// Always honour cancellation between targets, even when no stealth
+		// delay is configured.
+		if i > 0 {
+			delay := time.Duration(0)
+			if config.Stealth != nil {
+				delay = utils.CalculateStealthDelay(config.Stealth.Sleep, config.Stealth.Jitter)
+			}
+			if delay > 0 {
 				log.Info("Applying stealth delay between targets", svc1log.SafeParam("delay", delay))
 				select {
 				case <-ctx.Done():
-					return &discoverfern.DiscoverRouteReport{
-						Config: &config,
-						Result: &discoverfern.DiscoverRouteResult{
-							Traceroutes: tracerouteResults,
-						},
-						Errors: append(errors, ctx.Err().Error()),
-					}, nil
+					return partialReport(ctx.Err()), ctx.Err()
 				case <-time.After(delay):
 				}
+			} else if err := ctx.Err(); err != nil {
+				return partialReport(err), err
 			}
 		}
 

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -62,7 +62,10 @@ func RunRouteDiscovery(ctx context.Context, config discoverfern.DiscoverRouteCon
 	var tracerouteResults []*discoverfern.TracerouteResult
 
 	// partialReport returns the report accumulated so far; used when the
-	// context is cancelled between targets.
+	// context is cancelled between targets. The error is recorded inside
+	// the report's Errors slice and the function returns (report, nil) so
+	// callers that gate on err != nil still surface partial results to the
+	// user — matching the pattern used by RunHostDiscovery.
 	partialReport := func(err error) *discoverfern.DiscoverRouteReport {
 		return &discoverfern.DiscoverRouteReport{
 			Config: &config,
@@ -86,11 +89,11 @@ func RunRouteDiscovery(ctx context.Context, config discoverfern.DiscoverRouteCon
 				log.Info("Applying stealth delay between targets", svc1log.SafeParam("delay", delay))
 				select {
 				case <-ctx.Done():
-					return partialReport(ctx.Err()), ctx.Err()
+					return partialReport(ctx.Err()), nil
 				case <-time.After(delay):
 				}
 			} else if err := ctx.Err(); err != nil {
-				return partialReport(err), err
+				return partialReport(err), nil
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Wires per-target stealth delay into `discover route` (traceroute), matching the pattern already used by `discover host` and `discover port`
- Adds a `RouteStealthConfig` Fern type with optional `sleep` + `jitter`, surfaced via `--sleep` / `--jitter` CLI flags
- Reuses `utils.CalculateStealthDelay` between targets inside `RunRouteDiscovery`
- Validates `jitter > 0` requires `sleep > 0`, and `jitter` is bounded `[0, 100]`

## Audit of other tools (intentionally skipped)
- `discover socket / tls / service / domain`: single-request, sleep adds no value
- `pentest service *` (smb, ssh, telnet, ldap, ftp, mongodb, redis, mysql, imap, pop3, msrpc, winrm, kerberos): single-target, no inter-request loop
- `pentest scan cve`: nuclei-based, already has `--global-rate-limit` for stealth
- `pentest spray *` (including MySQL spray AITF-26): already inherits sleep/jitter from `SprayStealthConfig`
- `enumerate service`: concurrent worker pool, not a sequential loop

## Test plan
- [x] `./godelw verify` passes
- [ ] Manual: `networkscan discover route --targets 8.8.8.8,1.1.1.1 --sleep 2 --jitter 50` shows variable delay between targets
- [ ] Manual: `--jitter 30` without `--sleep` returns validation error
- [ ] Manual: `--jitter 150` returns validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral timing and reporting changes only; reuses existing stealth validation and delay helpers with no auth or data-handling impact.
> 
> **Overview**
> Adds **per-target stealth pacing** to `discover route`, aligned with `discover host` and `discover port`.
> 
> The CLI gains `--sleep` and `--jitter` with the same rules as other discover commands: jitter requires sleep, and jitter is capped at 0–100%. When `sleep > 0`, `DiscoverRouteConfig` carries optional `RouteStealthConfig` (new Fern type on `DiscoverRouteConfig.stealth`).
> 
> `RunRouteDiscovery` now waits between multi-target traceroutes via `utils.CalculateStealthDelay`, and checks `ctx` cancellation between targets even without stealth. On cancel during a wait (or when no delay is configured), it returns **partial traceroute results** through a `partialReport` helper (error in the report, `nil` top-level error), matching `RunHostDiscovery`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7551680e4c65ca66316ec6c5e27948aca57924c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->