### PR TITLE
Classify connection-failure cause in enumerate logs/reports

### DIFF
--- a/internal/enumerate/ftp/ftp.go
+++ b/internal/enumerate/ftp/ftp.go
@@ -9,6 +9,9 @@ import (
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	ftp "github.com/Method-Security/networkscan/generated/go/enumerate/ftp"
 
+	// Utils
+	utils "github.com/Method-Security/networkscan/utils"
+
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -57,8 +60,12 @@ func (f *LibraryEnumerateFTP) EnumerateTarget(ctx context.Context, target string
 	// Attempt to connect to the target
 	conn, err := attemptConnection(ctx, target)
 	if err != nil {
-		log.Error("Failed to connect to FTP target", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
-		errors = append(errors, fmt.Sprintf("Failed to connect to %s: %v", target, err))
+		detail := utils.ClassifyNetError(err)
+		log.Error("Failed to connect to FTP target",
+			svc1log.SafeParam("target", target),
+			svc1log.SafeParam("category", string(detail.Category)),
+			svc1log.SafeParam("error", detail.Cause))
+		errors = append(errors, fmt.Sprintf("failed to connect to %s [%s]: %s", target, detail.Category, detail.Cause))
 		return &enumeratefern.EnumerateServiceDetails{EnumerateFtpDetails: &details}, errors
 	}
 

--- a/internal/enumerate/ike/ike.go
+++ b/internal/enumerate/ike/ike.go
@@ -11,6 +11,7 @@ import (
 	enumeratefern "github.com/Method-Security/networkscan/generated/go/enumerate"
 	ikefern "github.com/Method-Security/networkscan/generated/go/enumerate/ike"
 	ikeprotocol "github.com/Method-Security/networkscan/internal/protocol/ike"
+	utils "github.com/Method-Security/networkscan/utils"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
@@ -44,7 +45,11 @@ func (l *LibraryEnumerateIKE) EnumerateTarget(ctx context.Context, target string
 	// IKEv2 probe
 	ikev2Response, err := probeUDP(ctx, target, ikeprotocol.BuildIKEv2SAInitRequest())
 	if err != nil {
-		log.Warn("IKEv2 probe failed", svc1log.SafeParam("target", target), svc1log.SafeParam("error", err))
+		detail := utils.ClassifyNetError(err)
+		log.Warn("IKEv2 probe failed",
+			svc1log.SafeParam("target", target),
+			svc1log.SafeParam("category", string(detail.Category)),
+			svc1log.SafeParam("error", detail.Cause))
 	} else if len(ikev2Response) >= 28 && isPlausibleIKEPacket(ikev2Response) {
 		applyIKEv2ResponseToServerInfo(ikev2Response, &serverInfo)
 		if serverInfo.Ikev2Supported != nil {

--- a/utils/neterrors.go
+++ b/utils/neterrors.go
@@ -1,0 +1,152 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"syscall"
+)
+
+// NetErrorCategory is a stable, coarse classification of a failed outbound
+// connection/probe. It is the closest thing to an "error code" an operator can
+// filter and triage on when a scan never reaches the target — the common shape
+// when egress is blocked by a firewall or routed through a restricted network.
+type NetErrorCategory string
+
+const (
+	NetErrorDNS           NetErrorCategory = "dns_resolution_failed"
+	NetErrorConnRefused   NetErrorCategory = "connection_refused"
+	NetErrorConnReset     NetErrorCategory = "connection_reset"
+	NetErrorTimeout       NetErrorCategory = "timeout"
+	NetErrorTLS           NetErrorCategory = "tls_error"
+	NetErrorNoRouteToHost NetErrorCategory = "no_route_to_host"
+	NetErrorNetworkDown   NetErrorCategory = "network_unreachable"
+	NetErrorCanceled      NetErrorCategory = "canceled"
+	NetErrorOther         NetErrorCategory = "network_error"
+)
+
+// NetErrorDetail is an operator-facing description of a failed connection. Cause
+// is always the fully unwrapped error string (never a reflected struct), and the
+// remaining fields name the layer that failed.
+type NetErrorDetail struct {
+	Category NetErrorCategory
+	Cause    string
+	Op       string
+	Network  string
+	Address  string
+}
+
+// String renders the detail as a single human-readable line.
+func (d NetErrorDetail) String() string {
+	var b strings.Builder
+	b.WriteString(string(d.Category))
+	if d.Address != "" {
+		fmt.Fprintf(&b, " (%s", d.Address)
+		if d.Network != "" {
+			fmt.Fprintf(&b, "/%s", d.Network)
+		}
+		b.WriteString(")")
+	}
+	if d.Cause != "" {
+		fmt.Fprintf(&b, ": %s", d.Cause)
+	}
+	return b.String()
+}
+
+// ClassifyNetError unwraps a Go network error (typically *net.OpError wrapping
+// *net.DNSError / x509 / tls / syscall errors, possibly nested in *url.Error)
+// into a stable category plus the underlying cause and the failing layer, so a
+// probe that never reaches the target reports *why* (dns/refused/reset/no-route/
+// tls/timeout) instead of an opaque struct dump.
+func ClassifyNetError(err error) NetErrorDetail {
+	if err == nil {
+		return NetErrorDetail{}
+	}
+	detail := NetErrorDetail{Category: NetErrorOther, Cause: err.Error()}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		detail.Op = opErr.Op
+		detail.Network = opErr.Net
+		if opErr.Addr != nil {
+			detail.Address = opErr.Addr.String()
+		}
+	}
+
+	switch {
+	case errors.Is(err, context.Canceled):
+		detail.Category = NetErrorCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		detail.Category = NetErrorTimeout
+	case classifyDNS(err, &detail):
+		detail.Category = NetErrorDNS
+	case classifyTLS(err):
+		detail.Category = NetErrorTLS
+	case classifySyscall(err, &detail):
+		// category set by classifySyscall
+	case isTimeout(err):
+		detail.Category = NetErrorTimeout
+	}
+	return detail
+}
+
+func classifyDNS(err error, detail *NetErrorDetail) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		if dnsErr.Name != "" {
+			detail.Address = dnsErr.Name
+		}
+		return true
+	}
+	return false
+}
+
+func classifyTLS(err error) bool {
+	var (
+		unknownAuthority x509.UnknownAuthorityError
+		hostnameErr      x509.HostnameError
+		invalidCert      x509.CertificateInvalidError
+		certVerifyErr    *tls.CertificateVerificationError
+		recordHeaderErr  *tls.RecordHeaderError
+	)
+	if errors.As(err, &unknownAuthority) ||
+		errors.As(err, &hostnameErr) ||
+		errors.As(err, &invalidCert) ||
+		errors.As(err, &certVerifyErr) ||
+		errors.As(err, &recordHeaderErr) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "tls:") || strings.Contains(msg, "x509:")
+}
+
+func classifySyscall(err error, detail *NetErrorDetail) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	switch errno {
+	case syscall.ECONNREFUSED:
+		detail.Category = NetErrorConnRefused
+	case syscall.ECONNRESET, syscall.EPIPE:
+		detail.Category = NetErrorConnReset
+	case syscall.EHOSTUNREACH:
+		detail.Category = NetErrorNoRouteToHost
+	case syscall.ENETUNREACH, syscall.ENETDOWN:
+		detail.Category = NetErrorNetworkDown
+	case syscall.ETIMEDOUT:
+		detail.Category = NetErrorTimeout
+	default:
+		return false
+	}
+	return true
+}
+
+func isTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/utils/neterrors_test.go
+++ b/utils/neterrors_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func dialErr(inner error) error {
+	return &net.OpError{
+		Op:   "dial",
+		Net:  "tcp",
+		Addr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 21},
+		Err:  inner,
+	}
+}
+
+func TestClassifyNetError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		category NetErrorCategory
+		wantAddr string
+	}{
+		{name: "connection refused", err: dialErr(os.NewSyscallError("connect", syscall.ECONNREFUSED)), category: NetErrorConnRefused, wantAddr: "1.2.3.4:21"},
+		{name: "connection reset", err: dialErr(os.NewSyscallError("read", syscall.ECONNRESET)), category: NetErrorConnReset},
+		{name: "no route to host", err: dialErr(os.NewSyscallError("connect", syscall.EHOSTUNREACH)), category: NetErrorNoRouteToHost},
+		{name: "network unreachable", err: dialErr(os.NewSyscallError("connect", syscall.ENETUNREACH)), category: NetErrorNetworkDown},
+		{name: "syscall timeout", err: dialErr(os.NewSyscallError("connect", syscall.ETIMEDOUT)), category: NetErrorTimeout},
+		{name: "dns not found", err: &net.DNSError{Name: "nope.example.com", IsNotFound: true}, category: NetErrorDNS, wantAddr: "nope.example.com"},
+		{name: "context deadline", err: context.DeadlineExceeded, category: NetErrorTimeout},
+		{name: "context canceled", err: context.Canceled, category: NetErrorCanceled},
+		{name: "tls unknown authority", err: x509.UnknownAuthorityError{}, category: NetErrorTLS},
+		{name: "tls string", err: errors.New("tls: handshake failure"), category: NetErrorTLS},
+		{name: "unknown", err: errors.New("weird failure"), category: NetErrorOther},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detail := ClassifyNetError(tt.err)
+			if detail.Category != tt.category {
+				t.Fatalf("category = %q, want %q (cause=%q)", detail.Category, tt.category, detail.Cause)
+			}
+			if detail.Cause == "" {
+				t.Fatalf("cause must never be empty for %v", tt.err)
+			}
+			if tt.wantAddr != "" && detail.Address != tt.wantAddr {
+				t.Fatalf("address = %q, want %q", detail.Address, tt.wantAddr)
+			}
+			if detail.String() == "" {
+				t.Fatalf("String() must not be empty")
+			}
+		})
+	}
+}
+
+func TestClassifyNetErrorNil(t *testing.T) {
+	if got := ClassifyNetError(nil); got.Category != "" || got.Cause != "" {
+		t.Fatalf("nil error should classify to empty detail, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Problem
Like webscan, outbound probe failures were logged with
`svc1log.SafeParam("error", err)`, which reflects `*net.OpError` into a struct
and drops the underlying reason. When a scan is blocked by a firewall the
operator sees no usable cause.

## Change
- New `utils/neterrors.go` → `ClassifyNetError(err)` unwraps the error chain
  (`net.OpError` / `net.DNSError` / `x509` / `tls` / `syscall`) into a stable
  **category**: `dns_resolution_failed`, `connection_refused`,
  `connection_reset`, `timeout`, `tls_error`, `no_route_to_host`,
  `network_unreachable`, `canceled`, `network_error` — plus the full unwrapped
  cause and the failing network layer.
- Wired into the FTP connect failure and the IKEv2 probe failure: both the log
  line (`category` + string `error`) and the report's `Errors[]` now name *why*
  the connection failed.
- Classifier unit tests.

This is the networkscan companion to webscan's transport-error logging PR. The
same helper can be extended to the other enumerate/protocol dial sites (smtp,
pop3, ssh, smb, ldap) in follow-ups; this PR establishes the helper + pattern on
the clearest connection-failure paths and avoids files in flight on other PRs.

## Test plan
- [x] `go test ./utils/...`
- [x] `go build` + `go vet` the changed packages
- [ ] CI green

Made with [Cursor](https://cursor.com)