### PR TITLE
Add custom CVE detector adapter for pentest cve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,3 +162,36 @@ The tool follows a modular architecture with clear separation of concerns:
 - Shared protocol libraries should be used across modules for consistency
 - Configuration through Fern definitions for type safety
 - **CRITICAL**: Always run `./godelw verify` after TODO completion before merging
+
+## CVE Detection — Two Execution Paths, One Report
+
+`pentest cve` runs **both** nuclei templates and custom Go detectors and merges them into the same `PentestCveReport`. This mirrors `discover service`, where fingerprintx and custom protocol plugins both feed the same `ServiceDetails` type. Downstream processors don't care which path produced an attempt — the report shape is identical.
+
+| Path | Lives in | Use when |
+|------|----------|----------|
+| Nuclei template | `utils/nuclei/templates/cve/<year>/...` | A working nuclei template exists or can be written. Default — easier to maintain. |
+| Custom Go detector | `internal/pentest/cve/detectors/cve_<year>_<id>.go` | Detection requires Go code that nuclei cannot express: stateful protocols, custom binary probes, multi-step handshakes, library-driven checks (SMB/Kerberos/etc.), or anything that needs internal helpers in `internal/protocol/`. |
+
+### Adding a custom CVE detector
+
+1. **Create the file** — `internal/pentest/cve/detectors/cve_<year>_<id>.go`, package `detectors`. Type name `CVE_<year>_<id>` (underscores). See `internal/pentest/cve/detectors/doc.go` for the skeleton.
+2. **Implement the `cve.Detector` interface** (defined in `internal/pentest/cve/detector.go`):
+   - `CVEID()` → canonical ID matching `^CVE-\d{4}-\d{4,}$` (the report builder regexes on this).
+   - `Year()` → 4-digit string; used by the `--years` CLI filter exactly like nuclei template years.
+   - `Protocol()` → uppercase token (`"SSH"`, `"FTP"`, `"HTTP"`, …) matching the `--protocol` filter; empty means "any protocol".
+   - `Detect(ctx, target, timeout)` → returns `*nuclei.NucleiAttemptInfo` with `TemplateId == CVEID()`. Return semantics:
+     - Vulnerable → attempt with `Finding.Finding = true` and populated `NucleiFindingInfo` (Name, Description, Severity, `Classification.Cves`).
+     - Probed-but-clean → attempt with `Finding.Finding = false`.
+     - Service didn't match → `(nil, nil)`.
+     - Fatal probe error → `(nil, err)` — surfaced as a warning, not an error.
+3. **Register it** — append a pointer to the type in `registeredDetectors` in `internal/pentest/cve/registry.go`.
+4. **Verify** — `./godelw verify`. No new Fern types are needed; the existing `nuclei.NucleiAttemptInfo` shape is what custom detectors produce.
+
+### Rules
+
+- **One detector per CVE.** Don't bundle multiple CVEs into one type; the year/protocol filters and the per-CVE TemplateId rely on the 1-to-1 mapping.
+- **Don't bypass filters.** Always declare a real `Year()` and `Protocol()`. If the detector legitimately works against any protocol, return `""` for `Protocol()` and document why in a one-line comment.
+- **Reuse existing protocol clients** from `internal/protocol/` and `internal/common/` before writing new probe code.
+- **Don't add CLI flags.** The custom path uses the existing `--targets / --protocol / --years / --timeout` flags. New knobs that don't fit those filters mean the check probably belongs somewhere other than `pentest cve`.
+- **No silent drift between paths.** If you change the `NucleiAttemptInfo` / `NucleiFindingInfo` Fern shape, both paths must keep producing it identically. Run a real `pentest cve` against a known target and inspect the JSON before opening a PR.
+- **`--template-paths` skips custom detectors.** When the operator passes `--template-paths`, the orchestrator runs only those nuclei templates and the custom detector registry is skipped entirely — matching how that flag turns off `--years` and `--protocol` for nuclei.

