### PR TITLE
Forbid extra fields in generated Pydantic models

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -14,6 +14,8 @@ groups:
     generators:
       - name: fernapi/fern-pydantic-model
         version: 1.11.2
+        config:
+          extra_fields: forbid
         output:
           location: local-file-system
           path: ../generated/python
@@ -24,6 +26,7 @@ groups:
         version: 1.11.2
         config:
           package_name: methodnetworkscan
+          extra_fields: forbid
         output:
           location: pypi
           package-name: methodnetworkscan
@@ -36,6 +39,7 @@ groups:
         version: 1.11.2
         config:
           package_name: methodnetworkscan
+          extra_fields: forbid
         output:
           location: pypi
           package-name: methodnetworkscan


### PR DESCRIPTION
## Summary

Set `extra_fields: forbid` on every `fern-pydantic-model` generator block (`pypi-local`, `pypi-test`, `pypi`) so the generated `PentestSshConfig` / `PentestSmbConfig` / etc. raise `pydantic.ValidationError` when constructed with unknown kwargs.

## Why

Today the generated models use `extra="allow"`, which silently accepts unknown kwargs and serializes them to the wire payload. That's how `stop_first_success=...` / `continue_on_error=...` slipped through the ontology compilers, got serialized to `--stop-first-success` / `--continue-on-error`, and broke against the v0.0.194 CLI as `unknown flag` → empty stdout → "signal parse failed" on the ontology processor side.

Strict mode (`extra="forbid"`) surfaces the same class of bug at **construction time** in the consumer (ontology compiler / tests), not at runtime on Jackal.

## What ships

`generated/python/` is gitignored — CI regenerates from `fern/generators.yml` at publish time, so this single-file change propagates to the next `methodnetworkscan` wheel automatically.

Generated `PentestGeneralConfig` (and every other model) flips from:

```python
model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")
```

to:

```python
model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="forbid")
```

Verified locally by running `fern generate --group pypi-local` and inspecting the regenerated `pentest_general_config.py`.

## Migration note for consumers

After the next `methodnetworkscan` wheel publishes, any ontology compiler that still passes unknown kwargs will start failing pydantic validation at compile time. ontology PR https://github.com/method-security/ontology/pull/1524 sweeps the known offenders (`stop_first_success`, `continue_on_error`). A pre-merge audit of all repos importing `methodnetworkscan` should grep for `methodnetworkscan` imports and confirm no other stragglers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for any consumer still passing unknown kwargs to generated models when they upgrade the next wheel; no runtime service logic changes in this repo.
> 
> **Overview**
> Sets **`extra_fields: forbid`** on all three **`fern-pydantic-model`** generator groups in `fern/generators.yml` (`pypi-local`, `pypi-test`, `pypi`), so regenerated Python models use Pydantic **`extra="forbid"`** instead of **`extra="allow"`**.
> 
> Unknown kwargs on generated config types (e.g. pentest models) will **fail at construction** with `ValidationError` rather than being accepted and sent on the wire—addressing cases where invalid fields reached the CLI and caused runtime parse failures.
> 
> `generated/python/` is not in-repo; the next **`methodnetworkscan`** publish picks this up from CI generation. Consumers must stop passing undeclared kwargs before upgrading the wheel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19dcc0264d35aadd06f63bf0d75e16fb91d83b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->