### PR TITLE
Add --continue-on-error flag and fix --stop-on-first-success Fern

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -211,11 +211,6 @@ Additional actions can be specified to layer more functionality on top.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
-			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -259,7 +254,7 @@ Additional actions can be specified to layer more functionality on top.`,
 			}
 
 			// Set Config
-			config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, remoteFilePath, timeout, stopFirstSuccess, continueOnError, successfulOnly, domain, ntlmHash, localAuth, anonymous, maxFileSizeBytes, shareName)
+			config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, remoteFilePath, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, localAuth, anonymous, maxFileSizeBytes, shareName)
 
 			// Generate the report
 			report, err := smbpentest.RunPentest(cmd.Context(), config)
@@ -285,7 +280,6 @@ Additional actions can be specified to layer more functionality on top.`,
 	pentestSMBCmd.Flags().String("remote-file-path", "", "Remote file path to download (format: SHARE\\path\\to\\file)")
 	pentestSMBCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestSMBCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
-	pentestSMBCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestSMBCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	pentestSMBCmd.Flags().Bool("verbose", false, "Verbose output")
 	pentestSMBCmd.Flags().Bool("anonymous", false, "Use null session (anonymous authentication, no credentials required)")
@@ -365,11 +359,6 @@ Additional actions can be specified to layer more functionality on top.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
-			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -386,7 +375,7 @@ Additional actions can be specified to layer more functionality on top.`,
 			}
 
 			// Set Config
-			config := getSSHPentestConfig(targets, actions, usernames, passwords, commands, uploadFiles, downloads, timeout, stopFirstSuccess, continueOnError, successfulOnly, keyFile)
+			config := getSSHPentestConfig(targets, actions, usernames, passwords, commands, uploadFiles, downloads, timeout, stopFirstSuccess, successfulOnly, keyFile)
 
 			// Generate the report
 			report, err := sshpentest.RunPentest(cmd.Context(), config)
@@ -410,7 +399,6 @@ Additional actions can be specified to layer more functionality on top.`,
 	pentestSSHCmd.Flags().StringSlice("download", []string{}, "Remote files to download")
 	pentestSSHCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestSSHCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
-	pentestSSHCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestSSHCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	_ = pentestSSHCmd.MarkFlagRequired("targets")
 
@@ -469,11 +457,6 @@ Additional actions can be specified to layer more functionality on top.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
-			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -481,7 +464,7 @@ Additional actions can be specified to layer more functionality on top.`,
 			}
 
 			// Set Config
-			config := getTelnetPentestConfig(targets, actions, usernames, passwords, commands, timeout, stopFirstSuccess, continueOnError, successfulOnly)
+			config := getTelnetPentestConfig(targets, actions, usernames, passwords, commands, timeout, stopFirstSuccess, successfulOnly)
 
 			// Generate the report
 			report, err := telnetpentest.RunPentest(cmd.Context(), config)
@@ -502,7 +485,6 @@ Additional actions can be specified to layer more functionality on top.`,
 	pentestTelnetCmd.Flags().String("command-file", "", "File containing commands to execute")
 	pentestTelnetCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestTelnetCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
-	pentestTelnetCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestTelnetCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	_ = pentestTelnetCmd.MarkFlagRequired("targets")
 
@@ -575,11 +557,6 @@ Additional actions can be specified to layer more functionality on top.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
-			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -639,7 +616,7 @@ Additional actions can be specified to layer more functionality on top.`,
 			}
 
 			// Set Config
-			config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, continueOnError, successfulOnly, domain, ntlmHash, localAuth, sleep, jitter, maxQueries, minimalQueries, collectionMethods)
+			config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, localAuth, sleep, jitter, maxQueries, minimalQueries, collectionMethods)
 			config.SearchConfig = searchConfig
 
 			// Generate the report
@@ -663,7 +640,6 @@ Additional actions can be specified to layer more functionality on top.`,
 	pentestLDAPCmd.Flags().Bool("local-auth", false, "Force authentication against local account instead of domain")
 	pentestLDAPCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestLDAPCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
-	pentestLDAPCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestLDAPCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	pentestLDAPCmd.Flags().Int("sleep", 0, "Delay in seconds between LDAP queries for stealth mode")
 	pentestLDAPCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delays")
@@ -763,7 +739,6 @@ For Kerberos password spraying use: pentest spray --service KERBEROS`,
 	pentestKerberosCmd.Flags().StringSlice("principals", []string{}, "Candidate principals for AS_REP_ROAST / USER_ENUM (defaults to --usernames)")
 	pentestKerberosCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds (per AS-REQ / TGS-REQ exchange)")
 	pentestKerberosCmd.Flags().StringSlice("etypes", []string{"AES256_CTS_HMAC_SHA1_96", "AES128_CTS_HMAC_SHA1_96", "RC4_HMAC"}, "Kerberos etype preference order (AES256_CTS_HMAC_SHA1_96, AES128_CTS_HMAC_SHA1_96, RC4_HMAC)")
-	pentestKerberosCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	_ = pentestKerberosCmd.MarkFlagRequired("targets")
 
 	// Add Command to 'Service' Command
@@ -798,7 +773,6 @@ For Kerberos password spraying use: pentest spray --service KERBEROS`,
 	pentestMSRPCCmd.Flags().String("domain", "", "Domain name (required for DCSync)")
 	pentestMSRPCCmd.Flags().StringSlice("actions", []string{}, "Actions to perform: DCSYNC (required)")
 	pentestMSRPCCmd.Flags().Int("timeout", 10, "Connection timeout in seconds")
-	pentestMSRPCCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	_ = pentestMSRPCCmd.MarkFlagRequired("targets")
 	_ = pentestMSRPCCmd.MarkFlagRequired("actions")
 	_ = pentestMSRPCCmd.MarkFlagRequired("domain")
@@ -884,11 +858,6 @@ Supports authentication testing and command execution via WinRM protocol.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
-			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -896,7 +865,7 @@ Supports authentication testing and command execution via WinRM protocol.`,
 			}
 
 			// Set Config
-			config := getWinRMPentestConfig(targets, actions, usernames, passwords, commands, domain, localAuth, port, useHTTPS, insecure, timeout, stopFirstSuccess, continueOnError, successfulOnly)
+			config := getWinRMPentestConfig(targets, actions, usernames, passwords, commands, domain, localAuth, port, useHTTPS, insecure, timeout, stopFirstSuccess, successfulOnly)
 
 			// Generate the report
 			report, err := winrmpentest.RunPentest(cmd.Context(), config)
@@ -922,7 +891,6 @@ Supports authentication testing and command execution via WinRM protocol.`,
 	pentestWinRMCmd.Flags().Bool("insecure", false, "Skip TLS certificate verification")
 	pentestWinRMCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestWinRMCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
