### PR TITLE
Update Plugins Protocols + Enum List

### DIFF
--- a/fern/definition/common/common.yml
+++ b/fern/definition/common/common.yml
@@ -3,6 +3,7 @@ types:
     enum:
       - ADB
       - AFP
+      - AJP13
       - AMQP
       - ARD
       - ATG
@@ -19,6 +20,7 @@ types:
       - DNP3
       - DUBBO
       - ECHO
+      - ETCD
       - ERLANGEPMD
       - ETHERNETIP
       - FGFM
@@ -112,7 +114,6 @@ types:
       - XDMCP
       - XMPP
       - ZOOKEEPER
-      - UNKNOWN
 
   TransportType:
     enum:

--- a/internal/discover/service/helpers/helpers.go
+++ b/internal/discover/service/helpers/helpers.go
@@ -11,7 +11,7 @@ import (
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
 )
 
-func GenericResult(host string, ip net.IP, port int, transport common.TransportType, appProtocol string, version string, metadata map[string]string) *discoverfern.ServiceDetails {
+func GenericResult(host string, ip net.IP, port int, transport common.TransportType, protocol common.ProtocolType, appProtocol string, version string, metadata map[string]string) *discoverfern.ServiceDetails {
 	if metadata == nil {
 		metadata = make(map[string]string)
 	}
@@ -22,7 +22,7 @@ func GenericResult(host string, ip net.IP, port int, transport common.TransportT
 		Port:      port,
 		Tls:       false,
 		Transport: transport,
-		Protocol:  common.ProtocolTypeUnknown,
+		Protocol:  protocol,
 		Version:   &version,
 		Metadata:  &discoverfern.ServiceMetadata{Generic: &discoverfern.GenericServiceMetadata{Metadata: metadata}},
 	}

--- a/internal/discover/service/plugins/adb.go
+++ b/internal/discover/service/plugins/adb.go
@@ -28,5 +28,5 @@ func (ADBFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 	if (cmd != "CNXN" && cmd != "AUTH") || !helpers.ValidADBPacket(resp) {
 		return nil, fmt.Errorf("not ADB")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Android Debug Bridge", "ADB", map[string]string{"response_command": cmd}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeAdb, "Android Debug Bridge", "ADB", map[string]string{"response_command": cmd}), nil
 }

--- a/internal/discover/service/plugins/afp.go
+++ b/internal/discover/service/plugins/afp.go
@@ -25,5 +25,5 @@ func (AFPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 	if len(resp) < 16 || resp[0] != 0x01 || resp[1] != 0x03 || !bytes.Contains(resp, []byte("AFP")) {
 		return nil, fmt.Errorf("not AFP")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "AFP", "AFP/DSI", map[string]string{"command": "GetStatus"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeAfp, "AFP", "AFP/DSI", map[string]string{"command": "GetStatus"}), nil
 }

--- a/internal/discover/service/plugins/ajp.go
+++ b/internal/discover/service/plugins/ajp.go
@@ -31,7 +31,7 @@ func (AJP13Fingerprinter) Detect(ctx context.Context, ip net.IP, port int, host 
 		return nil, fmt.Errorf("not AJP13")
 	}
 
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "AJP13", "Apache Jserv Protocol v1.3", map[string]string{
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeAjp13, "AJP13", "Apache Jserv Protocol v1.3", map[string]string{
 		"probe": "cping",
 		"state": "cpong",
 	}), nil

--- a/internal/discover/service/plugins/amqp.go
+++ b/internal/discover/service/plugins/amqp.go
@@ -24,10 +24,10 @@ func (AMQPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 		return nil, err
 	}
 	if bytes.HasPrefix(resp, []byte("AMQP")) {
-		return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "AMQP", "AMQP", map[string]string{"response": "protocol-header"}), nil
+		return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeAmqp, "AMQP", "AMQP", map[string]string{"response": "protocol-header"}), nil
 	}
 	if looksLikeAMQPConnectionStart(resp) {
-		return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "AMQP", "0-9-1", map[string]string{"method": "connection.start"}), nil
+		return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeAmqp, "AMQP", "0-9-1", map[string]string{"method": "connection.start"}), nil
 	}
 	return nil, fmt.Errorf("not AMQP")
 }