--- a/internal/pentest/cve.go
+++ b/internal/pentest/cve.go
@@ -6,11 +6,21 @@ import (
 
 	nuclei "github.com/Method-Security/networkscan/generated/go/common/nuclei"
 	pentestfern "github.com/Method-Security/networkscan/generated/go/pentest"
+	cveadapter "github.com/Method-Security/networkscan/internal/pentest/cve"
 	nucleiengine "github.com/Method-Security/networkscan/utils/nuclei"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-// PerformCVEScan executes CVE scanning using nuclei templates
+// PerformCVEScan executes CVE scanning. It runs two execution paths and merges
+// their results into a single PentestCveReport:
+//
+//  1. The nuclei engine, filtered by the same --years and --protocol the user
+//     supplies on the CLI.
+//  2. Custom Go-native detectors registered in internal/pentest/cve, filtered
+//     by the same flags so behavior is consistent across both paths.
+//
+// Both paths produce []*nuclei.NucleiTargetInfo, so the merged report is
+// identical in shape regardless of which detector type produced an attempt.
 func PerformCVEScan(ctx context.Context, config *pentestfern.PentestCveConfig) *pentestfern.PentestCveReport {
 	log := svc1log.FromContext(ctx)
 	var errors []string
@@ -65,6 +75,25 @@ func PerformCVEScan(ctx context.Context, config *pentestfern.PentestCveConfig) *
 	errors = append(errors, warnings...)
 	if err != nil {
 		errors = append(errors, err.Error())
+	}
+
+	// Run custom (non-nuclei) detectors with the same year/protocol filters
+	// the nuclei path used, then merge attempts into results keyed by target.
+	// Skip when the user supplied explicit --template-paths: in that mode the
+	// user wants only those nuclei templates run, no filter-driven scans.
+	if len(config.TemplatePaths) == 0 {
+		var protocolFilter string
+		if config.Protocol != nil {
+			protocolFilter = *config.Protocol
+		}
+		customResults, customWarnings := cveadapter.RunCustomDetectors(ctx, cveadapter.Options{
+			Targets:  config.Targets,
+			Years:    config.Years,
+			Protocol: protocolFilter,
+			Timeout:  config.Timeout,
+		})
+		errors = append(errors, customWarnings...)
+		results = cveadapter.MergeTargets(results, customResults)
 	}
 
 	result := &pentestfern.PentestCveResult{Report: results}

--- a/internal/pentest/cve.go
+++ b/internal/pentest/cve.go
@@ -91,6 +91,7 @@ func PerformCVEScan(ctx context.Context, config *pentestfern.PentestCveConfig) *
 			Years:    config.Years,
 			Protocol: protocolFilter,
 			Timeout:  config.Timeout,
+			Threads:  config.Threads,
 		})
 		errors = append(errors, customWarnings...)
 		results = cveadapter.MergeTargets(results, customResults)

