### PR TITLE
Fix Port Contains Helper Function

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	defaultServiceFingerprintTimeout = 10
-	defaultServicePluginThreads      = 4
+	defaultServiceFingerprintTimeout = 20
+	defaultServicePluginThreads      = 8
 	defaultCustomPluginThreads       = 1
-	defaultValidatePluginThreads     = 4
+	defaultValidatePluginThreads     = 8
 )
 
 // InitDiscoverCommand initializes the discover command and its subcommands (host, os, port, service, tls).
@@ -237,7 +237,7 @@ func (a *NetworkScan) InitDiscoverCommand() {
 	discoverPortCmd.Flags().String("scan-type", "SYN", "Port scan type: SYN (default, requires root) or CONNECT")
 	discoverPortCmd.Flags().Int("packets-per-second", 1000, "Packets per second to send (default: 1000)")
 	discoverPortCmd.Flags().Bool("validate", false, "Validate open ports by using service detection techniques")
-	discoverPortCmd.Flags().Int("validate-attempt-timeout", 10, "Timeout in seconds for each service detection attempt")
+	discoverPortCmd.Flags().Int("validate-attempt-timeout", defaultServiceFingerprintTimeout, "Timeout in seconds for each service detection attempt")
 	discoverPortCmd.Flags().Int("validate-threads", 0, "Number of concurrent threads to use during service detection")
 	discoverPortCmd.Flags().Int("validate-plugin-threads", defaultValidatePluginThreads, "Maximum number of custom service plugins to run concurrently per port during validation")
 	discoverPortCmd.Flags().Int("max-open-ports-validation-threshold", 50, "Trigger validation warning when more than this many ports are open (default: 50)")

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -131,8 +131,8 @@ Flags:
       --threads int                     Number of concurrent threads to use during port scanning (default 25)
       --top-ports string                Scan the top N most common TCP ports (options: full, 100, 1000)
       --validate                                    Validate open ports by using service detection techniques
-      --validate-attempt-timeout int               Timeout in seconds for each service detection attempt (default 10)
-      --validate-plugin-threads int                Maximum number of custom service plugins to run concurrently per port during validation (default 4)
+      --validate-attempt-timeout int               Timeout in seconds for each service detection attempt (default 20)
+      --validate-plugin-threads int                Maximum number of custom service plugins to run concurrently per port during validation (default 8)
       --validate-threads int                       Number of concurrent threads to use during service detection
       --max-open-ports-validation-threshold int    Trigger validation warning when more than this many ports are open (default 50)
 
@@ -175,10 +175,10 @@ Usage:
 
 Flags:
   -h, --help                 help for service
-      --threads int                Maximum number of custom service plugins to run concurrently per target (default 4)
+      --threads int                Maximum number of custom service plugins to run concurrently per target (default 8)
       --service-type string        Service type to fingerprint for stealth mode: SSH, HTTP, GRPC, KERBEROS, LDAP, SMB (stealth mode enabled when specified)
       --target string              Target address (IP:port or hostname:port for TCP, IP or hostname for UDP mode)
-      --timeout int                Timeout in seconds for each service fingerprinting attempt (default 10)
+      --timeout int                Timeout in seconds for each service fingerprinting attempt (default 20)
       --udp                        Enable UDP service discovery mode (scans common UDP ports like DNS, NTP, SNMP, etc.)
 
 Global Flags:

--- a/internal/discover/port/port.go
+++ b/internal/discover/port/port.go
@@ -244,7 +244,7 @@ func ensureRequiredPorts(config discoverfern.DiscoverPortConfig, requiredPorts [
 	if config.Ports != nil && *config.Ports != "" {
 		existingPorts := *config.Ports
 		for _, port := range requiredPorts {
-			if !strings.Contains(existingPorts, port) {
+			if !portSpecContainsPort(existingPorts, port) {
 				existingPorts += "," + port
 			}
 		}
@@ -273,6 +273,36 @@ func ensureRequiredPorts(config discoverfern.DiscoverPortConfig, requiredPorts [
 	}
 
 	return config
+}
+
+func portSpecContainsPort(portSpec string, port string) bool {
+	requiredPort, err := strconv.Atoi(port)
+	if err != nil {
+		return false
+	}
+
+	for _, token := range strings.Split(portSpec, ",") {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if token == port {
+			return true
+		}
+		start, end, ok := strings.Cut(token, "-")
+		if !ok {
+			continue
+		}
+		startPort, startErr := strconv.Atoi(strings.TrimSpace(start))
+		endPort, endErr := strconv.Atoi(strings.TrimSpace(end))
+		if startErr != nil || endErr != nil {
+			continue
+		}
+		if requiredPort >= startPort && requiredPort <= endPort {
+			return true
+		}
+	}
+	return false
 }
 
 // hasOpenRequiredPorts checks if any of the required ports (as strings) are open in the scan results


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is limited to port-list merging when validation is enabled and to CLI default tuning; no auth or data-path changes.
> 
> **Overview**
> **Port validation merge logic** now uses `portSpecContainsPort` instead of substring checks when deciding whether a required validation port is already in the user’s `--ports` spec, so ports like `1` are not treated as present when only `21` or `1-1024` is configured.
> 
> **Discover CLI defaults** are raised for service fingerprinting and plugin concurrency (timeout 20s, 8 threads for service and validate-plugin paths), and `--validate-attempt-timeout` reuses the same fingerprint timeout constant. Docs help text reflects the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a016cd04651e5508271dfd587a46663567157321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->