### PR TITLE
Dedupe Oracle Protocol

### DIFF
--- a/fern/definition/common/common.yml
+++ b/fern/definition/common/common.yml
@@ -70,7 +70,7 @@ types:
       - NTP
       - OPCUA
       - OPENVPN
-      - ORACLE
+      - ORACLEDB
       - PCOM
       - PCWORX
       - POP3

--- a/internal/discover/service/plugins/oracle.go
+++ b/internal/discover/service/plugins/oracle.go
@@ -144,7 +144,7 @@ func buildOracleResult(host string, ip net.IP, port int, body string) *discoverf
 		Tls:       false,
 		Version:   &version,
 		Transport: common.TransportTypeTcp,
-		Protocol:  common.ProtocolTypeOracle,
+		Protocol:  common.ProtocolTypeOracledb,
 		Metadata:  &discoverfern.ServiceMetadata{Oracle: info},
 	}
 }

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -461,7 +461,12 @@ func fxToServiceDetails(result *plugins.Service) *discoverfern.ServiceDetails {
 			return common.TransportTypeUnknown
 		}(),
 		Protocol: func() common.ProtocolType {
-			if protocol, err := common.NewProtocolTypeFromString(strings.ToUpper(result.Protocol)); err == nil {
+			protocolName := strings.ToUpper(result.Protocol)
+			// fingerprintx labels the Oracle TNS service "oracle"; our enum calls it ORACLEDB.
+			if protocolName == "ORACLE" {
+				protocolName = "ORACLEDB"
+			}
+			if protocol, err := common.NewProtocolTypeFromString(protocolName); err == nil {
 				return protocol
 			}
 			return common.ProtocolTypeUnknown


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enum rename is a breaking API change for consumers expecting `ORACLE` in discovery payloads; runtime mapping limits misclassification from fingerprintx but pentest spray still uses a separate `ORACLE` service enum.
> 
> **Overview**
> **Standardizes Oracle TNS discovery on a single protocol enum value: `ORACLEDB`.**
> 
> The Fern `ProtocolType` enum drops `ORACLE` in favor of `ORACLEDB`. The custom Oracle fingerprinter now reports `ProtocolTypeOracledb`, and `fxToServiceDetails` maps fingerprintx’s uppercase `ORACLE` string to `ORACLEDB` before enum parsing so Phase 2 results align with the custom probe instead of falling back to `UNKNOWN` or duplicating labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fcfb961aeb8a0bf31f5f90f29cf58f791b19b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->