--- a/internal/pentest/cve/detector.go
+++ b/internal/pentest/cve/detector.go
@@ -1,0 +1,62 @@
+// Package cve provides an adapter framework for non-nuclei CVE detection.
+//
+// CVE scanning in networkscan has two execution paths that both produce the
+// same Fern report shape ([]*nuclei.NucleiTargetInfo):
+//
+//  1. Nuclei templates — driven by utils/nuclei.RunNucleiEngine, filtered by
+//     year and protocol.
+//  2. Custom Go detectors — implemented in this package, also filtered by
+//     year and protocol. One detector covers exactly one CVE.
+//
+// This mirrors internal/discover/service: fingerprintx supplies broad
+// coverage while local plugins handle specialized protocols, and both feed
+// the same ServiceDetails type so the downstream report is uniform.
+//
+// To add a CVE check that cannot be expressed as a nuclei template, implement
+// the Detector interface in a file under internal/pentest/cve/detectors/ and
+// register it in registry.go.
+package cve
+
+import (
+	"context"
+
+	nuclei "github.com/Method-Security/networkscan/generated/go/common/nuclei"
+)
+
+// Detector implements detection for exactly one CVE without using a nuclei
+// template. Implementations live in internal/pentest/cve/detectors/ and are
+// registered in registry.go.
+//
+// Return semantics for Detect:
+//   - Vulnerable:        *NucleiAttemptInfo with Finding.Finding = true.
+//   - Probed-but-clean:  *NucleiAttemptInfo with Finding.Finding = false.
+//   - Not applicable:    (nil, nil) — e.g. wrong banner, port closed, service
+//     does not match. The orchestrator will skip the target silently.
+//   - Fatal probe error: (nil, err) — surfaced as a warning in the report.
+//
+// The returned NucleiAttemptInfo.TemplateId MUST equal CVEID() so downstream
+// processors can key off it the same way they key off a nuclei template ID.
+type Detector interface {
+	// CVEID returns the canonical identifier, e.g. "CVE-2024-12345". Must be
+	// unique across all registered detectors and must match the regex
+	// ^CVE-\d{4}-\d{4,}$ so the existing report builder recognizes it.
+	CVEID() string
+
+	// Year returns the 4-digit publication year as a string (e.g. "2024").
+	// The orchestrator only runs a detector if its Year is in the caller's
+	// --years filter, matching the year-subdirectory semantics used by the
+	// nuclei template path.
+	Year() string
+
+	// Protocol returns the application protocol filter token this detector
+	// applies to (e.g. "SSH", "HTTP", "FTP", "SMB"). Compared case-insensitively
+	// against the --protocol CLI flag. Empty means "any protocol" — the
+	// detector will always be considered once the year filter passes.
+	Protocol() string
+
+	// Detect probes a single target string (host:port form, as passed via
+	// --targets) and returns the attempt result. See package doc above for
+	// return semantics. Implementations should respect ctx cancellation and
+	// honor the supplied timeout (seconds).
+	Detect(ctx context.Context, target string, timeout int) (*nuclei.NucleiAttemptInfo, error)
+}

--- a/internal/pentest/cve/detectors/doc.go
+++ b/internal/pentest/cve/detectors/doc.go
@@ -1,0 +1,43 @@
+// Package detectors holds one file per non-nuclei CVE check.
+//
+// Each file in this directory defines a single type implementing
+// internal/pentest/cve.Detector and is registered in
+// internal/pentest/cve/registry.go.
+//
+// File naming: cve_<year>_<id>.go (lower-case, underscores). The type name
+// uses Go-friendly underscores too: CVE_2024_12345.
+//
+// Skeleton for a new detector:
+//
+//	package detectors
+//
+//	import (
+//	    "context"
+//
+//	    nuclei "github.com/Method-Security/networkscan/generated/go/common/nuclei"
+//	)
+//
+//	type CVE_2024_12345 struct{}
+//
+//	func (CVE_2024_12345) CVEID() string   { return "CVE-2024-12345" }
+//	func (CVE_2024_12345) Year() string    { return "2024" }
+//	func (CVE_2024_12345) Protocol() string { return "FTP" }
+//
+//	func (d CVE_2024_12345) Detect(ctx context.Context, target string, timeout int) (*nuclei.NucleiAttemptInfo, error) {
+//	    // 1. Probe the target. Use utils.ParseHostPort to split host:port.
+//	    // 2. Return (nil, nil) if the service doesn't match (wrong banner, port closed, etc.).
+//	    // 3. Return (nil, err) for fatal probe errors.
+//	    // 4. On a clean probe, return an attempt with Finding.Finding=false.
+//	    // 5. On a confirmed hit, return an attempt with Finding.Finding=true and
+//	    //    populate the NucleiFindingInfo fields (Name, Description, Severity,
+//	    //    Classification.Cves) so downstream processors see the same shape they
+//	    //    would from a nuclei template.
+//	    return nil, nil
+//	}
+//
+// Register in internal/pentest/cve/registry.go:
+//
+//	var registeredDetectors = []cve.Detector{
+//	    &detectors.CVE_2024_12345{},
+//	}
+package detectors