-	pentestWinRMCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestWinRMCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	_ = pentestWinRMCmd.MarkFlagRequired("targets")
 
@@ -1025,19 +993,13 @@ file download (DOWNLOAD), and file upload (UPLOAD).`,
 				a.OutputSignal.AddError(err)
 				return
 			}
-			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 
 			// Set Config
 			config := getFTPPentestConfig(targets, actions, usernames, passwords, domain, timeout,
 				paths, recursive, maxDepth,
 				remotePaths,
 				contents,
-				maxFileSize,
-				continueOnError)
+				maxFileSize)
 
 			// Generate the report
 			report, err := ftppentest.RunPentest(cmd.Context(), config, dataMode)
@@ -1061,7 +1023,6 @@ file download (DOWNLOAD), and file upload (UPLOAD).`,
 	pentestFTPCmd.Flags().Int64("max-file-size", 1048576, "Max file size in bytes for DOWNLOAD/UPLOAD (default 1MB)")
 	pentestFTPCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestFTPCmd.Flags().String("data-mode", "auto", "FTP data connection mode: auto, passive, or active")
-	pentestFTPCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	_ = pentestFTPCmd.MarkFlagRequired("targets")
 
 	// Add Command to 'Service' Command
@@ -2583,14 +2544,13 @@ func getSprayPasswordPentestConfig(targets []string, service pentestfern.SprayTa
 			Timeout:            timeout,
 			StopOnFirstSuccess: stopFirstSuccess,
 			SuccessfulOnly:     successfulOnly,
-			ContinueOnError:    true,
 			Stealth:            stealthConfig,
 		},
 	}
 }
 
 // getSMBPentestConfig creates a configuration for SMB pentest operations with the provided parameters.
-func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, remoteFilePath string, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, anonymous bool, maxFileSize int64, shareName string) *smbfern.PentestSmbConfig {
+func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, remoteFilePath string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, anonymous bool, maxFileSize int64, shareName string) *smbfern.PentestSmbConfig {
 	var domainPtr, ntlmHashPtr *string
 	var localAuthPtr *bool
 	if domain != "" {
@@ -2643,13 +2603,12 @@ func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, u
 		SharesMapConfig:     sharesMapConfig,
 		Timeout:             timeout,
 		StopOnFirstSuccess:  &stopFirstSuccess,
-		ContinueOnError:     &continueOnError,
 		SuccessfulOnly:      &successfulOnly,
 	}
 }
 
 // getSSHPentestConfig creates a configuration for SSH pentest operations with the provided parameters.
-func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
+func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, stopFirstSuccess bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
 	var keyFilePtr *string
 	if keyFile != "" {
 		keyFilePtr = &keyFile
@@ -2687,13 +2646,12 @@ func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, u
 		FileTransferConfig: fileTransferConfig,
 		Timeout:            timeout,
 		StopOnFirstSuccess: &stopFirstSuccess,
-		ContinueOnError:    &continueOnError,
 		SuccessfulOnly:     &successfulOnly,
 	}
 }
 
 // getTelnetPentestConfig creates a configuration for Telnet pentest operations with the provided parameters.
-func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnetAction, usernames []string, passwords []string, commands []string, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
+func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnetAction, usernames []string, passwords []string, commands []string, timeout int, stopFirstSuccess bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
 	var execConfig *telnetfern.ExecConfig
 	if len(commands) > 0 {
 		execConfig = &telnetfern.ExecConfig{
@@ -2708,14 +2666,13 @@ func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnet
 		Passwords:          passwords,
 		Timeout:            timeout,
 		StopOnFirstSuccess: &stopFirstSuccess,
-		ContinueOnError:    &continueOnError,
 		SuccessfulOnly:     &successfulOnly,
 		ExecConfig:         execConfig,
 	}
 }
 
 // getLDAPPentestConfig creates a configuration for LDAP pentest operations with the provided parameters.