--- a/internal/discover/service/plugins/bacnet.go
+++ b/internal/discover/service/plugins/bacnet.go
@@ -25,5 +25,5 @@ func (BACnetFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 	if len(resp) < 8 || resp[0] != 0x81 || (resp[1] != 0x0a && resp[1] != 0x0b) || !bytes.Contains(resp[4:], []byte{0x10, 0x00}) {
 		return nil, fmt.Errorf("not BACnet/IP")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, "BACnet/IP", "BACnet/IP", map[string]string{"response": "i-am"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, common.ProtocolTypeBacnet, "BACnet/IP", "BACnet/IP", map[string]string{"response": "i-am"}), nil
 }

--- a/internal/discover/service/plugins/beanstalkd.go
+++ b/internal/discover/service/plugins/beanstalkd.go
@@ -26,5 +26,5 @@ func (BeanstalkdFingerprinter) Detect(ctx context.Context, ip net.IP, port int, 
 	if !strings.HasPrefix(text, "OK ") || (!strings.Contains(text, "\npid:") && !strings.Contains(text, "\ncurrent-jobs-urgent:")) {
 		return nil, fmt.Errorf("not beanstalkd")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "beanstalkd", "beanstalkd", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeBeanstalkd, "beanstalkd", "beanstalkd", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/beckhoffads.go
+++ b/internal/discover/service/plugins/beckhoffads.go
@@ -31,7 +31,7 @@ func (BeckhoffADSFingerprinter) Detect(ctx context.Context, ip net.IP, port int,
 	if name != "" {
 		meta["device"] = name
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Beckhoff ADS", "ADS", meta), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeBeckhoffads, "Beckhoff ADS", "ADS", meta), nil
 }
 
 func beckhoffADSReadDeviceInfoProbe(ip net.IP) []byte {

--- a/internal/discover/service/plugins/coap.go
+++ b/internal/discover/service/plugins/coap.go
@@ -24,5 +24,5 @@ func (CoAPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	if len(resp) < 4 || resp[0]>>6 != 1 || resp[2] != 0x12 || resp[3] != 0x34 || resp[1] == 0x00 {
 		return nil, fmt.Errorf("not CoAP")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, "CoAP", fmt.Sprintf("code-%d.%02d", resp[1]>>5, resp[1]&0x1f), map[string]string{"message_id": "0x1234"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, common.ProtocolTypeCoap, "CoAP", fmt.Sprintf("code-%d.%02d", resp[1]>>5, resp[1]&0x1f), map[string]string{"message_id": "0x1234"}), nil
 }

--- a/internal/discover/service/plugins/codesys.go
+++ b/internal/discover/service/plugins/codesys.go
@@ -49,5 +49,5 @@ func (CodesysFingerprinter) Detect(ctx context.Context, ip net.IP, port int, hos
 			meta["product"] = strings.TrimSpace(product)
 		}
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "CODESYS", "CODESYS V2", meta), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeCodesys, "CODESYS", "CODESYS V2", meta), nil
 }

--- a/internal/discover/service/plugins/dnp3.go
+++ b/internal/discover/service/plugins/dnp3.go
@@ -25,7 +25,7 @@ func (DNP3Fingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	if !validDNP3Frame(resp) {
 		return nil, fmt.Errorf("not DNP3")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "DNP3", "DNP3", map[string]string{"response": "link-layer"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeDnp3, "DNP3", "DNP3", map[string]string{"response": "link-layer"}), nil
 }
 
 func buildDNP3LinkStatusRequest() []byte {

--- a/internal/discover/service/plugins/dnp3udp.go
+++ b/internal/discover/service/plugins/dnp3udp.go
@@ -24,5 +24,5 @@ func (DNP3UDPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, hos
 	if !validDNP3Frame(resp) {
 		return nil, fmt.Errorf("not DNP3")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, "DNP3", "DNP3", map[string]string{"response": "link-layer"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, common.ProtocolTypeDnp3, "DNP3", "DNP3", map[string]string{"response": "link-layer"}), nil
 }

--- a/internal/discover/service/plugins/dubbo.go
+++ b/internal/discover/service/plugins/dubbo.go
@@ -27,5 +27,5 @@ func (DubboFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host 
 	if !strings.Contains(lower, "dubbo>") && !strings.Contains(lower, "dubbo") {
 		return nil, fmt.Errorf("not Dubbo")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Apache Dubbo", "Dubbo", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeDubbo, "Apache Dubbo", "Dubbo", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/erlangepmd.go
+++ b/internal/discover/service/plugins/erlangepmd.go
@@ -26,5 +26,5 @@ func (ErlangEPMDFingerprinter) Detect(ctx context.Context, ip net.IP, port int, 
 	if len(resp) < 4 || !strings.Contains(text, "name ") {
 		return nil, fmt.Errorf("not Erlang EPMD")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Erlang EPMD", "EPMD", map[string]string{"names": strings.TrimSpace(text[4:])}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeErlangepmd, "Erlang EPMD", "EPMD", map[string]string{"names": strings.TrimSpace(text[4:])}), nil
 }

--- a/internal/discover/service/plugins/etcd.go
+++ b/internal/discover/service/plugins/etcd.go
@@ -120,7 +120,7 @@ func buildEtcdServiceResult(host string, ip net.IP, port int, tlsEnabled bool, s
 		Port:      port,
 		Tls:       tlsEnabled,
 		Transport: common.TransportTypeTcp,
-		Protocol:  common.ProtocolTypeUnknown,
+		Protocol:  common.ProtocolTypeEtcd,
 		Metadata:  &discoverfern.ServiceMetadata{Etcd: serverInfo},
 	}
 }

--- a/internal/discover/service/plugins/ethernetip.go
+++ b/internal/discover/service/plugins/ethernetip.go
@@ -35,7 +35,7 @@ func (EthernetIPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, 
 	if product != "" {
 		meta["identity"] = product
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "EtherNet/IP", "CIP", meta), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeEthernetip, "EtherNet/IP", "CIP", meta), nil
 }
 
 func ethernetIPListIdentityRequest() []byte {

--- a/internal/discover/service/plugins/ethernetipudp.go
+++ b/internal/discover/service/plugins/ethernetipudp.go
@@ -34,5 +34,5 @@ func (EthernetIPUDPFingerprinter) Detect(ctx context.Context, ip net.IP, port in
 	if product != "" {
 		meta["identity"] = product
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, "EtherNet/IP", "CIP", meta), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, common.ProtocolTypeEthernetip, "EtherNet/IP", "CIP", meta), nil
 }

--- a/internal/discover/service/plugins/finger.go
+++ b/internal/discover/service/plugins/finger.go
@@ -27,5 +27,5 @@ func (FingerFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 	if strings.Contains(lower, "http/") || (!strings.Contains(lower, "finger") && !strings.Contains(lower, "login") && !strings.Contains(lower, "no information")) {
 		return nil, fmt.Errorf("not Finger")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Finger", "RFC1288", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeFinger, "Finger", "RFC1288", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/gitdaemon.go
+++ b/internal/discover/service/plugins/gitdaemon.go
@@ -27,5 +27,5 @@ func (GitDaemonFingerprinter) Detect(ctx context.Context, ip net.IP, port int, h
 	if !helpers.LooksLikeGitDaemon(resp) {
 		return nil, fmt.Errorf("not git-daemon")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Git daemon", "git", map[string]string{"response": strings.TrimSpace(string(resp))}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeGitdaemon, "Git daemon", "git", map[string]string{"response": strings.TrimSpace(string(resp))}), nil
 }

--- a/internal/discover/service/plugins/gopher.go
+++ b/internal/discover/service/plugins/gopher.go
@@ -25,5 +25,5 @@ func (GopherFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 	if !helpers.ValidGopherItem(text) {
 		return nil, fmt.Errorf("not Gopher")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Gopher", "Gopher", map[string]string{"first_item": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeGopher, "Gopher", "Gopher", map[string]string{"first_item": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/hpdataprotector.go
+++ b/internal/discover/service/plugins/hpdataprotector.go
@@ -26,7 +26,7 @@ func (HPDataProtectorFingerprinter) Detect(ctx context.Context, ip net.IP, port 
 	if !looksLikeHPDataProtector(text) {
 		return nil, fmt.Errorf("not HP Data Protector")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "HP Data Protector", "OmniInet", map[string]string{"banner": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeHpdataprotector, "HP Data Protector", "OmniInet", map[string]string{"banner": helpers.FirstLine(text)}), nil
 }
 
 func looksLikeHPDataProtector(text string) bool {

--- a/internal/discover/service/plugins/http.go
+++ b/internal/discover/service/plugins/http.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 
 	"github.com/Method-Security/networkscan/generated/go/common"
 	discoverfern "github.com/Method-Security/networkscan/generated/go/discover"
@@ -60,10 +59,9 @@ func (HTTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 			server = "HTTP Server" // Default if no server header
 		}
 
-		// Use HTTPS protocol when TLS is detected, otherwise HTTP
-		protocolName := "HTTP"
+		protocol := common.ProtocolTypeHttp
 		if proto.isTLS {
-			protocolName = "HTTPS"
+			protocol = common.ProtocolTypeHttps
 		}
 
 		// Build generic metadata map
@@ -81,12 +79,7 @@ func (HTTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 			Tls:       proto.isTLS,
 			Version:   &server,
 			Transport: common.TransportTypeTcp,
-			Protocol: func() common.ProtocolType {
-				if protocol, err := common.NewProtocolTypeFromString(strings.ToUpper(protocolName)); err == nil {
-					return protocol
-				}
-				return common.ProtocolTypeUnknown
-			}(),
+			Protocol:  protocol,
 			Metadata: &discoverfern.ServiceMetadata{Generic: &discoverfern.GenericServiceMetadata{
 				Metadata: metadata,
 			}},

--- a/internal/discover/service/plugins/ident.go
+++ b/internal/discover/service/plugins/ident.go
@@ -26,5 +26,5 @@ func (IdentFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host 
 	if !strings.Contains(text, "1") || (!strings.Contains(text, " : ERROR : ") && !strings.Contains(text, " : USERID : ")) {
 		return nil, fmt.Errorf("not Ident")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Ident", "RFC1413", map[string]string{"response": strings.TrimSpace(string(resp))}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeIdent, "Ident", "RFC1413", map[string]string{"response": strings.TrimSpace(string(resp))}), nil
 }

--- a/internal/discover/service/plugins/irc.go
+++ b/internal/discover/service/plugins/irc.go
@@ -26,5 +26,5 @@ func (IRCFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 	if !helpers.LooksLikeIRC(text) {
 		return nil, fmt.Errorf("not IRC")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "IRC", "IRC", map[string]string{"banner": strings.TrimSpace(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeIrc, "IRC", "IRC", map[string]string{"banner": strings.TrimSpace(text)}), nil
 }

--- a/internal/discover/service/plugins/javarmi.go
+++ b/internal/discover/service/plugins/javarmi.go
@@ -29,5 +29,5 @@ func (JavaRMIFingerprinter) Detect(ctx context.Context, ip net.IP, port int, hos
 	if hostnameLen <= 0 || hostnameLen > 255 || len(resp) < 3+hostnameLen+2 || !helpers.IsRMIEndpointHost(resp[3:3+hostnameLen]) {
 		return nil, fmt.Errorf("invalid Java RMI endpoint ack")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Java RMI", "JRMI", map[string]string{"handshake": "stream-protocol-ack", "endpoint": string(resp[3 : 3+hostnameLen])}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeJavarmi, "Java RMI", "JRMI", map[string]string{"handshake": "stream-protocol-ack", "endpoint": string(resp[3 : 3+hostnameLen])}), nil
 }

--- a/internal/discover/service/plugins/jetdirect.go
+++ b/internal/discover/service/plugins/jetdirect.go
@@ -27,5 +27,5 @@ func (JetDirectFingerprinter) Detect(ctx context.Context, ip net.IP, port int, h
 	if !strings.Contains(text, "@PJL") && !strings.Contains(strings.ToUpper(text), "INFO ID") {
 		return nil, fmt.Errorf("not JetDirect/PJL")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "JetDirect/PJL", "PJL", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeJetdirect, "JetDirect/PJL", "PJL", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/jmx.go
+++ b/internal/discover/service/plugins/jmx.go
@@ -28,7 +28,7 @@ func (JMXFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 	if !bytes.Contains(bytes.ToLower(resp), []byte("jmxrmi")) {
 		return nil, fmt.Errorf("not JMX")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "JMX", "JMX RMI", map[string]string{"rmi_registry_binding": "jmxrmi"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeJmx, "JMX", "JMX RMI", map[string]string{"rmi_registry_binding": "jmxrmi"}), nil
 }
 
 func jmxRegistryListCall() []byte {

--- a/internal/discover/service/plugins/lpd.go
+++ b/internal/discover/service/plugins/lpd.go
@@ -27,5 +27,5 @@ func (LPDFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 	if !strings.Contains(lower, "lpd") && !strings.Contains(lower, "printer") && !strings.Contains(lower, "queue") {
 		return nil, fmt.Errorf("not LPD")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Line Printer Daemon", "LPD", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeLpd, "Line Printer Daemon", "LPD", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/melsec.go
+++ b/internal/discover/service/plugins/melsec.go
@@ -20,11 +20,11 @@ func (MELSECFingerprinter) DefaultPorts() []int { return []int{5000, 5001, 5006,
 func (MELSECFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host string, timeout int) (*discoverfern.ServiceDetails, error) {
 	resp, err := helpers.TCPExchange(ctx, ip, port, timeout, melsec3EReadProbe(), 256)
 	if err == nil && validMELSEC3EResponse(resp) {
-		return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "MELSEC MC", "3E", map[string]string{"frame": "3e-binary"}), nil
+		return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeMelsec, "MELSEC MC", "3E", map[string]string{"frame": "3e-binary"}), nil
 	}
 	resp, asciiErr := helpers.TCPExchange(ctx, ip, port, timeout, []byte("500000FF03FF000018001004010000D*0000000001"), 256)
 	if asciiErr == nil && validMELSEC3EASCIIResponse(resp) {
-		return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "MELSEC MC", "3E", map[string]string{"frame": "3e-ascii"}), nil
+		return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeMelsec, "MELSEC MC", "3E", map[string]string{"frame": "3e-ascii"}), nil
 	}
 	if err != nil {
 		return nil, err

--- a/internal/discover/service/plugins/nats.go
+++ b/internal/discover/service/plugins/nats.go
@@ -26,5 +26,5 @@ func (NATSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	if !strings.HasPrefix(text, "INFO ") || !strings.Contains(text, "server_id") {
 		return nil, fmt.Errorf("not NATS")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "NATS", "NATS", map[string]string{"banner": strings.TrimSpace(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeNats, "NATS", "NATS", map[string]string{"banner": strings.TrimSpace(text)}), nil
 }

--- a/internal/discover/service/plugins/ndmp.go
+++ b/internal/discover/service/plugins/ndmp.go
@@ -26,7 +26,7 @@ func (NDMPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	if !looksLikeNDMP(resp) {
 		return nil, fmt.Errorf("not NDMP")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "NDMP", "NDMP", map[string]string{"response": "connect-open-reply"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeNdmp, "NDMP", "NDMP", map[string]string{"response": "connect-open-reply"}), nil
 }
 
 func ndmpConnectOpenRequest() []byte {

--- a/internal/discover/service/plugins/nfs.go
+++ b/internal/discover/service/plugins/nfs.go
@@ -24,7 +24,7 @@ func (NFSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host st
 			continue
 		}
 		if ok, status := validNFSRPCReply(resp); ok {
-			return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "NFS", fmt.Sprintf("NFSv%d", version), map[string]string{"rpc_status": status}), nil
+			return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeNfs, "NFS", fmt.Sprintf("NFSv%d", version), map[string]string{"rpc_status": status}), nil
 		}
 	}
 	return nil, fmt.Errorf("not NFS")

--- a/internal/discover/service/plugins/nfsudp.go
+++ b/internal/discover/service/plugins/nfsudp.go
@@ -23,7 +23,7 @@ func (NFSUDPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 			continue
 		}
 		if ok, status := validNFSRPCReply(resp); ok {
-			return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, "NFS", fmt.Sprintf("NFSv%d", version), map[string]string{"rpc_status": status}), nil
+			return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, common.ProtocolTypeNfs, "NFS", fmt.Sprintf("NFSv%d", version), map[string]string{"rpc_status": status}), nil
 		}
 	}
 	return nil, fmt.Errorf("not NFS")

--- a/internal/discover/service/plugins/nntp.go
+++ b/internal/discover/service/plugins/nntp.go
@@ -26,5 +26,5 @@ func (NNTPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	if !(strings.HasPrefix(text, "200 ") || strings.HasPrefix(text, "201 ")) || !strings.Contains(strings.ToUpper(text), "NNTP") {
 		return nil, fmt.Errorf("not NNTP")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "NNTP", "NNTP", map[string]string{"banner": strings.TrimSpace(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeNntp, "NNTP", "NNTP", map[string]string{"banner": strings.TrimSpace(text)}), nil
 }

--- a/internal/discover/service/plugins/poppassd.go
+++ b/internal/discover/service/plugins/poppassd.go
@@ -27,5 +27,5 @@ func (PoppassdFingerprinter) Detect(ctx context.Context, ip net.IP, port int, ho
 	if !strings.HasPrefix(text, "200 ") || (!strings.Contains(lower, "poppassd") && !strings.Contains(lower, "who are you")) {
 		return nil, fmt.Errorf("not poppassd")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "poppassd", "poppassd", map[string]string{"banner": strings.TrimSpace(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypePoppassd, "poppassd", "poppassd", map[string]string{"banner": strings.TrimSpace(text)}), nil
 }

--- a/internal/discover/service/plugins/radius.go
+++ b/internal/discover/service/plugins/radius.go
@@ -29,5 +29,5 @@ func (RADIUSFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 	if len(resp) < 20 || resp[1] != 0x42 || (resp[0] != 2 && resp[0] != 3 && resp[0] != 11) || int(binary.BigEndian.Uint16(resp[2:4])) > len(resp) {
 		return nil, fmt.Errorf("not RADIUS")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, "RADIUS", fmt.Sprintf("code-%d", resp[0]), map[string]string{"identifier": "0x42"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, common.ProtocolTypeRadius, "RADIUS", fmt.Sprintf("code-%d", resp[0]), map[string]string{"identifier": "0x42"}), nil
 }

--- a/internal/discover/service/plugins/rlogin.go
+++ b/internal/discover/service/plugins/rlogin.go
@@ -27,5 +27,5 @@ func (RloginFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 	if !strings.Contains(lower, "rlogin") && !strings.Contains(lower, "connection refused") && !strings.Contains(lower, "authenticated rlogin") {
 		return nil, fmt.Errorf("not rlogin")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "rlogin", "rlogin", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeRlogin, "rlogin", "rlogin", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/rtmp.go
+++ b/internal/discover/service/plugins/rtmp.go
@@ -26,5 +26,5 @@ func (RTMPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	if len(resp) < 1537 || resp[0] != 0x03 {
 		return nil, fmt.Errorf("not RTMP")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "RTMP", "RTMP", map[string]string{"handshake": "s0s1"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeRtmp, "RTMP", "RTMP", map[string]string{"handshake": "s0s1"}), nil
 }

--- a/internal/discover/service/plugins/s7comm.go
+++ b/internal/discover/service/plugins/s7comm.go
@@ -25,5 +25,5 @@ func (S7CommFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host
 	if len(resp) < 7 || resp[0] != 0x03 || resp[1] != 0x00 || resp[5] != 0xd0 {
 		return nil, fmt.Errorf("not S7comm")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Siemens S7comm", "COTP/S7", map[string]string{"cotp": "connection-confirm"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeS7Comm, "Siemens S7comm", "COTP/S7", map[string]string{"cotp": "connection-confirm"}), nil
 }

--- a/internal/discover/service/plugins/saprouter.go
+++ b/internal/discover/service/plugins/saprouter.go
@@ -26,5 +26,5 @@ func (SAPRouterFingerprinter) Detect(ctx context.Context, ip net.IP, port int, h
 	if !strings.Contains(strings.ToLower(text), "saprouter") {
 		return nil, fmt.Errorf("not SAProuter")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "SAProuter", "SAP NI", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeSaprouter, "SAProuter", "SAP NI", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/tarantool.go
+++ b/internal/discover/service/plugins/tarantool.go
@@ -26,5 +26,5 @@ func (TarantoolFingerprinter) Detect(ctx context.Context, ip net.IP, port int, h
 	if !strings.HasPrefix(text, "Tarantool ") || !strings.Contains(text, "(Binary)") {
 		return nil, fmt.Errorf("not Tarantool")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "Tarantool", helpers.FirstLine(text), map[string]string{"banner": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeTarantool, "Tarantool", helpers.FirstLine(text), map[string]string{"banner": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/weblogict3.go
+++ b/internal/discover/service/plugins/weblogict3.go
@@ -28,5 +28,5 @@ func (WebLogicT3Fingerprinter) Detect(ctx context.Context, ip net.IP, port int, 
 		return nil, fmt.Errorf("not WebLogic T3")
 	}
 	version := strings.TrimPrefix(strings.SplitN(text, "\n", 2)[0], "HELO:")
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "WebLogic T3", version, map[string]string{"banner": strings.TrimSpace(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeWeblogict3, "WebLogic T3", version, map[string]string{"banner": strings.TrimSpace(text)}), nil
 }

--- a/internal/discover/service/plugins/whois.go
+++ b/internal/discover/service/plugins/whois.go
@@ -27,5 +27,5 @@ func (WhoisFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host 
 	if strings.Contains(lower, "http/") || (!strings.Contains(lower, "whois") && !strings.Contains(lower, "domain") && !strings.Contains(lower, "registrar") && !strings.HasPrefix(strings.TrimSpace(text), "%")) {
 		return nil, fmt.Errorf("not WHOIS")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "WHOIS", "WHOIS", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeWhois, "WHOIS", "WHOIS", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/wsdiscovery.go
+++ b/internal/discover/service/plugins/wsdiscovery.go
@@ -27,5 +27,5 @@ func (WSDiscoveryFingerprinter) Detect(ctx context.Context, ip net.IP, port int,
 	if !strings.Contains(text, "ProbeMatches") && !strings.Contains(text, "schemas.xmlsoap.org/ws/2005/04/discovery") {
 		return nil, fmt.Errorf("not WS-Discovery")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, "WS-Discovery", "WS-Discovery", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeUdp, common.ProtocolTypeWsdiscovery, "WS-Discovery", "WS-Discovery", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/xmpp.go
+++ b/internal/discover/service/plugins/xmpp.go
@@ -27,5 +27,5 @@ func (XMPPFingerprinter) Detect(ctx context.Context, ip net.IP, port int, host s
 	if !strings.Contains(text, "<stream:stream") || !strings.Contains(text, "jabber:") {
 		return nil, fmt.Errorf("not XMPP")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "XMPP", "XMPP", map[string]string{"response": helpers.FirstLine(text)}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeXmpp, "XMPP", "XMPP", map[string]string{"response": helpers.FirstLine(text)}), nil
 }

--- a/internal/discover/service/plugins/zookeeper.go
+++ b/internal/discover/service/plugins/zookeeper.go
@@ -24,5 +24,5 @@ func (ZooKeeperFingerprinter) Detect(ctx context.Context, ip net.IP, port int, h
 	if string(resp) != "imok" {
 		return nil, fmt.Errorf("not ZooKeeper")
 	}
-	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, "ZooKeeper", "ZooKeeper", map[string]string{"four_letter_word": "ruok"}), nil
+	return helpers.GenericResult(host, ip, port, common.TransportTypeTcp, common.ProtocolTypeZookeeper, "ZooKeeper", "ZooKeeper", map[string]string{"four_letter_word": "ruok"}), nil
 }

--- a/internal/discover/service/service.go
+++ b/internal/discover/service/service.go
@@ -197,7 +197,6 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 		addrPort := netip.AddrPortFrom(netip.MustParseAddr(ip.String()), uint16(port))
 		fingerprintTarget := plugins.Target{Address: addrPort, Host: host}
 		serviceFound := false
-		var fingerprintResult *plugins.Service
 
 		/* --- Phase 1: Run custom fingerprinters on default ports only ------- */
 		// Collect applicable fingerprinters for this port
@@ -251,13 +250,14 @@ func RunServiceFingerprint(ctx context.Context, config discoverfern.DiscoverServ
 			}()
 
 			select {
+			// fingerprintx timed out or context cancelled - move to Phase 3.
 			case <-fxCtx.Done():
-				// fingerprintx timed out or context cancelled - move to Phase 3
 			case fxResult := <-resultChan:
 				if fxResult != nil && fxResult.Protocol != "" {
-					fingerprintResult = fxResult
-					results = append(results, fxToServiceDetails(fingerprintResult))
-					serviceFound = true
+					if details := fxToServiceDetails(fxResult); details != nil {
+						results = append(results, details)
+						serviceFound = true
+					}
 				}
 			case err := <-errChan:
 				// fingerprintx failed - continue to Phase 3
@@ -418,6 +418,16 @@ func noEarlierFingerprintersPending(completed []bool, bestIndex int) bool {
 
 // fxToServiceDetails converts fingerprintx result to ServiceDetails
 func fxToServiceDetails(result *plugins.Service) *discoverfern.ServiceDetails {
+	protocolName := strings.ToUpper(result.Protocol)
+	// fingerprintx labels the Oracle TNS service "oracle"; our enum calls it ORACLEDB.
+	if protocolName == "ORACLE" {
+		protocolName = "ORACLEDB"
+	}
+	protocol, err := common.NewProtocolTypeFromString(protocolName)
+	if err != nil {
+		return nil
+	}
+
 	// Parse fingerprintx result into a map so we can enrich it
 	var meta map[string]interface{}
 	if len(result.Raw) > 0 {
@@ -460,17 +470,7 @@ func fxToServiceDetails(result *plugins.Service) *discoverfern.ServiceDetails {
 			}
 			return common.TransportTypeUnknown
 		}(),
-		Protocol: func() common.ProtocolType {
-			protocolName := strings.ToUpper(result.Protocol)
-			// fingerprintx labels the Oracle TNS service "oracle"; our enum calls it ORACLEDB.
-			if protocolName == "ORACLE" {
-				protocolName = "ORACLEDB"
-			}
-			if protocol, err := common.NewProtocolTypeFromString(protocolName); err == nil {
-				return protocol
-			}
-			return common.ProtocolTypeUnknown
-		}(),
+		Protocol: protocol,
 		Version:  &result.Version,
 		Metadata: &discoverfern.ServiceMetadata{Generic: &discoverfern.GenericServiceMetadata{Metadata: metadataMap}},
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide change to discovery output semantics and a breaking enum change for API consumers; unmapped fingerprintx protocols no longer appear as UNKNOWN services.
> 
> **Overview**
> Service discovery now sets **`ProtocolType`** on detected services instead of leaving **`UNKNOWN`**, and the shared **`ProtocolType`** enum is tightened to match.
> 
> **API / schema:** **`ProtocolType.UNKNOWN`** is removed from the Fern definition; **`AJP13`** and **`ETCD`** are added. **`helpers.GenericResult`** takes an explicit **`protocol`** argument and assigns it on **`ServiceDetails`**.
> 
> **Custom fingerprinters:** Dozens of plugins (ADB, AMQP, BACnet, etcd, HTTP/HTTPS, NFS, S7comm, etc.) pass the matching **`common.ProtocolType*`** constant. The HTTP plugin sets **`HTTP`** vs **`HTTPS`** from TLS instead of parsing strings at runtime.
> 
> **fingerprintx path:** **`fxToServiceDetails`** maps fingerprintx protocol names to the enum (still renaming **`oracle`** → **`ORACLEDB`**). Unmapped names return **`nil`** instead of **`UNKNOWN`**, so Phase 2 only records a hit when conversion succeeds—otherwise scanning continues as if fingerprintx did not identify a typed protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9179e3f6b5dd4b2bc3f2311e2d9a2ecb15d3764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->