--- a/internal/pentest/cve/registry.go
+++ b/internal/pentest/cve/registry.go
@@ -1,0 +1,22 @@
+package cve
+
+// registeredDetectors is the canonical list of custom (non-nuclei) CVE
+// detectors. Adding a new CVE check means:
+//
+//  1. Implement Detector in internal/pentest/cve/detectors/<cve_id>.go
+//     (lower-case, underscores — e.g. cve_2024_12345.go).
+//  2. Append a zero-value of the implementing type to this slice.
+//
+// Keep the slice ordered chronologically (oldest CVE first) for readability;
+// runtime order does not affect correctness because each detector covers a
+// distinct CVE ID.
+var registeredDetectors = []Detector{
+	// Add entries here, e.g.:
+	// &detectors.CVE_2024_12345{},
+}
+
+// Registered returns the list of registered detectors. Exported for tests and
+// for the runner; production code should call RunCustomDetectors instead.
+func Registered() []Detector {
+	return registeredDetectors
+}

--- a/internal/pentest/cve/runner.go
+++ b/internal/pentest/cve/runner.go
@@ -3,6 +3,7 @@ package cve
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -10,15 +11,20 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+// defaultDetectorThreads matches the documented default for pentest cve's
+// --threads flag (see cmd/pentest.go). Used only when callers leave
+// Options.Threads at its zero value.
+const defaultDetectorThreads = 25
+
 // Options mirrors the subset of PentestCveConfig that custom detectors care
-// about. The runner does not see thread/rate-limit knobs — those are nuclei
-// engine concerns. Concurrency for custom detectors is bounded per-target via
-// goroutines and ctx cancellation.
+// about. Threads bounds concurrent (target × detector) probes; without it a
+// large registry would open one goroutine per pair and overwhelm targets.
 type Options struct {
 	Targets  []string
 	Years    []string
 	Protocol string
 	Timeout  int
+	Threads  int
 }
 
 // RunCustomDetectors runs every registered Detector that passes the year and
@@ -37,44 +43,47 @@ func RunCustomDetectors(ctx context.Context, opts Options) ([]*nuclei.NucleiTarg
 		return nil, nil
 	}
 
+	threads := opts.Threads
+	if threads <= 0 {
+		threads = defaultDetectorThreads
+	}
+
 	log.Info("Running custom CVE detectors",
 		svc1log.SafeParam("detectors", len(active)),
-		svc1log.SafeParam("targets", len(opts.Targets)))
+		svc1log.SafeParam("targets", len(opts.Targets)),
+		svc1log.SafeParam("threads", threads))
 
-	type result struct {
-		target  string
-		attempt *nuclei.NucleiAttemptInfo
-		warn    string
+	type job struct {
+		target string
+		det    Detector
 	}
 
-	resultsCh := make(chan result, len(active)*len(opts.Targets))
+	jobs := make(chan job)
+	resultsCh := make(chan detectorResult, len(active)*len(opts.Targets))
 	var wg sync.WaitGroup
 
-	for _, target := range opts.Targets {
-		for _, det := range active {
-			wg.Add(1)
-			go func(target string, det Detector) {
-				defer wg.Done()
-				defer func() {
-					if r := recover(); r != nil {
-						resultsCh <- result{target: target, warn: fmt.Sprintf("detector %s panicked on %s: %v", det.CVEID(), target, r)}
-					}
-				}()
-				attempt, err := det.Detect(ctx, target, opts.Timeout)
-				if err != nil {
-					resultsCh <- result{target: target, warn: fmt.Sprintf("detector %s failed on %s: %v", det.CVEID(), target, err)}
-					return
-				}
-				if attempt == nil {
-					return
-				}
-				if attempt.TemplateId == "" {
-					attempt.TemplateId = det.CVEID()
-				}
-				resultsCh <- result{target: target, attempt: attempt}
-			}(target, det)
-		}
+	for i := 0; i < threads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				runOne(ctx, j.det, j.target, opts.Timeout, resultsCh)
+			}
+		}()
 	}