-func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, sleep int, jitter int, maxQueries int, minimalQueries bool, collectionMethods []ldapfern.CollectionMethod) *ldapfern.PentestLdapConfig {
+func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, sleep int, jitter int, maxQueries int, minimalQueries bool, collectionMethods []ldapfern.CollectionMethod) *ldapfern.PentestLdapConfig {
 	var domainPtr, ntlmHashPtr *string
 	var localAuthPtr *bool
 	if domain != "" {
@@ -2777,7 +2734,6 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 		LocalAuth:          localAuthPtr,
 		Timeout:            timeout,
 		StopOnFirstSuccess: &stopFirstSuccess,
-		ContinueOnError:    &continueOnError,
 		SuccessfulOnly:     &successfulOnly,
 		DomaindumpConfig:   domainDumpConfig,
 	}
@@ -2878,10 +2834,6 @@ func getKerberosConfig(cmd *cobra.Command, targets []string, actions []kerberosf
 	if err != nil {
 		return nil, err
 	}
-	continueOnError, err := cmd.Flags().GetBool("continue-on-error")
-	if err != nil {
-		return nil, err
-	}
 	var domainPtr *string
 	if domain != "" {
 		domainPtr = &domain
@@ -2958,7 +2910,6 @@ func getKerberosConfig(cmd *cobra.Command, targets []string, actions []kerberosf
 		Domain:              domainPtr,
 		NtlmHash:            ntlmHashPtr,
 		Timeout:             timeout,
-		ContinueOnError:     &continueOnError,
 		ServiceTicketConfig: serviceTicketConfig,
 		AsRepRoastConfig:    asRepRoastConfig,
 		KerberoastConfig:    kerberoastConfig,
@@ -3002,11 +2953,6 @@ func getMSRPCPentestConfig(cmd *cobra.Command) (*msrpcfern.PentestMsrpcConfig, e
 		return nil, err
 	}
 
-	continueOnError, err := cmd.Flags().GetBool("continue-on-error")
-	if err != nil {
-		return nil, err
-	}
-
 	actionParser := utils.GetMSRPCParser()
 	actions, err := actionParser.ParseActions(actionStrings)
 	if err != nil {
@@ -3043,21 +2989,20 @@ func getMSRPCPentestConfig(cmd *cobra.Command) (*msrpcfern.PentestMsrpcConfig, e
 	}
 
 	return &msrpcfern.PentestMsrpcConfig{
-		Targets:         targets,
-		Actions:         actions,
-		Usernames:       usernames,
-		Passwords:       passwords,
-		NtlmHash:        ntlmHashPtr,
-		KerberosTicket:  kerberosTicketPtr,
-		Domain:          domainPtr,
-		Timeout:         timeout,
-		ContinueOnError: &continueOnError,
-		DcsyncConfig:    dcsyncConfig,
+		Targets:        targets,
+		Actions:        actions,
+		Usernames:      usernames,
+		Passwords:      passwords,
+		NtlmHash:       ntlmHashPtr,
+		KerberosTicket: kerberosTicketPtr,
+		Domain:         domainPtr,
+		Timeout:        timeout,
+		DcsyncConfig:   dcsyncConfig,
 	}, nil
 }
 
 // getWinRMPentestConfig creates a configuration for WinRM pentest operations with the provided parameters
-func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAction, usernames []string, passwords []string, commands []string, domain string, localAuth bool, port int, useHTTPS bool, insecure bool, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool) *winrmfern.PentestWinrmConfig {
+func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAction, usernames []string, passwords []string, commands []string, domain string, localAuth bool, port int, useHTTPS bool, insecure bool, timeout int, stopFirstSuccess bool, successfulOnly bool) *winrmfern.PentestWinrmConfig {
 	var domainPtr *string
 	var localAuthPtr *bool
 	if domain != "" {
@@ -3092,7 +3037,6 @@ func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAct
 		ExecConfig:         execConfig,
 		Timeout:            timeout,
 		StopOnFirstSuccess: &stopFirstSuccess,
-		ContinueOnError:    &continueOnError,
 		SuccessfulOnly:     &successfulOnly,
 	}
 }
@@ -3140,15 +3084,13 @@ func getFTPPentestConfig(
 	remotePaths []string,
 	contents []string,
 	maxFileSize int64,
-	continueOnError bool,
 ) *ftpfern.PentestFtpConfig {
 	config := &ftpfern.PentestFtpConfig{
-		Targets:         targets,
-		Actions:         actions,
-		Usernames:       usernames,
-		Passwords:       passwords,
-		Timeout:         timeout,
-		ContinueOnError: &continueOnError,
+		Targets:   targets,
+		Actions:   actions,
+		Usernames: usernames,
+		Passwords: passwords,
+		Timeout:   timeout,
 	}
 	if domain != "" {
 		config.Domain = &domain

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -211,6 +211,11 @@ Additional actions can be specified to layer more functionality on top.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
+			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -254,7 +259,7 @@ Additional actions can be specified to layer more functionality on top.`,
 			}
 
 			// Set Config
-			config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, remoteFilePath, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, localAuth, anonymous, maxFileSizeBytes, shareName)
+			config := getSMBPentestConfig(targets, actions, usernames, passwords, commands, remoteFilePath, timeout, stopFirstSuccess, continueOnError, successfulOnly, domain, ntlmHash, localAuth, anonymous, maxFileSizeBytes, shareName)
 
 			// Generate the report
 			report, err := smbpentest.RunPentest(cmd.Context(), config)
@@ -280,6 +285,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	pentestSMBCmd.Flags().String("remote-file-path", "", "Remote file path to download (format: SHARE\\path\\to\\file)")
 	pentestSMBCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestSMBCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
+	pentestSMBCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestSMBCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	pentestSMBCmd.Flags().Bool("verbose", false, "Verbose output")
 	pentestSMBCmd.Flags().Bool("anonymous", false, "Use null session (anonymous authentication, no credentials required)")
@@ -359,6 +365,11 @@ Additional actions can be specified to layer more functionality on top.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
+			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -375,7 +386,7 @@ Additional actions can be specified to layer more functionality on top.`,
 			}
 
 			// Set Config
-			config := getSSHPentestConfig(targets, actions, usernames, passwords, commands, uploadFiles, downloads, timeout, stopFirstSuccess, successfulOnly, keyFile)
+			config := getSSHPentestConfig(targets, actions, usernames, passwords, commands, uploadFiles, downloads, timeout, stopFirstSuccess, continueOnError, successfulOnly, keyFile)
 
 			// Generate the report
 			report, err := sshpentest.RunPentest(cmd.Context(), config)
@@ -399,6 +410,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	pentestSSHCmd.Flags().StringSlice("download", []string{}, "Remote files to download")
 	pentestSSHCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestSSHCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
+	pentestSSHCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestSSHCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	_ = pentestSSHCmd.MarkFlagRequired("targets")
 
@@ -457,6 +469,11 @@ Additional actions can be specified to layer more functionality on top.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
+			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -464,7 +481,7 @@ Additional actions can be specified to layer more functionality on top.`,
 			}
 
 			// Set Config
-			config := getTelnetPentestConfig(targets, actions, usernames, passwords, commands, timeout, stopFirstSuccess, successfulOnly)
+			config := getTelnetPentestConfig(targets, actions, usernames, passwords, commands, timeout, stopFirstSuccess, continueOnError, successfulOnly)
 
 			// Generate the report
 			report, err := telnetpentest.RunPentest(cmd.Context(), config)
@@ -485,6 +502,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	pentestTelnetCmd.Flags().String("command-file", "", "File containing commands to execute")
 	pentestTelnetCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestTelnetCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
+	pentestTelnetCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestTelnetCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	_ = pentestTelnetCmd.MarkFlagRequired("targets")
 
@@ -557,6 +575,11 @@ Additional actions can be specified to layer more functionality on top.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
+			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -616,7 +639,7 @@ Additional actions can be specified to layer more functionality on top.`,
 			}
 
 			// Set Config
-			config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, successfulOnly, domain, ntlmHash, localAuth, sleep, jitter, maxQueries, minimalQueries, collectionMethods)
+			config := getLDAPPentestConfig(targets, actions, usernames, passwords, timeout, stopFirstSuccess, continueOnError, successfulOnly, domain, ntlmHash, localAuth, sleep, jitter, maxQueries, minimalQueries, collectionMethods)
 			config.SearchConfig = searchConfig
 
 			// Generate the report
@@ -640,6 +663,7 @@ Additional actions can be specified to layer more functionality on top.`,
 	pentestLDAPCmd.Flags().Bool("local-auth", false, "Force authentication against local account instead of domain")
 	pentestLDAPCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestLDAPCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
+	pentestLDAPCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestLDAPCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	pentestLDAPCmd.Flags().Int("sleep", 0, "Delay in seconds between LDAP queries for stealth mode")
 	pentestLDAPCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to randomize sleep delays")
@@ -739,6 +763,7 @@ For Kerberos password spraying use: pentest spray --service KERBEROS`,
 	pentestKerberosCmd.Flags().StringSlice("principals", []string{}, "Candidate principals for AS_REP_ROAST / USER_ENUM (defaults to --usernames)")
 	pentestKerberosCmd.Flags().Int("timeout", 5000, "Connection timeout in milliseconds (per AS-REQ / TGS-REQ exchange)")
 	pentestKerberosCmd.Flags().StringSlice("etypes", []string{"AES256_CTS_HMAC_SHA1_96", "AES128_CTS_HMAC_SHA1_96", "RC4_HMAC"}, "Kerberos etype preference order (AES256_CTS_HMAC_SHA1_96, AES128_CTS_HMAC_SHA1_96, RC4_HMAC)")
+	pentestKerberosCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	_ = pentestKerberosCmd.MarkFlagRequired("targets")
 
 	// Add Command to 'Service' Command
@@ -773,6 +798,7 @@ For Kerberos password spraying use: pentest spray --service KERBEROS`,
 	pentestMSRPCCmd.Flags().String("domain", "", "Domain name (required for DCSync)")
 	pentestMSRPCCmd.Flags().StringSlice("actions", []string{}, "Actions to perform: DCSYNC (required)")
 	pentestMSRPCCmd.Flags().Int("timeout", 10, "Connection timeout in seconds")
+	pentestMSRPCCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	_ = pentestMSRPCCmd.MarkFlagRequired("targets")
 	_ = pentestMSRPCCmd.MarkFlagRequired("actions")
 	_ = pentestMSRPCCmd.MarkFlagRequired("domain")
@@ -858,6 +884,11 @@ Supports authentication testing and command execution via WinRM protocol.`,
 				a.OutputSignal.AddError(err)
 				return
 			}
+			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -865,7 +896,7 @@ Supports authentication testing and command execution via WinRM protocol.`,
 			}
 
 			// Set Config
-			config := getWinRMPentestConfig(targets, actions, usernames, passwords, commands, domain, localAuth, port, useHTTPS, insecure, timeout, stopFirstSuccess, successfulOnly)
+			config := getWinRMPentestConfig(targets, actions, usernames, passwords, commands, domain, localAuth, port, useHTTPS, insecure, timeout, stopFirstSuccess, continueOnError, successfulOnly)
 
 			// Generate the report
 			report, err := winrmpentest.RunPentest(cmd.Context(), config)
@@ -891,6 +922,7 @@ Supports authentication testing and command execution via WinRM protocol.`,
 	pentestWinRMCmd.Flags().Bool("insecure", false, "Skip TLS certificate verification")
 	pentestWinRMCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestWinRMCmd.Flags().Bool("stop-on-first-success", false, "Stop after first successful auth")
+	pentestWinRMCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	pentestWinRMCmd.Flags().Bool("successful-only", false, "Show only successful results")
 	_ = pentestWinRMCmd.MarkFlagRequired("targets")
 
@@ -993,13 +1025,19 @@ file download (DOWNLOAD), and file upload (UPLOAD).`,
 				a.OutputSignal.AddError(err)
 				return
 			}
+			continueOnError, err := cmd.Flags().GetBool("continue-on-error")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set Config
 			config := getFTPPentestConfig(targets, actions, usernames, passwords, domain, timeout,
 				paths, recursive, maxDepth,
 				remotePaths,
 				contents,
-				maxFileSize)
+				maxFileSize,
+				continueOnError)
 
 			// Generate the report
 			report, err := ftppentest.RunPentest(cmd.Context(), config, dataMode)
@@ -1023,6 +1061,7 @@ file download (DOWNLOAD), and file upload (UPLOAD).`,
 	pentestFTPCmd.Flags().Int64("max-file-size", 1048576, "Max file size in bytes for DOWNLOAD/UPLOAD (default 1MB)")
 	pentestFTPCmd.Flags().Int("timeout", 10000, "Connection timeout in milliseconds")
 	pentestFTPCmd.Flags().String("data-mode", "auto", "FTP data connection mode: auto, passive, or active")
+	pentestFTPCmd.Flags().Bool("continue-on-error", false, "Continue executing against remaining targets after an error")
 	_ = pentestFTPCmd.MarkFlagRequired("targets")
 
 	// Add Command to 'Service' Command
@@ -1522,13 +1561,13 @@ QUERY runs discovery queries (session privileges, users, roles, version) after s
 			}
 
 			config := &oraclefern.PentestOracleConfig{
-				Targets:          targets,
-				Actions:          actions,
-				Usernames:        usernames,
-				Passwords:        passwords,
-				Timeout:          timeout,
-				StopFirstSuccess: &stopFirstSuccess,
-				SuccessfulOnly:   &successfulOnly,
+				Targets:            targets,
+				Actions:            actions,
+				Usernames:          usernames,
+				Passwords:          passwords,
+				Timeout:            timeout,
+				StopOnFirstSuccess: &stopFirstSuccess,
+				SuccessfulOnly:     &successfulOnly,
 			}
 			if sid != "" {
 				config.Sid = &sid
@@ -2009,16 +2048,16 @@ Use PROBE to fingerprint RDP servers without credentials. Use PROBE,AUTH for ful
 			}
 
 			config := &postgresfern.PentestPostgresConfig{
-				Targets:          targets,
-				Usernames:        usernames,
-				Passwords:        passwords,
-				Database:         databasePtr,
-				SslMode:          sslModePtr,
-				AllowMutations:   &allowMutations,
-				Queries:          queries,
-				Timeout:          timeout,
-				StopFirstSuccess: &stopFirstSuccess,
-				Actions:          actions,
+				Targets:            targets,
+				Usernames:          usernames,
+				Passwords:          passwords,
+				Database:           databasePtr,
+				SslMode:            sslModePtr,
+				AllowMutations:     &allowMutations,
+				Queries:            queries,
+				Timeout:            timeout,
+				StopOnFirstSuccess: &stopFirstSuccess,
+				Actions:            actions,
 			}
 
 			report, err := postgrespentest.RunPentest(cmd.Context(), config)