+
+	go func() {
+		defer close(jobs)
+		for _, target := range opts.Targets {
+			for _, det := range active {
+				select {
+				case <-ctx.Done():
+					return
+				case jobs <- job{target: target, det: det}:
+				}
+			}
+		}
+	}()
 
 	go func() {
 		wg.Wait()
@@ -99,6 +108,34 @@ func RunCustomDetectors(ctx context.Context, opts Options) ([]*nuclei.NucleiTarg
 	}
 
 	return ordered, warnings
+}
+
+type detectorResult struct {
+	target  string
+	attempt *nuclei.NucleiAttemptInfo
+	warn    string
+}
+
+// runOne wraps a single Detector.Detect call with panic recovery and sends
+// either an attempt or a warning to the result channel.
+func runOne(ctx context.Context, det Detector, target string, timeout int, out chan<- detectorResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			out <- detectorResult{target: target, warn: fmt.Sprintf("detector %s panicked on %s: %v", det.CVEID(), target, r)}
+		}
+	}()
+	attempt, err := det.Detect(ctx, target, timeout)
+	if err != nil {
+		out <- detectorResult{target: target, warn: fmt.Sprintf("detector %s failed on %s: %v", det.CVEID(), target, err)}
+		return
+	}
+	if attempt == nil {
+		return
+	}
+	if attempt.TemplateId == "" {
+		attempt.TemplateId = det.CVEID()
+	}
+	out <- detectorResult{target: target, attempt: attempt}
 }
 
 // filterDetectors keeps detectors whose Year is in years (if years is non-empty)
@@ -130,26 +167,53 @@ func filterDetectors(in []Detector, years []string, protocol string) []Detector 
 }
 
 // MergeTargets combines two NucleiTargetInfo slices keyed by Target string.
-// Attempts from b are appended to the matching target from a; targets present
-// only in b are appended in their original order. The slice from a is mutated
-// in place (its TargetInfo pointers gain extra attempts) but the input order
-// is preserved.
+//
+// The nuclei path keys by ev.URL — which for HTTP templates is "http://host:port"
+// and for network templates is "host:port". Custom detectors are handed the
+// raw --targets entry. To merge correctly across both shapes, we key by a
+// normalized form (host:port, scheme stripped, lowercased) so the same target
+// scanned by both paths collapses into one NucleiTargetInfo. The original
+// Target string on each entry is preserved (we don't rewrite the target the
+// nuclei report builder set).
 func MergeTargets(a, b []*nuclei.NucleiTargetInfo) []*nuclei.NucleiTargetInfo {
 	if len(b) == 0 {
 		return a
 	}
 	idx := make(map[string]*nuclei.NucleiTargetInfo, len(a))
 	for _, t := range a {
-		idx[t.Target] = t
+		idx[normalizeTargetKey(t.Target)] = t
 	}
 	merged := a
 	for _, t := range b {
-		if existing, ok := idx[t.Target]; ok {
+		key := normalizeTargetKey(t.Target)
+		if existing, ok := idx[key]; ok {
 			existing.Attempts = append(existing.Attempts, t.Attempts...)
 			continue
 		}
 		merged = append(merged, t)
-		idx[t.Target] = t
+		idx[key] = t
 	}
 	return merged
+}
+
+// normalizeTargetKey reduces a target string to a stable host:port key so the
+// raw --targets form ("1.2.3.4:22") and the URL form nuclei may emit
+// ("ssh://1.2.3.4:22", "http://1.2.3.4:80") collapse to the same value.
+// Returns the lower-cased input unchanged if no scheme is present and no URL
+// parse is possible — preserving today's behavior for anything we don't
+// recognize as a URL.
+func normalizeTargetKey(t string) string {
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return ""
+	}
+	lower := strings.ToLower(t)
+	if !strings.Contains(lower, "://") {
+		return lower
+	}
+	u, err := url.Parse(lower)
+	if err != nil || u.Host == "" {
+		return lower
+	}
+	return u.Host
 }

--- a/internal/pentest/cve/runner.go
+++ b/internal/pentest/cve/runner.go
@@ -1,0 +1,155 @@
+package cve
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	nuclei "github.com/Method-Security/networkscan/generated/go/common/nuclei"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// Options mirrors the subset of PentestCveConfig that custom detectors care
+// about. The runner does not see thread/rate-limit knobs — those are nuclei
+// engine concerns. Concurrency for custom detectors is bounded per-target via
+// goroutines and ctx cancellation.
+type Options struct {
+	Targets  []string
+	Years    []string
+	Protocol string
+	Timeout  int
+}
+
+// RunCustomDetectors runs every registered Detector that passes the year and
+// protocol filters against each target. Results are merged into a slice of
+// NucleiTargetInfo (one entry per target with at least one attempt), matching
+// the shape produced by utils/nuclei.RunNucleiEngine so the caller can append
+// the two slices and treat them uniformly.
+//
+// The second return value carries non-fatal warnings (e.g. per-detector
+// errors) using the same convention as RunNucleiEngine.
+func RunCustomDetectors(ctx context.Context, opts Options) ([]*nuclei.NucleiTargetInfo, []string) {
+	log := svc1log.FromContext(ctx)
+
+	active := filterDetectors(registeredDetectors, opts.Years, opts.Protocol)
+	if len(active) == 0 {
+		return nil, nil
+	}
+
+	log.Info("Running custom CVE detectors",
+		svc1log.SafeParam("detectors", len(active)),
+		svc1log.SafeParam("targets", len(opts.Targets)))
+
+	type result struct {
+		target  string
+		attempt *nuclei.NucleiAttemptInfo
+		warn    string
+	}
+
+	resultsCh := make(chan result, len(active)*len(opts.Targets))
+	var wg sync.WaitGroup
+
+	for _, target := range opts.Targets {
+		for _, det := range active {
+			wg.Add(1)
+			go func(target string, det Detector) {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						resultsCh <- result{target: target, warn: fmt.Sprintf("detector %s panicked on %s: %v", det.CVEID(), target, r)}
+					}
+				}()
+				attempt, err := det.Detect(ctx, target, opts.Timeout)
+				if err != nil {
+					resultsCh <- result{target: target, warn: fmt.Sprintf("detector %s failed on %s: %v", det.CVEID(), target, err)}
+					return
+				}
+				if attempt == nil {
+					return
+				}
+				if attempt.TemplateId == "" {
+					attempt.TemplateId = det.CVEID()
+				}
+				resultsCh <- result{target: target, attempt: attempt}
+			}(target, det)
+		}
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	targetIdx := make(map[string]*nuclei.NucleiTargetInfo)
+	var ordered []*nuclei.NucleiTargetInfo
+	var warnings []string
+	for r := range resultsCh {
+		if r.warn != "" {
+			warnings = append(warnings, r.warn)
+			continue
+		}
+		info, ok := targetIdx[r.target]
+		if !ok {
+			info = &nuclei.NucleiTargetInfo{Target: r.target}
+			targetIdx[r.target] = info
+			ordered = append(ordered, info)
+		}
+		info.Attempts = append(info.Attempts, r.attempt)
+	}
+
+	return ordered, warnings
+}
+
+// filterDetectors keeps detectors whose Year is in years (if years is non-empty)
+// and whose Protocol matches protocol (case-insensitive; empty Protocol on the
+// detector matches any caller protocol).
+func filterDetectors(in []Detector, years []string, protocol string) []Detector {
+	yearSet := make(map[string]struct{}, len(years))
+	for _, y := range years {
+		yearSet[y] = struct{}{}
+	}
+	wantProtocol := strings.ToUpper(strings.TrimSpace(protocol))
+
+	var out []Detector
+	for _, d := range in {
+		if len(yearSet) > 0 {
+			if _, ok := yearSet[d.Year()]; !ok {
+				continue
+			}
+		}
+		if wantProtocol != "" {
+			dp := strings.ToUpper(strings.TrimSpace(d.Protocol()))
+			if dp != "" && dp != wantProtocol {
+				continue
+			}
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// MergeTargets combines two NucleiTargetInfo slices keyed by Target string.
+// Attempts from b are appended to the matching target from a; targets present
+// only in b are appended in their original order. The slice from a is mutated
+// in place (its TargetInfo pointers gain extra attempts) but the input order
+// is preserved.
+func MergeTargets(a, b []*nuclei.NucleiTargetInfo) []*nuclei.NucleiTargetInfo {
+	if len(b) == 0 {
+		return a
+	}
+	idx := make(map[string]*nuclei.NucleiTargetInfo, len(a))
+	for _, t := range a {
+		idx[t.Target] = t
+	}
+	merged := a
+	for _, t := range b {
+		if existing, ok := idx[t.Target]; ok {
+			existing.Attempts = append(existing.Attempts, t.Attempts...)
+			continue
+		}
+		merged = append(merged, t)
+		idx[t.Target] = t
+	}
+	return merged
+}


### PR DESCRIPTION
## Summary

Adds a second execution path to `pentest cve` for CVE checks that can't be expressed as nuclei templates. Custom Go detectors implement a `Detector` interface, get registered in a slice, and emit the same `NucleiAttemptInfo` Fern shape that nuclei produces — so `PerformCVEScan` merges both paths into one `PentestCveReport` with no downstream changes.

Mirrors the `internal/discover/service` pattern where fingerprintx (external) and local plugins both feed `ServiceDetails`.

- `internal/pentest/cve/detector.go` — `Detector` interface (`CVEID / Year / Protocol / Detect`)
- `internal/pentest/cve/registry.go` — empty `registeredDetectors` slice; append new CVE types here
- `internal/pentest/cve/runner.go` — filters by `--years` + `--protocol`, runs detectors per-target concurrently with panic recovery, merges by target string
- `internal/pentest/cve/detectors/doc.go` — pattern + copy-paste skeleton for new CVE files
- `internal/pentest/cve.go` — calls both engines, merges results
- `CLAUDE.md` — "CVE Detection — Two Execution Paths, One Report" section documenting the choice between nuclei vs Go and the add-a-detector flow

When `--template-paths` is set, custom detectors are skipped (matching how that flag turns off the year/protocol filters for nuclei).

No Fern type changes. Registry is empty in this PR — future PRs add one detector per CVE.

## Test plan
- [ ] `./godelw verify` passes
- [ ] `./godelw build` produces a working binary
- [ ] `pentest cve --targets <ip>:<port> --protocol HTTP --years 2024` still runs the existing nuclei path unchanged
- [ ] Add a throwaway test detector locally, register it, and confirm its `NucleiAttemptInfo` appears in the merged report under the correct target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Orchestration changes how CVE scans run and probe targets concurrently; merge-key normalization affects report grouping, though behavior is additive with an empty registry until detectors land.
> 
> **Overview**
> **`pentest cve` now runs nuclei and a pluggable Go detector registry, then merges both into the same `PentestCveReport`** without new Fern types. Custom checks implement `cve.Detector` (`CVEID`, `Year`, `Protocol`, `Detect`), emit `NucleiAttemptInfo`, and register in `registry.go` (empty in this PR).
> 
> `PerformCVEScan` calls `RunCustomDetectors` with the same `--years`, `--protocol`, `--timeout`, and `--threads` as nuclei when `--template-paths` is **not** set; explicit template paths skip the custom path entirely. The runner filters detectors, runs target×detector work on a worker pool with panic recovery, and `MergeTargets` normalizes host:port vs URL-shaped targets so attempts from both paths land on one `NucleiTargetInfo` per host.
> 
> `CLAUDE.md` documents the two-path model and how to add detectors under `internal/pentest/cve/detectors/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deb8c9f986afcb260cfd3115a1a1fa47e6621e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->