@@ -2122,12 +2161,12 @@ disabled.`,
 			}
 
 			config := &snmpfern.PentestSnmpConfig{
-				Targets:          targets,
-				Timeout:          timeout,
-				Actions:          actions,
-				Communities:      communities,
-				Usernames:        usernames,
-				StopFirstSuccess: &stopFirstSuccess,
+				Targets:            targets,
+				Timeout:            timeout,
+				Actions:            actions,
+				Communities:        communities,
+				Usernames:          usernames,
+				StopOnFirstSuccess: &stopFirstSuccess,
 				WriteTest: &snmpfern.WriteTestConfig{
 					Restore: &restore,
 				},
@@ -2551,7 +2590,7 @@ func getSprayPasswordPentestConfig(targets []string, service pentestfern.SprayTa
 }
 
 // getSMBPentestConfig creates a configuration for SMB pentest operations with the provided parameters.
-func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, remoteFilePath string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, anonymous bool, maxFileSize int64, shareName string) *smbfern.PentestSmbConfig {
+func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, usernames []string, passwords []string, commands []string, remoteFilePath string, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, anonymous bool, maxFileSize int64, shareName string) *smbfern.PentestSmbConfig {
 	var domainPtr, ntlmHashPtr *string
 	var localAuthPtr *bool
 	if domain != "" {
@@ -2603,13 +2642,14 @@ func getSMBPentestConfig(targets []string, actions []smbfern.PentestSmbAction, u
 		ShareDownloadConfig: shareDownloadConfig,
 		SharesMapConfig:     sharesMapConfig,
 		Timeout:             timeout,
-		StopFirstSuccess:    &stopFirstSuccess,
+		StopOnFirstSuccess:  &stopFirstSuccess,
+		ContinueOnError:     &continueOnError,
 		SuccessfulOnly:      &successfulOnly,
 	}
 }
 
 // getSSHPentestConfig creates a configuration for SSH pentest operations with the provided parameters.
-func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, stopFirstSuccess bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
+func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, usernames []string, passwords []string, commands []string, uploadFiles map[string]string, downloads []string, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool, keyFile string) *sshfern.PentestSshConfig {
 	var keyFilePtr *string
 	if keyFile != "" {
 		keyFilePtr = &keyFile
@@ -2646,13 +2686,14 @@ func getSSHPentestConfig(targets []string, actions []sshfern.PentestSshAction, u
 		ExecConfig:         execConfig,
 		FileTransferConfig: fileTransferConfig,
 		Timeout:            timeout,
-		StopFirstSuccess:   &stopFirstSuccess,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		ContinueOnError:    &continueOnError,
 		SuccessfulOnly:     &successfulOnly,
 	}
 }
 
 // getTelnetPentestConfig creates a configuration for Telnet pentest operations with the provided parameters.
-func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnetAction, usernames []string, passwords []string, commands []string, timeout int, stopFirstSuccess bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
+func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnetAction, usernames []string, passwords []string, commands []string, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool) *telnetfern.PentestTelnetConfig {
 	var execConfig *telnetfern.ExecConfig
 	if len(commands) > 0 {
 		execConfig = &telnetfern.ExecConfig{
@@ -2661,19 +2702,20 @@ func getTelnetPentestConfig(targets []string, actions []telnetfern.PentestTelnet
 	}
 
 	return &telnetfern.PentestTelnetConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
-		ExecConfig:       execConfig,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		ContinueOnError:    &continueOnError,
+		SuccessfulOnly:     &successfulOnly,
+		ExecConfig:         execConfig,
 	}
 }
 
 // getLDAPPentestConfig creates a configuration for LDAP pentest operations with the provided parameters.
-func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, sleep int, jitter int, maxQueries int, minimalQueries bool, collectionMethods []ldapfern.CollectionMethod) *ldapfern.PentestLdapConfig {
+func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction, usernames []string, passwords []string, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool, domain string, ntlmHash string, localAuth bool, sleep int, jitter int, maxQueries int, minimalQueries bool, collectionMethods []ldapfern.CollectionMethod) *ldapfern.PentestLdapConfig {
 	var domainPtr, ntlmHashPtr *string
 	var localAuthPtr *bool
 	if domain != "" {
@@ -2726,17 +2768,18 @@ func getLDAPPentestConfig(targets []string, actions []ldapfern.PentestLdapAction
 	}
 
 	return &ldapfern.PentestLdapConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Domain:           domainPtr,
-		NtlmHash:         ntlmHashPtr,
-		LocalAuth:        localAuthPtr,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
-		DomaindumpConfig: domainDumpConfig,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Domain:             domainPtr,
+		NtlmHash:           ntlmHashPtr,
+		LocalAuth:          localAuthPtr,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		ContinueOnError:    &continueOnError,
+		SuccessfulOnly:     &successfulOnly,
+		DomaindumpConfig:   domainDumpConfig,
 	}
 }
 
@@ -2835,6 +2878,10 @@ func getKerberosConfig(cmd *cobra.Command, targets []string, actions []kerberosf
 	if err != nil {
 		return nil, err
 	}
+	continueOnError, err := cmd.Flags().GetBool("continue-on-error")
+	if err != nil {
+		return nil, err
+	}
 	var domainPtr *string
 	if domain != "" {
 		domainPtr = &domain
@@ -2911,6 +2958,7 @@ func getKerberosConfig(cmd *cobra.Command, targets []string, actions []kerberosf
 		Domain:              domainPtr,
 		NtlmHash:            ntlmHashPtr,
 		Timeout:             timeout,
+		ContinueOnError:     &continueOnError,
 		ServiceTicketConfig: serviceTicketConfig,
 		AsRepRoastConfig:    asRepRoastConfig,
 		KerberoastConfig:    kerberoastConfig,
@@ -2954,6 +3002,11 @@ func getMSRPCPentestConfig(cmd *cobra.Command) (*msrpcfern.PentestMsrpcConfig, e
 		return nil, err
 	}
 
+	continueOnError, err := cmd.Flags().GetBool("continue-on-error")
+	if err != nil {
+		return nil, err
+	}
+
 	actionParser := utils.GetMSRPCParser()
 	actions, err := actionParser.ParseActions(actionStrings)
 	if err != nil {
@@ -2990,20 +3043,21 @@ func getMSRPCPentestConfig(cmd *cobra.Command) (*msrpcfern.PentestMsrpcConfig, e
 	}
 
 	return &msrpcfern.PentestMsrpcConfig{
-		Targets:        targets,
-		Actions:        actions,
-		Usernames:      usernames,
-		Passwords:      passwords,
-		NtlmHash:       ntlmHashPtr,
-		KerberosTicket: kerberosTicketPtr,
-		Domain:         domainPtr,
-		Timeout:        timeout,
-		DcsyncConfig:   dcsyncConfig,
+		Targets:         targets,
+		Actions:         actions,
+		Usernames:       usernames,
+		Passwords:       passwords,
+		NtlmHash:        ntlmHashPtr,
+		KerberosTicket:  kerberosTicketPtr,
+		Domain:          domainPtr,
+		Timeout:         timeout,
+		ContinueOnError: &continueOnError,
+		DcsyncConfig:    dcsyncConfig,
 	}, nil
 }
 
 // getWinRMPentestConfig creates a configuration for WinRM pentest operations with the provided parameters
-func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAction, usernames []string, passwords []string, commands []string, domain string, localAuth bool, port int, useHTTPS bool, insecure bool, timeout int, stopFirstSuccess bool, successfulOnly bool) *winrmfern.PentestWinrmConfig {
+func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAction, usernames []string, passwords []string, commands []string, domain string, localAuth bool, port int, useHTTPS bool, insecure bool, timeout int, stopFirstSuccess bool, continueOnError bool, successfulOnly bool) *winrmfern.PentestWinrmConfig {
 	var domainPtr *string
 	var localAuthPtr *bool
 	if domain != "" {
@@ -3026,19 +3080,20 @@ func getWinRMPentestConfig(targets []string, actions []winrmfern.PentestWinrmAct
 	}
 
 	return &winrmfern.PentestWinrmConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Domain:           domainPtr,
-		LocalAuth:        localAuthPtr,
-		Port:             portPtr,
-		UseHttps:         &useHTTPS,
-		Insecure:         &insecure,
-		ExecConfig:       execConfig,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Domain:             domainPtr,
+		LocalAuth:          localAuthPtr,
+		Port:               portPtr,
+		UseHttps:           &useHTTPS,
+		Insecure:           &insecure,
+		ExecConfig:         execConfig,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		ContinueOnError:    &continueOnError,
+		SuccessfulOnly:     &successfulOnly,
 	}
 }
 
@@ -3085,13 +3140,15 @@ func getFTPPentestConfig(
 	remotePaths []string,
 	contents []string,
 	maxFileSize int64,
+	continueOnError bool,
 ) *ftpfern.PentestFtpConfig {
 	config := &ftpfern.PentestFtpConfig{
-		Targets:   targets,
-		Actions:   actions,
-		Usernames: usernames,
-		Passwords: passwords,
-		Timeout:   timeout,
+		Targets:         targets,
+		Actions:         actions,
+		Usernames:       usernames,
+		Passwords:       passwords,
+		Timeout:         timeout,
+		ContinueOnError: &continueOnError,
 	}
 	if domain != "" {
 		config.Domain = &domain
@@ -3160,13 +3217,13 @@ func getIMAPPentestConfig(
 	allowDestructive bool,
 ) *imapfern.PentestImapConfig {
 	config := &imapfern.PentestImapConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
 	}
 	if mechanism != "" {
 		config.Mechanism = &mechanism
@@ -3221,14 +3278,14 @@ func getMSSQLPentestConfig(targets []string, actions []mssqlfern.PentestMssqlAct
 	}
 
 	return &mssqlfern.PentestMssqlConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
-		QueryConfig:      queryConfig,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
+		QueryConfig:        queryConfig,
 	}, nil
 }
 
@@ -3261,18 +3318,18 @@ func getMongoDBPentestConfig(
 	}
 
 	return &mongodbfern.PentestMongodbConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Databases:        databases,
-		Collections:      collections,
-		QueryFilter:      queryFilterPtr,
-		Projection:       projectionPtr,
-		Limit:            limitPtr,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Databases:          databases,
+		Collections:        collections,
+		QueryFilter:        queryFilterPtr,
+		Projection:         projectionPtr,
+		Limit:              limitPtr,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
 	}
 }
 
@@ -3307,17 +3364,17 @@ func getMySQLPentestConfig(
 	}
 
 	return &mysqlfern.PentestMysqlConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Database:         databasePtr,
-		SslMode:          sslModePtr,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
-		Queries:          queries,
-		AllowMutations:   &allowMutations,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Database:           databasePtr,
+		SslMode:            sslModePtr,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
+		Queries:            queries,
+		AllowMutations:     &allowMutations,
 	}, nil
 }
 
@@ -3388,13 +3445,13 @@ func getEtcdPentestConfig(
 	successfulOnly bool,
 ) *etcdfern.PentestEtcdConfig {
 	config := &etcdfern.PentestEtcdConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
 	}
 	if len(clusterEndpoints) > 0 {
 		config.ClusterEndpoints = clusterEndpoints
@@ -3424,13 +3481,13 @@ func getRDPPentestConfig(
 	verbose bool,
 ) *rdpfern.PentestRdpConfig {
 	config := &rdpfern.PentestRdpConfig{
-		Targets:          targets,
-		Actions:          actions,
-		Usernames:        usernames,
-		Passwords:        passwords,
-		Timeout:          timeout,
-		StopFirstSuccess: &stopFirstSuccess,
-		SuccessfulOnly:   &successfulOnly,
+		Targets:            targets,
+		Actions:            actions,
+		Usernames:          usernames,
+		Passwords:          passwords,
+		Timeout:            timeout,
+		StopOnFirstSuccess: &stopFirstSuccess,
+		SuccessfulOnly:     &successfulOnly,
 	}
 	if domain != "" {
 		config.Domain = &domain

--- a/fern/definition/pentest/common.yml
+++ b/fern/definition/pentest/common.yml
@@ -16,5 +16,5 @@ types:
 
       # Behavior options
       successfulOnly: optional<boolean>
-      stopFirstSuccess: optional<boolean>
+      stopOnFirstSuccess: optional<boolean>
       continueOnError: optional<boolean>

--- a/fern/definition/pentest/common.yml
+++ b/fern/definition/pentest/common.yml
@@ -17,4 +17,3 @@ types:
       # Behavior options
       successfulOnly: optional<boolean>
       stopOnFirstSuccess: optional<boolean>
-      continueOnError: optional<boolean>

--- a/fern/definition/pentest/spray.yml
+++ b/fern/definition/pentest/spray.yml
@@ -130,7 +130,6 @@ types:
       stopOnFirstSuccess: boolean
       stopOnLockoutDetected: optional<boolean>
       successfulOnly: boolean
-      continueOnError: boolean
 
       # Rate limiting and stealth
       requestsPerMinute: optional<integer>
@@ -154,7 +153,6 @@ types:
       timeout: integer
 
       # Behavior configuration
-      continueOnError: boolean
       successfulOnly: boolean
 
       # Rate limiting and stealth

--- a/internal/pentest/etcd/auth.go
+++ b/internal/pentest/etcd/auth.go
@@ -40,7 +40,7 @@ func PerformAuth(ctx context.Context, target string, config *etcdfern.PentestEtc
 
 	result := &pentestfern.AuthResult{Target: t.FormatTarget()}
 
-	stopOnFirst := config.StopFirstSuccess != nil && *config.StopFirstSuccess
+	stopOnFirst := config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess
 
 	tryAttempt := func(username, password string) bool {
 		attempt := tryEtcdAuth(ctx, client, username, password)

--- a/internal/pentest/imap/auth.go
+++ b/internal/pentest/imap/auth.go
@@ -57,7 +57,7 @@ func PerformAuthentication(ctx context.Context, target string, config *imapfern.
 			log.Info("IMAP authentication successful",
 				svc1log.SafeParam("username", cred.Username),
 				svc1log.SafeParam("mechanism", mechUsed))
-			if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+			if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 				break
 			}
 		}

--- a/internal/pentest/mongodb/auth.go
+++ b/internal/pentest/mongodb/auth.go
@@ -12,7 +12,7 @@ import (
 )
 
 // PerformAuth tests each username+password combination against MongoDB and returns an AuthResult.
-// On the first successful authentication (when StopFirstSuccess is set), it stops early.
+// On the first successful authentication (when StopOnFirstSuccess is set), it stops early.
 func PerformAuth(ctx context.Context, target string, config *mongodbfern.PentestMongodbConfig) (*pentestfern.AuthResult, error) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting MongoDB auth operation", svc1log.SafeParam("target", target))
@@ -40,7 +40,7 @@ func PerformAuth(ctx context.Context, target string, config *mongodbfern.Pentest
 		return result, nil
 	}
 
-	stopOnFirst := config.StopFirstSuccess != nil && *config.StopFirstSuccess
+	stopOnFirst := config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess
 
 	for _, username := range usernames {
 		for _, password := range passwords {

--- a/internal/pentest/mssql/auth.go
+++ b/internal/pentest/mssql/auth.go
@@ -79,7 +79,7 @@ func PerformAuthentication(ctx context.Context, target string, config *mssqlfern
 		}
 
 		// If stopFirstSuccess is set, stop trying further usernames after any success
-		if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+		if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 			for _, attempt := range result.AuthAttempts {
 				if attempt.Success {
 					applySuccessfulOnlyFilter(result, config)

--- a/internal/pentest/mysql/run.go
+++ b/internal/pentest/mysql/run.go
@@ -179,7 +179,7 @@ type queryCredential struct {
 // collectQueryCredentials derives the credentials used for the QUERY stage:
 // successful AUTH attempts when AUTH ran, otherwise the supplied credentials.
 func collectQueryCredentials(config *mysqlfern.PentestMysqlConfig, authResult *mysqlfern.AuthResult, hasAuth bool) []queryCredential {
-	stopFirstSuccess := config.StopFirstSuccess != nil && *config.StopFirstSuccess
+	stopFirstSuccess := config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess
 	var creds []queryCredential
 
 	if authResult != nil {
@@ -223,7 +223,7 @@ func collectQueryCredentials(config *mysqlfern.PentestMysqlConfig, authResult *m
 }
 
 // performAuthForTarget iterates username/password pairs and runs PerformAuthentication
-// against the target, honoring StopFirstSuccess and SuccessfulOnly from the unified
+// against the target, honoring StopOnFirstSuccess and SuccessfulOnly from the unified
 // general config. Returns a MySQL-typed AuthResult — which extends the unified
 // AuthResult with `databaseName` + `serverVersion` populated from the first
 // successful authentication so downstream processors can enrich
@@ -264,7 +264,7 @@ func performAuthForTarget(ctx context.Context, target string, config *mysqlfern.
 		svc1log.SafeParam("credentialPairs", len(credPairs)))
 
 	successfulOnly := config.SuccessfulOnly != nil && *config.SuccessfulOnly
-	stopFirstSuccess := config.StopFirstSuccess != nil && *config.StopFirstSuccess
+	stopFirstSuccess := config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess
 
 	var attempts []*pentestfern.AuthAttempt
 	var errs []string

--- a/internal/pentest/oracle/auth.go
+++ b/internal/pentest/oracle/auth.go
@@ -41,7 +41,7 @@ func PerformAuthentication(ctx context.Context, target, sid string, config *orac
 		serviceName = *config.ServiceName
 	}
 
-	stopOnFirst := config.StopFirstSuccess != nil && *config.StopFirstSuccess
+	stopOnFirst := config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess
 
 usernameLoop:
 	for _, username := range usernames {

--- a/internal/pentest/postgres/auth.go
+++ b/internal/pentest/postgres/auth.go
@@ -141,7 +141,7 @@ func PerformAuthentication(ctx context.Context, target string, config *postgresf
 
 			attempts = append(attempts, attempt)
 
-			if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+			if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 				goto done
 			}
 		}

--- a/internal/pentest/postgres/run.go
+++ b/internal/pentest/postgres/run.go
@@ -95,7 +95,7 @@ func runForTarget(ctx context.Context, target string, config *postgresfern.Pente
 						pw = *attempt.Password
 					}
 					successfulCreds = append(successfulCreds, struct{ user, pass string }{attempt.Username, pw})
-					if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+					if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 						break
 					}
 				}
@@ -118,7 +118,7 @@ func runForTarget(ctx context.Context, target string, config *postgresfern.Pente
 				}
 				for _, pw := range pwList {
 					successfulCreds = append(successfulCreds, struct{ user, pass string }{u, pw})
-					if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+					if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 						stopped = true
 						break
 					}

--- a/internal/pentest/rdp/auth.go
+++ b/internal/pentest/rdp/auth.go
@@ -47,7 +47,7 @@ import (
 //
 // The function runs the PROBE phase first to capture server negotiation info,
 // then produces one attempt per username×password (or hash) combination from
-// config, respecting StopFirstSuccess semantics so the loop structure is correct
+// config, respecting StopOnFirstSuccess semantics so the loop structure is correct
 // for future real auth outcomes.
 func PerformAuthentication(ctx context.Context, target string, config *rdpfern.PentestRdpConfig) (*rdpfern.AuthResult, error) {
 	log := svc1log.FromContext(ctx)
@@ -93,7 +93,7 @@ func PerformAuthentication(ctx context.Context, target string, config *rdpfern.P
 	}
 
 	var attempts []*pentestfern.AuthAttempt
-	stopOnFirst := config.StopFirstSuccess != nil && *config.StopFirstSuccess
+	stopOnFirst := config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess
 
 	domain := ""
 	if config.Domain != nil {
@@ -125,7 +125,7 @@ func PerformAuthentication(ctx context.Context, target string, config *rdpfern.P
 
 		attempts = append(attempts, attempt)
 
-		// Honour StopFirstSuccess even in v1 — when v2 adds real auth, the loop
+		// Honour StopOnFirstSuccess even in v1 — when v2 adds real auth, the loop
 		// semantics will be correct without structural changes.
 		if stopOnFirst && attempt.Success {
 			break

--- a/internal/pentest/redis/auth.go
+++ b/internal/pentest/redis/auth.go
@@ -120,7 +120,7 @@ func PerformAuthenticationWithContext(ctx context.Context, target string, config
 			}
 			attempts = append(attempts, attempt)
 
-			if attempt.Success && config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+			if attempt.Success && config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 				break
 			}
 		}

--- a/internal/pentest/smb/auth.go
+++ b/internal/pentest/smb/auth.go
@@ -202,7 +202,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 					svc1log.SafeParam("username", cred.Username),
 					svc1log.SafeParam("hash", "[REDACTED]"))
 
-				if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+				if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 					break
 				}
 			}
@@ -222,7 +222,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 					svc1log.SafeParam("username", cred.Username),
 					svc1log.SafeParam("password", "[REDACTED]"))
 
-				if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+				if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 					break
 				}
 			}

--- a/internal/pentest/smb/eternalblue/eternalblue.go
+++ b/internal/pentest/smb/eternalblue/eternalblue.go
@@ -264,7 +264,7 @@ var trans2SessionSetupProbe = []byte{
 	0x00, 0x00, // Flags
 	0x00, 0x00, // SecurityMode
 	0x00, 0x00, // Capabilities
-	0x00,       // Reserved / pad (byte 15 — brings total to 15, matching ParameterCount)
+	0x00, // Reserved / pad (byte 15 — brings total to 15, matching ParameterCount)
 	// Padding to reach DataOffset=74 (ByteCount=17 = 1+15+1)
 	0x00,
 }

--- a/internal/pentest/snmp/writetest.go
+++ b/internal/pentest/snmp/writetest.go
@@ -36,7 +36,7 @@ func RunWriteTest(ctx context.Context, target string, config *snmpfern.PentestSn
 
 	version := snmpVersion(config.Version)
 	oid, testValue, restore := writeTestParams(config)
-	stopFirst := config.StopFirstSuccess != nil && *config.StopFirstSuccess
+	stopFirst := config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess
 
 	var entries []*snmpfern.SnmpWriteTestEntry
 	var probeErrors []string

--- a/internal/pentest/ssh/auth.go
+++ b/internal/pentest/ssh/auth.go
@@ -79,7 +79,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 				svc1log.SafeParam("username", cred.Username),
 				svc1log.SafeParam("password", "[REDACTED]"))
 
-			if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+			if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 				break
 			}
 		}

--- a/internal/pentest/telnet/auth.go
+++ b/internal/pentest/telnet/auth.go
@@ -81,7 +81,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 				svc1log.SafeParam("username", cred.Username),
 				svc1log.SafeParam("password", "[REDACTED]"))
 
-			if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+			if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 				break
 			}
 		}

--- a/internal/pentest/winrm/auth.go
+++ b/internal/pentest/winrm/auth.go
@@ -180,7 +180,7 @@ func performAuthAttemptsWithContext(ctx context.Context, host string, port int, 
 				svc1log.SafeParam("username", cred.Username),
 				svc1log.SafeParam("password", "[REDACTED]"))
 
-			if config.StopFirstSuccess != nil && *config.StopFirstSuccess {
+			if config.StopOnFirstSuccess != nil && *config.StopOnFirstSuccess {
 				break
 			}
 		}


### PR DESCRIPTION
- Add --continue-on-error CLI flag to SSH, SMB, Telnet, LDAP, WinRM, FTP, Kerberos, and MSRPC pentest service commands, wiring it through to the ContinueOnError field in each Fern config type
- Rename Fern field stopFirstSuccess -> stopOnFirstSuccess in common.yml so the generated Python field name (stop_on_first_success) matches the CLI flag (--stop-on-first-success); the ontology compiler was generating --stop-first-success, causing empty signal output when the platform ran pentest service commands
- Regenerate Go types and update all references to StopFirstSuccess -> StopOnFirstSuccess across cmd/ and internal/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical rename across pentest configs can break platform/ontology consumers still using old field names; removing `continueOnError` may change spray error-handling semantics where it was previously always true.
> 
> **Overview**
> Aligns pentest Fern schemas and generated Go with the **`--stop-on-first-success`** CLI flag by renaming **`stopFirstSuccess` → `stopOnFirstSuccess`** in `PentestGeneralConfig`, spray configs, and every service pentest config builder in `cmd/pentest.go`, with matching **`StopOnFirstSuccess`** reads across auth/query paths (SSH, SMB, LDAP, Oracle, Postgres, MySQL, IMAP, etcd, etc.).
> 
> Removes **`continueOnError`** from shared pentest Fern (`common.yml`, `spray.yml`) and stops hardcoding **`ContinueOnError: true`** on password spray config in `cmd/pentest.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba7b2ade83823618fa9a5be17b5f9cdd3733a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->